### PR TITLE
Fix selection of special attributes

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -718,7 +718,7 @@ class KleinanzeigenBot(WebScrapingMixin):
                     pass  # nosec
 
                 try:
-                    await self.web_select(By.XPATH, f"//select[@id='{special_attribute_key}']", special_attribute_value)
+                    await self.web_select(By.XPATH, f"//select[contains(@id, '{special_attribute_key}')]", special_attribute_value)
                 except TimeoutError:
                     LOG.debug("Attribute field '%s' is not of kind dropdown, trying to input as plain text...", special_attribute_key)
                     try:
@@ -726,7 +726,7 @@ class KleinanzeigenBot(WebScrapingMixin):
                     except TimeoutError:
                         LOG.debug("Attribute field '%s' is not of kind plain text, trying to input as radio button...", special_attribute_key)
                         try:
-                            await self.web_click(By.XPATH, f"//*[@id='{special_attribute_key}']/option[@value='{special_attribute_value}']")
+                            await self.web_click(By.XPATH, f"//*[contains(@id, '{special_attribute_key}')]/option[@value='{special_attribute_value}']")
                         except TimeoutError as ex:
                             LOG.debug("Attribute field '%s' is not of kind radio button.", special_attribute_key)
                             raise TimeoutError(f"Failed to set special attribute [{special_attribute_key}]") from ex


### PR DESCRIPTION
*Issue #, if available:*
fixes #281

*Description of changes:* 

This Pull Requests submits two fixes.
1) The condition is nowadays set within a dialog. I added a function to set the condition accordingly. My implemented option is backwards compatible and requires a mapping from the condition_s key to the friendly name which shall be selected. It might be an idea to change the download behavior to save the condition friendly name ("Neu" instead of the condition_s key "new") in another issue?
2) The special attributes field keys changed from "key" to "category.key". We currently haven't saved the category name anywhere, which makes it difficult to select the special attribute field by full name. Instead this hotfix uses "contains" to find the special attributes field. Credits @Vel-San https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/281#issuecomment-2185020997

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
