### PR TITLE
fix: correct city selection when multiple cities are available for a ZIP code

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -668,6 +668,18 @@ class KleinanzeigenBot(WebScrapingMixin):
         #############################
         if ad_cfg["contact"]["zipcode"]:
             await self.web_input(By.ID, "pstad-zip", ad_cfg["contact"]["zipcode"])
+            # Set city if location is specified
+            if ad_cfg["contact"].get("location"):
+                try:
+                    await self.web_sleep(1)  # Wait for city dropdown to populate
+                    options = await self.web_find_all(By.CSS_SELECTOR, "#pstad-citychsr option")
+                    for option in options:
+                        option_text = await self.web_text(By.CSS_SELECTOR, "option", parent=option)
+                        if option_text == ad_cfg["contact"]["location"]:
+                            await self.web_select(By.ID, "pstad-citychsr", option_text)
+                            break
+                except TimeoutError:
+                    LOG.debug("Could not set city from location")
 
         #############################
         # set contact street


### PR DESCRIPTION
## Description

When multiple cities are available for a ZIP code, the bot now correctly selects the city specified in the YAML file's `location` field instead of always choosing the first option.

## Changes
- Adds logic to select the correct city from the dropdown based on the `location` field.  
- Adds a small delay after ZIP code input to allow the dropdown to populate.  
- Uses the proper `WebScrapingMixin` method to read dropdown options.  

## Issue #
_None_

## Description of Changes
Fixes a bug in city selection when multiple locations are available for a postal code. Previously, the first location was always selected, even if a different one was specified in the YAML file.

## How to Test
1. Create a listing with a postal code that has multiple location options (e.g., `27321`).  
2. In the YAML file under `contact`, specify both the `zipcode` and a `location`:  
   ```yaml
   contact:
     zipcode: '27321'
     location: 'Niedersachsen - Thedinghausen'
   ```
3. Run the bot – it should now select the correct location.

## Checklist
- [x] The code follows the project’s style.  
- [x] The changes have been tested.  
- [x] The documentation has been updated (if necessary).  

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
