### PR TITLE
feat: Call a script after a configurable amount of publishings

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ categories:
 publishing:
   delete_old_ads: "AFTER_PUBLISH" # one of: AFTER_PUBLISH, BEFORE_PUBLISH, NEVER
   delete_old_ads_by_title: true # only works if delete_old_ads is set to BEFORE_PUBLISH
+  callout:
+    intervall: 10 # number of publishings before the command is executed again
+    command: "" # command which is executed e.g. VPN reconnect to get a new IP: "\"C:\Program Files\Windscribe\windscribe-cli.exe\" connect \"De\""
+    sleep: 5 # number of seconds to sleep after the command has been executed
 
 # browser configuration
 browser:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """
-import asyncio, atexit, copy, importlib.metadata, json, os, re, signal, shutil, sys, textwrap, time, subprocess
+import asyncio, atexit, copy, importlib.metadata, json, os, re, signal, shutil, sys, textwrap, time
 import getopt  # pylint: disable=deprecated-module
 import urllib.parse as urllib_parse
 import urllib.request as urllib_request
@@ -581,11 +581,11 @@ class KleinanzeigenBot(WebScrapingMixin):
 
             count += 1
 
-            if self.config["publishing"]["callout"] is not "":
-                if count % self.config["publishing"]["callout"]["intervall"] == 0:
+            if self.config["publishing"]["callout"] != "":
+                if (count % self.config["publishing"]["callout"]["intervall"] == 0) | self.config["publishing"]["callout"]["intervall"] == 1:
                     LOG.info("Interval Reached! Calling comamnd:")
-                    LOG.info(" -> " + self.config["publishing"]["callout"]["command"])
-                    LOG.info(subprocess.Popen(self.config["publishing"]["callout"]["command"], shell=True, stdout=subprocess.PIPE).stdout.read())
+                    LOG.info(" -> %s", self.config["publishing"]["callout"]["command"])
+                    LOG.info(os.popen(self.config["publishing"]["callout"]["command"]).read())
                     time.sleep(self.config["publishing"]["callout"]["sleep"])
                 else:
                     LOG.info("Skipping publishing callout")

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """
-import asyncio, atexit, copy, importlib.metadata, json, os, re, signal, shutil, sys, textwrap, time
+import asyncio, atexit, copy, importlib.metadata, json, os, re, signal, shutil, sys, textwrap, time, subprocess
 import getopt  # pylint: disable=deprecated-module
 import urllib.parse as urllib_parse
 import urllib.request as urllib_request
@@ -580,6 +580,15 @@ class KleinanzeigenBot(WebScrapingMixin):
                 continue
 
             count += 1
+
+            if self.config["publishing"]["callout"] is not "":
+                if count % self.config["publishing"]["callout"]["intervall"] == 0:
+                    LOG.info("Interval Reached! Calling comamnd:")
+                    LOG.info(" -> " + self.config["publishing"]["callout"]["command"])
+                    LOG.info(subprocess.Popen(self.config["publishing"]["callout"]["command"], shell=True, stdout=subprocess.PIPE).stdout.read())
+                    time.sleep(self.config["publishing"]["callout"]["sleep"])
+                else:
+                    LOG.info("Skipping publishing callout")
 
             await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads)
             await self.web_await(lambda: self.web_check(By.ID, "checking-done", Is.DISPLAYED), timeout = 5 * 60)

--- a/src/kleinanzeigen_bot/resources/config_defaults.yaml
+++ b/src/kleinanzeigen_bot/resources/config_defaults.yaml
@@ -29,6 +29,10 @@ categories: {}
 publishing:
   delete_old_ads: "AFTER_PUBLISH" # one of: AFTER_PUBLISH, BEFORE_PUBLISH, NEVER
   delete_old_ads_by_title: true # only works if delete_old_ads is set to BEFORE_PUBLISH
+  callout:
+    intervall: 10 # number of publishings before the command is executed again
+    command: "" # command which is executed e.g. VPN reconnect to get a new IP: "\"C:\Program Files\Windscribe\windscribe-cli.exe\" connect \"De\""
+    sleep: 5 # number of seconds to sleep after the command has been executed
 
 # browser configuration
 browser:

--- a/src/kleinanzeigen_bot/resources/config_defaults.yaml
+++ b/src/kleinanzeigen_bot/resources/config_defaults.yaml
@@ -30,9 +30,9 @@ publishing:
   delete_old_ads: "AFTER_PUBLISH" # one of: AFTER_PUBLISH, BEFORE_PUBLISH, NEVER
   delete_old_ads_by_title: true # only works if delete_old_ads is set to BEFORE_PUBLISH
   callout:
-    intervall: 10 # number of publishings before the command is executed again
+    intervall: 5 # number of publishings before the command is executed again
     command: "" # command which is executed e.g. VPN reconnect to get a new IP: "\"C:\Program Files\Windscribe\windscribe-cli.exe\" connect \"De\""
-    sleep: 5 # number of seconds to sleep after the command has been executed
+    sleep: 6 # number of seconds to sleep after the command has been executed
 
 # browser configuration
 browser:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -71,6 +71,7 @@ kleinanzeigen_bot/__init__.py:
     "ad": "Anzeige"
     "Skipping publishing callout": "Veröffentlichungsscript überspringen"
     "Interval Reached! Calling comamnd:": "Intervall erreicht! Folgender Befehl wird ausgeführt:"
+    " -> %s": " -> %s"
 
   publish_ad:
     "Publishing ad '%s'...": "Veröffentliche Anzeige '%s'..."

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -69,6 +69,8 @@ kleinanzeigen_bot/__init__.py:
     "Skipping because ad is reserved": "Überspringen, da Anzeige reserviert ist"
     "DONE: (Re-)published %s": "FERTIG: %s (erneut) veröffentlicht"
     "ad": "Anzeige"
+    "Skipping publishing callout": "Veröffentlichungsscript überspringen"
+    "Interval Reached! Calling comamnd:": "Intervall erreicht! Folgender Befehl wird ausgeführt:"
 
   publish_ad:
     "Publishing ad '%s'...": "Veröffentliche Anzeige '%s'..."


### PR DESCRIPTION


## ℹ️ Description
Add a configuration option to call a script after some publishings have been done.

I wanted to change my IP address every 10 publishings to avoid the captcha.

As this is my first ever pull-request, let me know if I have missed something.

## 📋 Changes Summary

Extension of the publishing config option:
```
publishing:
  delete_old_ads: "AFTER_PUBLISH" # one of: AFTER_PUBLISH, BEFORE_PUBLISH, NEVER
  delete_old_ads_by_title: true # only works if delete_old_ads is set to BEFORE_PUBLISH
  callout:
    intervall: 5 # number of publishings before the command is executed again
    command: "" # command which is executed e.g. VPN reconnect to get a new IP: "\"C:\Program Files\Windscribe\windscribe-cli.exe\" connect \"De\""
    sleep: 6 # number of seconds to sleep after the command has been executed
```
    

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).

> I expect this is not related to my changes...
> FAILED tests/unit/test_i18n.py::test_detect_locale[None-expected0] - AssertionError: For LANG=None, expected ('en', 'US', 'UTF-8') but got de_DE.UTF-8

- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have run security scans and addressed any identified issues (`pdm run audit`).

> Test is not happy with os.popen():
> **Starting a process with a shell, possible injection detected, security issue.**

- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

