### PR TITLE
fix: set custom shipping due css update #448

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3,19 +3,8 @@ SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """
-import asyncio
-import atexit
-import copy
+import asyncio, atexit, copy, importlib.metadata, json, os, re, signal, shutil, sys, textwrap, time
 import getopt  # pylint: disable=deprecated-module
-import importlib.metadata
-import json
-import os
-import re
-import shutil
-import signal
-import sys
-import textwrap
-import time
 import urllib.parse as urllib_parse
 import urllib.request as urllib_request
 from collections.abc import Iterable

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -128,6 +128,9 @@ kleinanzeigen_bot/__init__.py:
   fill_login_data_and_send:
     "Logging in as [%s]...": "Anmeldung als [%s]..."
 
+  __set_shipping:
+    "Unable to close shipping dialog!": "Versanddialog konnte nicht geschlossen werden!"
+
   __set_shipping_options:
     "Unable to close shipping dialog!": "Versanddialog konnte nicht geschlossen werden!"
 


### PR DESCRIPTION
## ℹ️ Description
The PR fixes setting of custom shipping price, where no shipping options were given.

- Link to the related issue(s): Issue #448
- The motivation is the correct handling of this case.

## 📋 Changes Summary
- check if shipping costs are set when no other options are set and then put them into right place

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x ] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x ] I have reviewed my changes to ensure they meet the project's standards.
- [x ] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x ] I have verified that linting passes (`pdm run lint`).
- [x ] I have run security scans and addressed any identified issues (`pdm run audit`).
- [x ] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
