### PR TITLE
FIX do not click on pstad-price to wait for category detection

### DIFF
--- a/kleinanzeigen_bot/__init__.py
+++ b/kleinanzeigen_bot/__init__.py
@@ -573,7 +573,7 @@ class KleinanzeigenBot(SeleniumMixin):
     def __set_category(self, ad_file:str, ad_cfg: dict[str, Any]):
         # click on something to trigger automatic category detection
         self.web_click(By.ID, "pstad-descrptn")
-        
+
         try:
             self.web_find(By.XPATH, "//*[@id='postad-category-path'][text()]")
             is_category_auto_selected = True

--- a/kleinanzeigen_bot/__init__.py
+++ b/kleinanzeigen_bot/__init__.py
@@ -571,8 +571,9 @@ class KleinanzeigenBot(SeleniumMixin):
         utils.save_dict(ad_file, ad_cfg_orig)
 
     def __set_category(self, ad_file:str, ad_cfg: dict[str, Any]):
-        # trigger and wait for automatic category detection
-        self.web_click(By.ID, "pstad-price")
+        # click on something to trigger automatic category detection
+        self.web_click(By.ID, "pstad-descrptn")
+        
         try:
             self.web_find(By.XPATH, "//*[@id='postad-category-path'][text()]")
             is_category_auto_selected = True


### PR DESCRIPTION
pstad-price is not always visible, click on pstadt-description instead

*Issue #, if available:*

*Description of changes:*

Publishing crashed when trying to click on pstad-price element. For some reason the element was not visible for me, but some other price field was.
I changed the field to be clicked to the description box because it is always visible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
