### PR TITLE
fix navigation button selector

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -166,7 +166,7 @@ class AdExtractor(WebScrapingMixin):
             if not multi_page:  # only one iteration for single-page overview
                 break
             # check if last page
-            nav_button:Element = (await self.web_find_all(By.CSS_SELECTOR, 'button.jsx-2828608826'))[-1]
+            nav_button:Element = (await self.web_find_all(By.CSS_SELECTOR, 'button.jsx-1553636621'))[-1]
             if nav_button.attrs['title'] != 'Nächste':
                 LOG.info('Last ad overview page explored.')
                 break


### PR DESCRIPTION
*Issue #, if available:*
#278
*Description of changes:*
The button selector for the navigation button has changed. This PR fixes the selector, so downloading ads when having multiple pages will work again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
