### PR TITLE
fix: consolidate description text processing (#432)

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -351,13 +351,8 @@ class KleinanzeigenBot(WebScrapingMixin):
                     if not self.__check_ad_republication(ad_cfg, ad_cfg_orig, ad_file_relative):
                         continue
 
-            # Get prefix/suffix from ad config if present, otherwise use defaults
-            prefix = ad_cfg.get("prefix", self.config["ad_defaults"]["description"]["prefix"] or "")
-            suffix = ad_cfg.get("suffix", self.config["ad_defaults"]["description"]["suffix"] or "")
-
-            # Combine description parts
-            ad_cfg["description"] = prefix + (ad_cfg["description"] or "") + suffix
-            ad_cfg["description"] = ad_cfg["description"].replace("@", "(at)")
+            # Get description with prefix/suffix from ad config if present, otherwise use defaults
+            ad_cfg["description"] = self.__get_description_with_affixes(ad_cfg)
 
             # Validate total length
             ensure(len(ad_cfg["description"]) <= 4000,
@@ -1098,8 +1093,9 @@ class KleinanzeigenBot(WebScrapingMixin):
             else get_description_affixes(self.config, prefix=False)
         )
 
-        # Combine the parts
+        # Combine the parts and replace @ with (at)
         final_description = str(prefix) + str(description_text) + str(suffix)
+        final_description = final_description.replace("@", "(at)")
 
         # Validate length
         ensure(len(final_description) <= 4000,


### PR DESCRIPTION
## ℹ️ Description
This PR fixes the KeyError: 'description' issue reported in #432 by properly handling description affixes in a single method.

- Link to the related issue(s): Issue #432
- The issue occurred because description prefix/suffix handling was inconsistent across the codebase. This PR consolidates all description text processing into the `__get_description_with_affixes` method.

## 📋 Changes Summary

- Moved `@` -> `(at)` replacement into `__get_description_with_affixes` method
- Removed duplicate prefix/suffix handling code
- Ensures consistent description text processing in one place


### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have run security scans and addressed any identified issues (`pdm run audit`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.