### PR TITLE
Fix download on given IDs list

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -183,6 +183,8 @@ class AdExtractor(WebScrapingMixin):
         :return: whether the navigation to the ad page was successful
         """
         if is_integer(id_or_url):
+            # navigate to start page, otherwise page can be None!
+            await self.web_open('https://www.kleinanzeigen.de/')
             # enter the ad ID into the search bar
             await self.web_input(By.ID, "site-search-query", id_or_url)
             # navigate to ad page and wait


### PR DESCRIPTION
pdm run app download --ads=2xxxxx will result in crash because page is still None, navigating to startpage fixes this.
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
