### PR TITLE
fix shipping options when downloading 

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ shipping_costs: # e.g. 2.95
 # - Hermes_M
 # possible package types for size L:
 # - DHL_10
+# - DHL_20
 # - DHL_31,5
 # - Hermes_L
 shipping_options: []

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -621,7 +621,8 @@ class KleinanzeigenBot(WebScrapingMixin):
             await self.__set_shipping_options(ad_cfg)
         else:
             try:
-                await self.web_click(By.CSS_SELECTOR, '[class*="jsx-2623555103"]')
+                await self.web_click(By.XPATH,
+                                     '//*[contains(@class, "ShippingSection")]//*//button[contains(@aria-label, "Dialog mit Optionen öffnen")]')
                 await self.web_click(By.CSS_SELECTOR, '[class*="CarrierSelectionModal--Button"]')
                 await self.web_click(By.CSS_SELECTOR, '[class*="CarrierOption--Main"]')
                 if ad_cfg["shipping_costs"]:
@@ -852,6 +853,7 @@ class KleinanzeigenBot(WebScrapingMixin):
             "DHL_5": ("Mittel", "Paket 5 kg"),
             "Hermes_M": ("Mittel", "M-Paket"),
             "DHL_10": ("Groß", "Paket 10 kg"),
+            "DHL_20": ("Groß", "Paket 20 kg"),
             "DHL_31,5": ("Groß", "Paket 31,5 kg"),
             "Hermes_L": ("Groß", "L-Paket"),
         }

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -8,7 +8,7 @@ import urllib.request as urllib_request
 import mimetypes
 from datetime import datetime
 from typing import Any, Final
-from . import json
+import json
 
 from .i18n import get_translating_logger, pluralize
 from .utils import is_integer, parse_decimal, save_dict
@@ -352,9 +352,9 @@ class AdExtractor(WebScrapingMixin):
                 # and find the right one by price
                 shipping_costs = json.loads(
                     (await self.web_request("https://gateway.kleinanzeigen.de/postad/api/v1/shipping-options?posterType=PRIVATE"))
-                        ["content"])["data"]["shippingOptionsResponse"]["options"]
+                    ["content"])["data"]["shippingOptionsResponse"]["options"]
 
-                internal_shipping_opt = [x for x in shipping_costs if x["priceInEuroCent"] == ship_costs*100]
+                internal_shipping_opt = [x for x in shipping_costs if x["priceInEuroCent"] == ship_costs * 100]
 
                 if not internal_shipping_opt:
                     return 'NOT_APPLICABLE', ship_costs, shipping_options

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -372,10 +372,11 @@ class AdExtractor(WebScrapingMixin):
                     "HERMES_004": "Hermes_L"
                 }
 
-                shipping_options = [shipping_option_mapping.get(internal_shipping_opt[0]['id'])]
-                if not shipping_options:
+                shipping_option = shipping_option_mapping.get(internal_shipping_opt[0]['id'])
+                if not shipping_option:
                     return 'NOT_APPLICABLE', ship_costs, shipping_options
 
+                shipping_options = [shipping_option]
         except TimeoutError:  # no pricing box -> no shipping given
             ship_type = 'NOT_APPLICABLE'
 

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -8,6 +8,7 @@ import urllib.request as urllib_request
 import mimetypes
 from datetime import datetime
 from typing import Any, Final
+from . import json
 
 from .i18n import get_translating_logger, pluralize
 from .utils import is_integer, parse_decimal, save_dict
@@ -347,23 +348,34 @@ class AdExtractor(WebScrapingMixin):
                 ship_type = 'SHIPPING'
                 ship_costs = float(parse_decimal(shipping_price_parts[-2]))
 
-                # extract shipping options
-                # It is only possible the extract the cheapest shipping option,
-                # as the other options are not shown
+                # reading shipping option from kleinanzeigen
+                # and find the right one by price
+                shipping_costs = json.loads(
+                    (await self.web_request("https://gateway.kleinanzeigen.de/postad/api/v1/shipping-options?posterType=PRIVATE"))
+                        ["content"])["data"]["shippingOptionsResponse"]["options"]
+
+                internal_shipping_opt = [x for x in shipping_costs if x["priceInEuroCent"] == ship_costs*100]
+
+                if not internal_shipping_opt:
+                    return 'NOT_APPLICABLE', ship_costs, shipping_options
+
+                # map to internal shipping identifiers used by kleinanzeigen-bot
                 shipping_option_mapping = {
-                    "DHL_2": "5,49",
-                    "Hermes_Päckchen": "4,50",
-                    "Hermes_S": "4,95",
-                    "DHL_5": "6,99",
-                    "Hermes_M": "6,75",
-                    "DHL_10": "10,49",
-                    "DHL_31,5": "19,99",
-                    "Hermes_L": "10,95",
+                    "DHL_001": "DHL_2",
+                    "DHL_002": "DHL_5",
+                    "DHL_003": "DHL_10",
+                    "DHL_004": "DHL_31,5",
+                    "DHL_005": "DHL_20",
+                    "HERMES_001": "Hermes_Päckchen",
+                    "HERMES_002": "Hermes_S",
+                    "HERMES_003": "Hermes_M",
+                    "HERMES_004": "Hermes_L"
                 }
-                for shipping_option, shipping_price in shipping_option_mapping.items():
-                    if shipping_price in shipping_text:
-                        shipping_options = [shipping_option]
-                        break
+
+                shipping_options = [shipping_option_mapping.get(internal_shipping_opt[0]['id'])]
+                if not shipping_options:
+                    return 'NOT_APPLICABLE', ship_costs, shipping_options
+
         except TimeoutError:  # no pricing box -> no shipping given
             ship_type = 'NOT_APPLICABLE'
 


### PR DESCRIPTION
#375
Refactored extraction of shipping options to use options directly from kleinanazeigen. 
Add new option DHL_20 for packets up to 20kg.
