### PR TITLE
fix for #394

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -651,9 +651,14 @@ class KleinanzeigenBot(WebScrapingMixin):
             except TimeoutError as ex:
                 LOG.debug(ex, exc_info = True)
         elif ad_cfg["shipping_options"]:
-            await self.web_click(By.XPATH, '//*[contains(@class, "ShippingSection")]//*//button[contains(@class, "SelectionButton")]')
-            await self.web_click(By.CSS_SELECTOR, '[class*="CarrierSelectionModal--Button"]')
-            await self.__set_shipping_options(ad_cfg)
+            try:
+                await self.web_click(By.XPATH, '//*[contains(@class, "ShippingSection")]//*//button[contains(@class, "SelectionButton")]')
+                await self.web_click(By.CSS_SELECTOR, '[class*="CarrierSelectionModal--Button"]')
+                await self.__set_shipping_options(ad_cfg)
+            except TimeoutError as ex:
+                # try to set special attribute selector (then we have a commercial account)
+                shipping_value = "ja" if ad_cfg["shipping_type"] == "SHIPPING" else "nein"
+                await self.web_select(By.XPATH, "//select[contains(@id, '.versand_s')]", shipping_value)
         else:
             try:
                 await self.web_click(By.XPATH,


### PR DESCRIPTION
## ℹ️ Description
If setting shipping options triggers a timeout, check for special option ".versand_s" since commercial accounts doesn't have shipping options controls.

- Link to the related issue(s): Issue #394 


## 📋 Changes Summary
- enhanced setting shipping options logic

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [ ] I have verified that linting passes (`pdm run lint`).
- [ ] I have run security scans and addressed any identified issues (`pdm run audit`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
