### PR TITLE
fix broken link to categories in config_defaults.yaml

### DIFF
--- a/src/kleinanzeigen_bot/resources/config_defaults.yaml
+++ b/src/kleinanzeigen_bot/resources/config_defaults.yaml
@@ -19,7 +19,7 @@ ad_defaults:
   republication_interval: 7 # every X days ads should be re-published
 
 # additional name to category ID mappings, see default list at
-# https://github.com/Second-Hand-Friends/kleinanzeigen-bot/blob/main/kleinanzeigen_bot/resources/categories.yaml
+# https://github.com/Second-Hand-Friends/kleinanzeigen-bot/blob/main/src/kleinanzeigen_bot/resources/categories.yaml
 # Notebooks: 161/278 # Elektronik > Notebooks
 # Autoteile: 210/223/sonstige_autoteile # Auto, Rad & Boot > Autoteile & Reifen > Weitere Autoteile
 categories: []


### PR DESCRIPTION
*Description of changes:*
While trying out the kleinanzeigen bot, I realized that the categories link in the default config is leading to a broken link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
