### PR TITLE
fix: ValueError when downloading ads without special_attributes

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -290,7 +290,7 @@ class AdExtractor(WebScrapingMixin):
         """
         belen_conf = await self.web_execute("window.BelenConf")
         special_attributes_str = belen_conf["universalAnalyticsOpts"]["dimensions"]["dimension108"]
-        special_attributes = dict(item.split(":") for item in special_attributes_str.split("|"))
+        special_attributes = dict(item.split(":") for item in special_attributes_str.split("|") if ":" in item)
         special_attributes = {k: v for k, v in special_attributes.items() if not k.endswith('.versand_s') and k != "versand_s"}
         return special_attributes
 

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -285,6 +285,7 @@ class AdExtractor(WebScrapingMixin):
     async def _extract_special_attributes_from_ad_page(self) -> dict[str, Any]:
         """
         Extracts the special attributes from an ad page.
+        If no items are available then special_attributes is empty
 
         :return: a dictionary (possibly empty) where the keys are the attribute names, mapped to their values
         """


### PR DESCRIPTION
*Issue https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/323

*Description of changes:*
At issue https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/323 the ad_2827968602 had NO special_attributes.  This broke down the for loop.
-> Fixed by adding a check for items.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@sebthom: Kindly review and merge the PR