### PR TITLE
FIX when downloading save person name as contact name; not the city

### DIFF
--- a/kleinanzeigen_bot/extract.py
+++ b/kleinanzeigen_bot/extract.py
@@ -130,7 +130,12 @@ class AdExtractor:
         address_halves = address_text.split(' - ')
         address_left_parts = address_halves[0].split(' ')  # zip code and region/city
         contact['zipcode'] = address_left_parts[0]
-        contact['name'] = address_halves[1]
+
+        contact_person_element = self.driver.find_element(By.CSS_SELECTOR, '#viewad-contact')
+        name_element = contact_person_element.find_element(By.CLASS_NAME, 'iconlist-text')
+        name = name_element.find_element(By.TAG_NAME, 'a').text
+        contact['name'] = name
+
         if 'street' not in contact:
             contact['street'] = None
         try:  # phone number is unusual for non-professional sellers today


### PR DESCRIPTION
*Issue #, if available:* https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/127

*Description of changes:*
- FIX Save person name as contact:name to ad yaml instead of city name

The `download` action saved the city name to the contact:name variable in the ad config file, but it should be the person name. This pull request fixes the behavior and saves the person name to the variable correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This PR is ready to be merged.
