### PR TITLE
Fix: Crash on downloading ads with prices >=1000 Eur

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -310,7 +310,7 @@ class AdExtractor(WebScrapingMixin):
             match price_str.split()[-1]:
                 case '€':
                     price_type = 'FIXED'
-                    price = int(price_str.split()[0])
+                    price = int(price_str.replace('.', '').split()[0])
                 case 'VB':
                     price_type = 'NEGOTIABLE'
                     if not price_str == "VB":  # can be either 'X € VB', or just 'VB'

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -310,6 +310,7 @@ class AdExtractor(WebScrapingMixin):
             match price_str.split()[-1]:
                 case '€':
                     price_type = 'FIXED'
+                    # replace('.', '') is to remove the thousands separator before parsing as int
                     price = int(price_str.replace('.', '').split()[0])
                 case 'VB':
                     price_type = 'NEGOTIABLE'


### PR DESCRIPTION
This fixes the following issue:

```
$ ./kleinanzeigen-bot --ads=all download
[...]
[INFO]  ... pausing for 1995 ms ...
[INFO] New directory for ad created at downloaded-ads/ad_2682902075.
[INFO] Extracting information from ad with title "Bandauflösung Tonstudio mit Rack, Faderport, Audio-PC, Funkmikros"
[ERROR] ValueError: invalid literal for int() with base 10: '4.500'
[2025675] Failed to execute script '__main__' due to unhandled exception!
successfully removed temp profile /tmp/uc_l5mu72fo
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
