### PR TITLE
ADD ability to select shipping packages and sell directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ ad_defaults:
   price_type: NEGOTIABLE # one of: FIXED, NEGOTIABLE, GIVE_AWAY, NOT_APPLICABLE
   shipping_type: SHIPPING # one of: PICKUP, SHIPPING, NOT_APPLICABLE
   shipping_costs: # e.g. 2.95
+  sell_directly: false # requires shipping_options to take effect
   contact:
     name: ""
     street: ""
@@ -294,6 +295,22 @@ special_attributes:
 
 shipping_type: # one of: PICKUP, SHIPPING, NOT_APPLICABLE
 shipping_costs: # e.g. 2.95
+
+# specify shipping options / packages
+# it is possible to select multiple packages, but only from one size (S, M, L)!
+# possible package types for size S:
+# - DHL_2
+# - Hermes_Päckchen
+# - Hermes_S
+# possible package types for size M:
+# - DHL_5
+# - Hermes_M
+# possible package types for size L:
+# - DHL_10
+# - DHL_31,5
+# - Hermes_L
+shipping_options: []
+sell_directly: # true or false, requires shipping_options to take effect
 
 # list of wildcard patterns to select images
 # if relative paths are specified, then they are relative to this ad configuration file

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Options:
   -v, --verbose     - enables verbose output - only useful when troubleshooting issues
 ```
 
+Limitation of `download`: It's only possible to extract the cheaptest given shipping option.
+
 ### Configuration
 
 All configuration files can be in YAML or JSON format.

--- a/kleinanzeigen_bot/__init__.py
+++ b/kleinanzeigen_bot/__init__.py
@@ -842,7 +842,8 @@ class KleinanzeigenBot(SeleniumMixin):
         info['price'], info['price_type'] = extractor.extract_pricing_info_from_ad_page()
 
         # process shipping
-        info['shipping_type'], info['shipping_costs'] = extractor.extract_shipping_info_from_ad_page()
+        info['shipping_type'], info['shipping_costs'], info['shipping_options'] = extractor.extract_shipping_info_from_ad_page()
+        info['sell_directly'] = extractor.extract_sell_directly_from_ad_page()
 
         # fetch images
         info['images'] = self.download_images_from_ad_page(directory, id_, LOG)

--- a/kleinanzeigen_bot/resources/ad_fields.yaml
+++ b/kleinanzeigen_bot/resources/ad_fields.yaml
@@ -8,6 +8,8 @@ price:
 price_type: # one of: FIXED, NEGOTIABLE, GIVE_AWAY, NOT_APPLICABLE
 shipping_type: # one of: PICKUP, SHIPPING, NOT_APPLICABLE
 shipping_costs:
+shipping_options: [] # see README.md for more information
+sell_directly: # requires shipping_options to take effect
 images: []
 contact:
   name:

--- a/kleinanzeigen_bot/resources/config_defaults.yaml
+++ b/kleinanzeigen_bot/resources/config_defaults.yaml
@@ -10,6 +10,7 @@ ad_defaults:
     suffix: ""
   price_type: NEGOTIABLE # one of: FIXED, NEGOTIABLE, GIVE_AWAY, NOT_APPLICABLE
   shipping_type: SHIPPING # one of: PICKUP, SHIPPING, NOT_APPLICABLE
+  sell_directly: false # requires shipping_options to take effect
   contact:
     name: ""
     street: ""


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*
- [x] ADD ability to select shipping packages and sell directly
- [x] UPDATE download functionality to get the information about the shipping options and sell directly; any idea from where we can get that?

*To be discussed*
- [ ] The naming of the keys to select the wanted shipping options in the ad config yaml are open for discussion (e.g. DHL_2, Hermes_S). There might be "easier" options. I don't like to use the "ebay-kleinanzeigen" names as these do not have the shipping company in the key ("e.g. Paket 2 kg")
- [ ] I used the key `data-testid` of the radio buttons to select the shipping options. These are in German. Could there be any problem when using a different browser/language? Is it even possible to use kleinanzeigen in another language?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
