### PR TITLE
fix: Make description field optional in ad_defaults (#435)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,9 +253,9 @@ addopts = """
   --ignore=data
   --ignore=dist
   --ignore=src/kleinanzeigen_bot/__main__.py
-  --cov=kleinanzeigen_bot
+  --cov=src/kleinanzeigen_bot
   --cov-report=term-missing
-  """
+"""
 markers = [
   "itest: marks a test as an integration test (i.e. a test with external dependencies)",
   "asyncio: mark test as async"

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1080,6 +1080,7 @@ class KleinanzeigenBot(WebScrapingMixin):
             if dicts.safe_get(ad_cfg, "description", "prefix") is not None
             # 3. Global prefix from config
             else get_description_affixes(self.config, prefix=True)
+            or ""  # Default to empty string if all sources are None
         )
 
         # Get suffix with precedence
@@ -1091,6 +1092,7 @@ class KleinanzeigenBot(WebScrapingMixin):
             if dicts.safe_get(ad_cfg, "description", "suffix") is not None
             # 3. Global suffix from config
             else get_description_affixes(self.config, prefix=False)
+            or ""  # Default to empty string if all sources are None
         )
 
         # Combine the parts and replace @ with (at)


### PR DESCRIPTION
## ℹ️ Description
This PR makes the description field in the main configuration (`ad_defaults`) optional, addressing issue #435. Previously, the bot would fail if no description or affixes were provided in the main configuration. This change improves flexibility for users while maintaining backward compatibility.

- Link to the related issue(s): Issue #435
- Motivation: Users should be able to run the bot without requiring description fields in the main configuration, as these can be specified at the individual ad level.

## 📋 Changes Summary

- Add fallback to empty string ("") when all description prefix/suffix sources are None in `__get_description_with_affixes` method
- Add comprehensive test suite for description handling in `test_init.py`
- Fix coverage path in `pyproject.toml` from 'kleinanzeigen_bot' to 'src/kleinanzeigen_bot'
- Add tests covering:
  - Description handling without main config description
  - New format affixes in configuration
  - Mixed old/new format affixes
  - Ad-level affix precedence
  - None value handling in affixes
  - Email address @ symbol replacement

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have run security scans and addressed any identified issues (`pdm run audit`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.