### PR TITLE
FIX extract sell directly from ad page

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -373,7 +373,7 @@ class AdExtractor(WebScrapingMixin):
         :return: a boolean indicating whether the sell directly option is active (optional)
         """
         try:
-            buy_now_is_active:bool = (await self.web_text(By.ID, 'j-buy-now')) == "Direkt kaufen"
+            buy_now_is_active:bool = 'Direkt kaufen' in (await self.web_text(By.ID, 'payment-buttons-sidebar'))
             return buy_now_is_active
         except TimeoutError:
             return None


### PR DESCRIPTION
*Issue #, if available:* no issue

*Description of changes:* Web element with id `j-buy-now` does not exist anymore. Fetch the `payment-buttons-sidebar` instead and check the text for `Direkt kaufen`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
