### PR TITLE
fix: Handle None values in calculate_content_hash (#395)

### DIFF
--- a/src/kleinanzeigen_bot/utils.py
+++ b/src/kleinanzeigen_bot/utils.py
@@ -347,15 +347,15 @@ def calculate_content_hash(ad_cfg: dict[str, Any]) -> str:
         "category": str(ad_cfg.get("category", "")),
         "price": str(ad_cfg.get("price", "")),  # Price always as string
         "price_type": str(ad_cfg.get("price_type", "")),
-        "special_attributes": dict(ad_cfg.get("special_attributes", {})),  # Copy the dict
+        "special_attributes": dict(ad_cfg.get("special_attributes") or {}),  # Handle None case
         "shipping_type": str(ad_cfg.get("shipping_type", "")),
         "shipping_costs": str(ad_cfg.get("shipping_costs", "")),
-        "shipping_options": sorted([str(x) for x in (ad_cfg.get("shipping_options") or [])]),  # Convert to list and sort
+        "shipping_options": sorted([str(x) for x in (ad_cfg.get("shipping_options") or [])]),  # Handle None case
         "sell_directly": bool(ad_cfg.get("sell_directly", False)),  # Explicitly convert to bool
-        "images": sorted([os.path.basename(img) if isinstance(img, str) else str(img) for img in ad_cfg.get("images", [])]),  # Only filenames
+        "images": sorted([os.path.basename(str(img)) if img is not None else "" for img in (ad_cfg.get("images") or [])]),  # Handle None values in images
         "contact": {
             "name": str(ad_cfg.get("contact", {}).get("name", "")),
-            "street": str(ad_cfg.get("contact", {}).get("street", "None")),  # Explicitly "None" as string for None values
+            "street": str(ad_cfg.get("contact", {}).get("street", "")),  # Changed from "None" to empty string for consistency
             "zipcode": str(ad_cfg.get("contact", {}).get("zipcode", "")),
             "phone": str(ad_cfg.get("contact", {}).get("phone", ""))
         }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,21 +33,21 @@ def test_ensure() -> None:
 def test_calculate_content_hash_with_none_values() -> None:
     """Test calculate_content_hash with None values in the ad configuration."""
     ad_cfg = {
-        # Minimale Konfiguration mit None-Werten wie im Bug-Report beschrieben
+        # Minimal configuration with None values as described in bug report
         "id": "123456789",
         "created_on": "2022-07-19T07:30:20.489289",
         "updated_on": "2025-01-22T19:46:46.735896",
-        "title": "Test Anzeige",
-        "description": "Test Beschreibung",
-        "images": [None, "/path/to/image.jpg", None],  # None-Werte in der images Liste
-        "shipping_options": None,  # None statt Liste
-        "special_attributes": None,  # None statt Dictionary
+        "title": "Test Ad",
+        "description": "Test Description",
+        "images": [None, "/path/to/image.jpg", None],  # List containing None values
+        "shipping_options": None,  # None instead of list
+        "special_attributes": None,  # None instead of dictionary
         "contact": {
-            "street": None  # None-Wert in contact
+            "street": None  # None value in contact
         }
     }
 
-    # Sollte keinen TypeError werfen
+    # Should not raise TypeError
     hash_value = utils.calculate_content_hash(ad_cfg)
     assert isinstance(hash_value, str)
-    assert len(hash_value) == 64  # SHA-256 Hash ist 64 Zeichen lang
+    assert len(hash_value) == 64  # SHA-256 hash is 64 characters long

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,3 +28,26 @@ def test_ensure() -> None:
 
     with pytest.raises(AssertionError):
         utils.ensure(lambda: False, "FALSE", timeout = 2)
+
+
+def test_calculate_content_hash_with_none_values() -> None:
+    """Test calculate_content_hash with None values in the ad configuration."""
+    ad_cfg = {
+        # Minimale Konfiguration mit None-Werten wie im Bug-Report beschrieben
+        "id": "123456789",
+        "created_on": "2022-07-19T07:30:20.489289",
+        "updated_on": "2025-01-22T19:46:46.735896",
+        "title": "Test Anzeige",
+        "description": "Test Beschreibung",
+        "images": [None, "/path/to/image.jpg", None],  # None-Werte in der images Liste
+        "shipping_options": None,  # None statt Liste
+        "special_attributes": None,  # None statt Dictionary
+        "contact": {
+            "street": None  # None-Wert in contact
+        }
+    }
+
+    # Sollte keinen TypeError werfen
+    hash_value = utils.calculate_content_hash(ad_cfg)
+    assert isinstance(hash_value, str)
+    assert len(hash_value) == 64  # SHA-256 Hash ist 64 Zeichen lang


### PR DESCRIPTION
## ℹ️ Description
This PR fixes a TypeError that occurs when ad configurations contain None values.

- Link to the related issue(s): Issue #395
- The issue occurs with ad configurations that don't have a content_hash yet and contain None values.

## 📋 Changes Summary

- Added test case to reproduce TypeError with None values
- Improved handling of None values in `calculate_content_hash`:
  - `special_attributes`: None becomes empty dictionary
  - `shipping_options`: None becomes empty list
  - `images`: None values in list become empty strings
  - Consistent handling of empty values (empty string instead of "None")

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] Code review completed
- [x] Tests pass successfully (`pdm run test`)
- [x] Linting passes (`pdm run lint`)
- [x] No documentation updates needed as this fixes internal behavior

I confirm that this contribution can be used, modified, copied, and redistributed under the terms of the project license.