### PR TITLE
Wait for confirmation page

### DIFF
--- a/kleinanzeigen_bot/__init__.py
+++ b/kleinanzeigen_bot/__init__.py
@@ -443,7 +443,7 @@ class KleinanzeigenBot(SeleniumMixin):
             count += 1
             LOG.info("Processing %s/%s: '%s' from [%s]...", count, len(ad_cfgs), ad_cfg["title"], ad_file)
             self.publish_ad(ad_file, ad_cfg, ad_cfg_orig)
-            pause(3000, 5000)
+            self.web_await(lambda _: self.webdriver.find_element(By.ID, "checking-done").is_displayed(), timeout = 5 * 60)            
 
         LOG.info("############################################")
         LOG.info("DONE: (Re-)published %s", pluralize("ad", count))

--- a/kleinanzeigen_bot/__init__.py
+++ b/kleinanzeigen_bot/__init__.py
@@ -443,8 +443,8 @@ class KleinanzeigenBot(SeleniumMixin):
             count += 1
             LOG.info("Processing %s/%s: '%s' from [%s]...", count, len(ad_cfgs), ad_cfg["title"], ad_file)
             self.publish_ad(ad_file, ad_cfg, ad_cfg_orig)
-            self.web_await(lambda _: self.webdriver.find_element(By.ID, "checking-done").is_displayed(), timeout = 5 * 60)            
-
+            self.web_await(lambda _: self.webdriver.find_element(By.ID, "checking-done").is_displayed(), timeout = 5 * 60)
+        
         LOG.info("############################################")
         LOG.info("DONE: (Re-)published %s", pluralize("ad", count))
         LOG.info("############################################")

--- a/kleinanzeigen_bot/__init__.py
+++ b/kleinanzeigen_bot/__init__.py
@@ -444,7 +444,7 @@ class KleinanzeigenBot(SeleniumMixin):
             LOG.info("Processing %s/%s: '%s' from [%s]...", count, len(ad_cfgs), ad_cfg["title"], ad_file)
             self.publish_ad(ad_file, ad_cfg, ad_cfg_orig)
             self.web_await(lambda _: self.webdriver.find_element(By.ID, "checking-done").is_displayed(), timeout = 5 * 60)
-        
+
         LOG.info("############################################")
         LOG.info("DONE: (Re-)published %s", pluralize("ad", count))
         LOG.info("############################################")


### PR DESCRIPTION
Sometimes it takes longer until the confirmation is shown, that the classified ad is published. In that case the pause aborts the publish process. To avoid this, changed to wait for a confirmation been visible.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
