### PR TITLE
CHANGE Save created_on date as string to ad yaml

### DIFF
--- a/kleinanzeigen_bot/__init__.py
+++ b/kleinanzeigen_bot/__init__.py
@@ -19,7 +19,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 
 from . import utils, resources, extract  # pylint: disable=W0406
-from .utils import abspath, apply_defaults, ensure, is_frozen, pause, pluralize, safe_get
+from .utils import abspath, apply_defaults, ensure, is_frozen, pause, pluralize, safe_get, parse_datetime
 from .selenium_mixin import SeleniumMixin
 
 # W0406: possibly a bug, see https://github.com/PyCQA/pylint/issues/3933
@@ -256,9 +256,9 @@ class KleinanzeigenBot(SeleniumMixin):
 
             if self.ads_selector == "due":
                 if ad_cfg["updated_on"]:
-                    last_updated_on = datetime.fromisoformat(ad_cfg["updated_on"])
+                    last_updated_on = parse_datetime(ad_cfg["updated_on"])
                 elif ad_cfg["created_on"]:
-                    last_updated_on = datetime.fromisoformat(ad_cfg["created_on"])
+                    last_updated_on = parse_datetime(ad_cfg["created_on"])
                 else:
                     last_updated_on = None
 

--- a/kleinanzeigen_bot/__init__.py
+++ b/kleinanzeigen_bot/__init__.py
@@ -804,7 +804,8 @@ class KleinanzeigenBot(SeleniumMixin):
         # convert creation date to ISO format
         created_parts = creation_date.split('.')
         creation_date = created_parts[2] + '-' + created_parts[1] + '-' + created_parts[0] + ' 00:00:00'
-        info['created_on'] = datetime.fromisoformat(creation_date)
+        creation_date = datetime.fromisoformat(creation_date).isoformat()
+        info['created_on'] = creation_date
         info['updated_on'] = None  # will be set later on
 
         return info

--- a/kleinanzeigen_bot/utils.py
+++ b/kleinanzeigen_bot/utils.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import copy, decimal, json, logging, os, re, secrets, sys, traceback, time
 from importlib.resources import read_text as get_resource_as_string
 from collections.abc import Callable, Sized
+from datetime import datetime
 from types import FrameType, ModuleType, TracebackType
 from typing import Any, Final, TypeVar
 
@@ -253,3 +254,19 @@ def parse_decimal(number:float | int | str) -> decimal.Decimal:
             return decimal.Decimal("".join(parts[:-1]) + "." + parts[-1])
         except decimal.InvalidOperation:
             raise decimal.DecimalException(f"Invalid number format: {number}") from ex
+
+
+def parse_datetime(date:datetime | str | None) -> datetime | None:
+    """
+    >>> parse_datetime(datetime(2020, 1, 1, 0, 0))
+    datetime.datetime(2020, 1, 1, 0, 0)
+    >>> parse_datetime("2020-01-01T00:00:00")
+    datetime.datetime(2020, 1, 1, 0, 0)
+    >>> parse_datetime(None)
+
+    """
+    if date is None:
+        return None
+    if isinstance(date, datetime):
+        return date
+    return datetime.fromisoformat(date)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/125

*Description of changes:*
- CHANGE When downloading an ad, save the created_on value as string (not datetime) to the ad yaml in accordance to how the updated_on value is saved by the (re-)publish function
- ADD parse_datetime helper function
- UPDATE Parsing of created_on/updated_on so it does allow datetime values in the ad yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
