### PR TITLE
Fix download element and path problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The following parameters can be configured:
 # wild card patterns to select ad configuration files
 # if relative paths are specified, then they are relative to this configuration file
 ad_files:
-  - "my_ads/**/ad_*.{json,yml,yaml}"
+  - "./**/ad_*.{json,yml,yaml}"
 
 # default values for ads, can be overwritten in each ad configuration file
 ad_defaults:

--- a/kleinanzeigen_bot/extract.py
+++ b/kleinanzeigen_bot/extract.py
@@ -194,7 +194,8 @@ class AdExtractor(SeleniumMixin):
 
         # collect ad references:
 
-        pagination_section = self.webdriver.find_element(By.CSS_SELECTOR, 'section.jsx-1105488430:nth-child(4)')
+        pagination_section = self.webdriver.find_element(By.CSS_SELECTOR, '.l-splitpage')\
+            .find_element(By.XPATH, './/section[4]')
         # scroll down to load dynamically
         self.web_scroll_page_down()
         pause(2000, 3000)

--- a/kleinanzeigen_bot/resources/config_defaults.yaml
+++ b/kleinanzeigen_bot/resources/config_defaults.yaml
@@ -1,5 +1,5 @@
 ad_files:
-  - "**/ad_*.{json,yml,yaml}"
+  - "./**/ad_*.{json,yml,yaml}"
 
 # default values for ads, can be overwritten in each ad configuration file
 ad_defaults:


### PR DESCRIPTION
*Issue #, if available:*
#149 #136 

*Description of changes:*

- To mitigate crashing when scanning the ad overview page, the selection of the `<section>` element is now more robust, and now should not depend on dynamic class assignment.
- Configured the standard ads path as suggested by @baflo. The downloaded ads are assigned to a specific directory. 
- Slightly adjusted load_ads, with a new optional parameter, and explicitly skipping _ad_fields.yaml_. Even if the ads selector is 'new', setting the second optional parameter to false allows to load all ads, if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
