### PR TITLE
ADD .gitignore downloaded-ads folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _LOCAL/
 /data
 /*.log
 kleinanzeigen_bot/version.py
+downloaded-ads
 
 # python
 /__pypackages__


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Gitignore the hardcoded `downloaded-ads` folder which will be created and used to save the downloaded ads in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
