### PR TITLE
FIX login check has to be done case insensitive

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -444,7 +444,7 @@ class KleinanzeigenBot(WebScrapingMixin):
     async def is_logged_in(self) -> bool:
         try:
             user_info = await self.web_text(By.ID, "user-email")
-            if self.config['login']['username'] in user_info:
+            if self.config['login']['username'].lower() in user_info.lower():
                 return True
         except TimeoutError:
             return False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The login check can fail unnecessary when the username does not match case sensitive.

Make the check case insensitive by lowering both strings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
