### PR TITLE
fix: No HTML element found with ID 'my-manageads-adlist'

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -157,7 +157,7 @@ class AdExtractor(WebScrapingMixin):
         while True:  # loop reference extraction until no more forward page
             # extract references
             list_items = await self.web_find_all(By.CLASS_NAME, 'cardbox',
-                    parent = await self.web_find(By.ID, 'my-manageads-adlist'))
+                    parent = await self.web_find(By.ID, 'my-manageitems-adlist'))
             refs += [
                 (await self.web_find(By.CSS_SELECTOR, 'article > section > section:nth-of-type(2) > h2 > div > a', parent = li)).attrs['href']
                 for li in list_items


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/283

*Description of changes:*
changed the id name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
