### PR TITLE
fix: Add 'changed' selector and separate it from 'due' selector behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,14 @@ Commands:
   version  - displays the application version
 
 Options:
-  --ads=all|due|new|<id(s)> (publish) - specifies which ads to (re-)publish (DEFAULT: due)
+  --ads=all|due|new|changed|<id(s)> (publish) - specifies which ads to (re-)publish (DEFAULT: due)
         Possible values:
         * all: (re-)publish all ads ignoring republication_interval
         * due: publish all new ads and republish ads according the republication_interval
         * new: only publish new ads (i.e. ads that have no id in the config file)
+        * changed: only publish ads that have been modified since last publication
         * <id(s)>: provide one or several ads by ID to (re-)publish, like e.g. "--ads=1,2,3" ignoring republication_interval
+        * Combinations: You can combine multiple selectors with commas, e.g. "--ads=changed,due" to publish both changed and due ads
   --ads=all|new|<id(s)> (download) - specifies which ads to download (DEFAULT: new)
         Possible values:
         * all: downloads all ads from your profile

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -24,6 +24,12 @@ kleinanzeigen_bot/__init__.py:
     "App version: %s": "App Version: %s"
     "Python version: %s": "Python Version: %s"
 
+  __check_ad_changed:
+    "Hash comparison for [%s]:": "Hash-Vergleich für [%s]:"
+    "    Stored hash: %s": "    Gespeicherter Hash: %s"
+    "    Current hash: %s": "    Aktueller Hash: %s"
+    "Changes detected in ad [%s], will republish": "Änderungen in Anzeige [%s] erkannt, wird erneut veröffentlicht"
+
   load_ads:
     "Searching for ad config files...": "Suche nach Anzeigendateien..."
     " -> found %s": "-> %s gefunden"
@@ -90,11 +96,8 @@ kleinanzeigen_bot/__init__.py:
     " -> uploading image [%s]": " -> Lade Bild [%s] hoch"
 
   __check_ad_republication:
-    "Hash comparison for [%s]:": "Hash-Vergleich für [%s]:"
-    "    Stored hash: %s": "    Gespeicherter Hash: %s"
-    "    Current hash: %s": "    Aktueller Hash: %s"
-    "Changes detected in ad [%s], will republish": "Änderungen in Anzeige [%s] erkannt, wird neu veröffentlicht"
-    " -> SKIPPED: ad [%s] was last published %d days ago. republication is only required every %s days": " -> ÜBERSPRUNGEN: Anzeige [%s] wurde zuletzt vor %d Tagen veröffentlicht. Eine erneute Veröffentlichung ist nur alle %s Tage erforderlich"
+    "Changes detected in ad [%s], will republish": "Änderungen in Anzeige [%s] erkannt, wird erneut veröffentlicht"
+    " -> SKIPPED: ad [%s] was last published %d days ago. republication is only required every %s days": " -> ÜBERSPRUNGEN: Anzeige [%s] wurde zuletzt vor %d Tagen veröffentlicht. Erneute Veröffentlichung ist erst nach %s Tagen erforderlich"
 
   __set_special_attributes:
     "Found %i special attributes": "%i spezielle Attribute gefunden"


### PR DESCRIPTION
## ℹ️ Description
This PR fixes a bug where the 'due' selector was also publishing changed ads regardless of their age. It implements a new 'changed' selector for the `--ads` option and ensures that the 'due' selector only republishes ads based on the time interval.

- Link to the related issue: Issue #411
- The motivation for this change is to provide users with more control over which ads are republished, allowing them to specifically target changed ads or due ads, or combine both behaviors.

## 📋 Changes Summary

- Added a new 'changed' selector for the `--ads` option that publishes only ads that have been modified since their last publication
- Modified the 'due' selector to only republish ads based on the time interval, without considering content changes
- Refactored the ad republication logic by splitting it into two separate methods:
  - `__check_ad_republication`: Checks if an ad is due for republication based on time interval
  - `__check_ad_changed`: Checks if an ad has been changed since last publication
- Added support for combining selectors with commas (e.g., `--ads=changed,due`)
- Updated documentation in help text and README to reflect the new functionality
- Updated German translations for new log messages
- Added comprehensive tests for the new functionality

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.