### PR TITLE
Fix/doctest pluralize locale

### DIFF
--- a/src/kleinanzeigen_bot/i18n.py
+++ b/src/kleinanzeigen_bot/i18n.py
@@ -153,6 +153,7 @@ def set_current_locale(new_locale:Locale) -> None:
 
 def pluralize(noun:str, count:int | Sized, prefix_with_count:bool = True) -> str:
     """
+    >>> set_current_locale(Locale("en"))  # Setup for doctests
     >>> pluralize("field", 1)
     '1 field'
     >>> pluralize("field", 2)


### PR DESCRIPTION
## ℹ️ Description
This PR fixes the issue where doctests in `i18n.py` fail on systems with non-English locales.

- Link to the related issue(s): Issue #390
- The doctests for pluralization rules should work consistently across all system configurations.

## 📋 Changes Summary
- Add explicit locale setup in `pluralize()` doctests to ensure consistent behavior
- Tests now pass regardless of system locale settings

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`)
- [x] I have verified that linting passes (`pdm run lint`)
- [x] I have run security scans and addressed any identified issues (`pdm run audit`)
- [x] I have updated documentation where necessary

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
