### PR TITLE
fix: Ensure Consistent Content Hash Calculation

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -279,7 +279,8 @@ class KleinanzeigenBot(WebScrapingMixin):
 
         # Check for changes first
         if ad_cfg["id"]:
-            current_hash = calculate_content_hash(ad_cfg)
+            # Calculate hash on original config to match what was stored
+            current_hash = calculate_content_hash(ad_cfg_orig)
             stored_hash = ad_cfg_orig.get("content_hash")
 
             LOG.debug("Hash comparison for [%s]:", ad_file_relative)
@@ -787,7 +788,8 @@ class KleinanzeigenBot(WebScrapingMixin):
         ad_cfg_orig["id"] = ad_id
 
         # Update content hash after successful publication
-        ad_cfg_orig["content_hash"] = calculate_content_hash(ad_cfg)
+        # Calculate hash on original config to ensure consistent comparison on restart
+        ad_cfg_orig["content_hash"] = calculate_content_hash(ad_cfg_orig)
         ad_cfg_orig["updated_on"] = datetime.utcnow().isoformat()
         if not ad_cfg["created_on"] and not ad_cfg["id"]:
             ad_cfg_orig["created_on"] = ad_cfg_orig["updated_on"]


### PR DESCRIPTION
## ℹ️ Description
This pull request addresses an issue with the content hash calculation in the `KleinanzeigenBot` class. The content hash was previously calculated on the current configuration, which could lead to inconsistencies. This change ensures that the hash is calculated on the original configuration, improving the reliability of the ad republishing process.

- Link to the related issue(s): Issue #413
- The motivation for this change is to ensure consistent behavior when checking for changes in ad configurations and to maintain the integrity of the content hash across sessions.

## 📋 Changes Summary

- Updated the `__check_ad_republication` method to calculate the content hash on the original configuration (`ad_cfg_orig`) instead of the current configuration (`ad_cfg`).
- Modified the `publish_ad` method to calculate the content hash on `ad_cfg_orig` to ensure consistent comparison on restart.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have run security scans and addressed any identified issues (`pdm run audit`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.