### PR TITLE
fix: failed to set special attributes #334

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -821,14 +821,14 @@ class KleinanzeigenBot(WebScrapingMixin):
                     raise TimeoutError(f"Failed to set special attribute [{special_attribute_key}] (not found)") from ex
 
                 # workaround for https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/368
-                elem_id = getattr(special_attr_elem.attrs, 'id' )
+                elem_id = getattr(special_attr_elem.attrs, 'id')
                 elem_id = ''.join(['\\' + c if c in '!"#$%&\'()*+,./:;<=>?@[\\]^`{|}~' else c for c in elem_id])
 
                 try:
                     if special_attr_elem.local_name == 'select':
                         LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)
                         await self.web_select(By.ID, elem_id, special_attribute_value)
-                    elif getattr(special_attr_elem.attrs, 'type' ) == 'checkbox':
+                    elif getattr(special_attr_elem.attrs, 'type') == 'checkbox':
                         LOG.debug("Attribute field '%s' seems to be a checkbox...", special_attribute_key)
                         await self.web_click(By.ID, elem_id)
                     else:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -814,18 +814,30 @@ class KleinanzeigenBot(WebScrapingMixin):
                     pass  # nosec
 
                 try:
-                    await self.web_select(By.XPATH, f"//select[contains(@id, '{special_attribute_key}')]", special_attribute_value)
-                except TimeoutError:
-                    LOG.debug("Attribute field '%s' is not of kind dropdown, trying to input as plain text...", special_attribute_key)
-                    try:
-                        await self.web_input(By.ID, special_attribute_key, special_attribute_value)
-                    except TimeoutError:
-                        LOG.debug("Attribute field '%s' is not of kind plain text, trying to input as radio button...", special_attribute_key)
-                        try:
-                            await self.web_click(By.XPATH, f"//*[contains(@id, '{special_attribute_key}')]/option[@value='{special_attribute_value}']")
-                        except TimeoutError as ex:
-                            LOG.debug("Attribute field '%s' is not of kind radio button.", special_attribute_key)
-                            raise TimeoutError(f"Failed to set special attribute [{special_attribute_key}]") from ex
+                    # finding element by name cause id are composed sometimes eg. autos.marke_s+autos.model_s for Modell by cars
+                    special_attr_elem = await self.web_find(By.XPATH, f"//*[contains(@name, '{special_attribute_key}')]")
+                except TimeoutError as ex:
+                    LOG.debug("Attribute field '%s' could not be found.", special_attribute_key)
+                    raise TimeoutError(f"Failed to set special attribute [{special_attribute_key}] (not found)") from ex
+
+                # workaround for https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/368
+                elem_id = getattr(special_attr_elem.attrs, 'id' )
+                elem_id = ''.join(['\\' + c if c in '!"#$%&\'()*+,./:;<=>?@[\\]^`{|}~' else c for c in elem_id])
+
+                try:
+                    if special_attr_elem.local_name == 'select':
+                        LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)
+                        await self.web_select(By.ID, elem_id, special_attribute_value)
+                    else:
+                        if getattr(special_attr_elem.attrs, 'type' ) == 'checkbox':
+                            LOG.debug("Attribute field '%s' seems to be a checkbox...", special_attribute_key)
+                            await self.web_click(By.ID, elem_id)
+                        else:
+                            LOG.debug("Attribute field '%s' seems to be a text input...", special_attribute_key)
+                            await self.web_input(By.ID, elem_id, special_attribute_value)
+                except TimeoutError as ex:
+                    LOG.debug("Attribute field '%s' is not of kind radio button.", special_attribute_key)
+                    raise TimeoutError(f"Failed to set special attribute [{special_attribute_key}]") from ex
                 LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value)
 
     async def __set_shipping_options(self, ad_cfg: dict[str, Any]) -> None:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -828,13 +828,12 @@ class KleinanzeigenBot(WebScrapingMixin):
                     if special_attr_elem.local_name == 'select':
                         LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)
                         await self.web_select(By.ID, elem_id, special_attribute_value)
+                    elif getattr(special_attr_elem.attrs, 'type' ) == 'checkbox':
+                        LOG.debug("Attribute field '%s' seems to be a checkbox...", special_attribute_key)
+                        await self.web_click(By.ID, elem_id)
                     else:
-                        if getattr(special_attr_elem.attrs, 'type' ) == 'checkbox':
-                            LOG.debug("Attribute field '%s' seems to be a checkbox...", special_attribute_key)
-                            await self.web_click(By.ID, elem_id)
-                        else:
-                            LOG.debug("Attribute field '%s' seems to be a text input...", special_attribute_key)
-                            await self.web_input(By.ID, elem_id, special_attribute_value)
+                        LOG.debug("Attribute field '%s' seems to be a text input...", special_attribute_key)
+                        await self.web_input(By.ID, elem_id, special_attribute_value)
                 except TimeoutError as ex:
                     LOG.debug("Attribute field '%s' is not of kind radio button.", special_attribute_key)
                     raise TimeoutError(f"Failed to set special attribute [{special_attribute_key}]") from ex

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -245,6 +245,9 @@ class AdExtractor(WebScrapingMixin):
             # change e.g. category "161/172" to "161/172/lautsprecher_kopfhoerer"
             info['category'] = f"{info['category']}/{info['special_attributes']['art_s']}"
             del info['special_attributes']['art_s']
+        if "schaden_s" in info['special_attributes']:
+            # change f to  'nein' and 't' to 'ja'
+            info['special_attributes']['schaden_s'] = info['special_attributes']['schaden_s'].translate(str.maketrans({'t': 'ja', 'f': 'nein'}))
         info['price'], info['price_type'] = await self._extract_pricing_info_from_ad_page()
         info['shipping_type'], info['shipping_costs'], info['shipping_options'] = await self._extract_shipping_info_from_ad_page()
         info['sell_directly'] = await self._extract_sell_directly_from_ad_page()


### PR DESCRIPTION
Refactored setting of specail attributes. This still has some effects in some cases since special attribute can have dependencies on each other and must be in an special order. For example in category car, the special attribute 'marke_s' must be set before 'model_s', otherwise when setting 'marke_s' 'model_s' gets cleared.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
