### PR TITLE
fix: setting zero shipping costs

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -934,16 +934,19 @@ class KleinanzeigenBot(WebScrapingMixin):
                 # try to set special attribute selector (then we have a commercial account)
                 shipping_value = "ja" if ad_cfg["shipping_type"] == "SHIPPING" else "nein"
                 await self.web_select(By.XPATH, special_shipping_selector, shipping_value)
-            elif ad_cfg["shipping_costs"]:
+            else:
                 try:
                     # no options. only costs. Set custom shipping cost
-                    await self.web_click(By.XPATH,
-                                         '//*[contains(@class, "SubSection")]//*//button[contains(@class, "SelectionButton")]')
-                    await self.web_click(By.XPATH, '//*[contains(@class, "CarrierSelectionModal")]//button[contains(text(),"Andere Versandmethoden")]')
-                    await self.web_click(By.XPATH, '//*[contains(@class, "CarrierOption--Main") and contains(@data-testid, "Individueller Versand")]')
-                    await self.web_input(By.CSS_SELECTOR, '.IndividualShippingInput input[type="text"]',
-                                         str.replace(ad_cfg["shipping_costs"], ".", ","))
-                    await self.web_click(By.XPATH, '//*[contains(@class, "ModalDialog--Actions")]//button[.//*[text()[contains(.,"Fertig")]]]')
+                    if not ad_cfg["shipping_costs"] is None:
+                        await self.web_click(By.XPATH,
+                                             '//*[contains(@class, "SubSection")]//*//button[contains(@class, "SelectionButton")]')
+                        await self.web_click(By.XPATH, '//*[contains(@class, "CarrierSelectionModal")]//button[contains(text(),"Andere Versandmethoden")]')
+                        await self.web_click(By.XPATH, '//*[contains(@class, "CarrierOption--Main") and contains(@data-testid, "Individueller Versand")]')
+
+                        if ad_cfg["shipping_costs"]:
+                            await self.web_input(By.CSS_SELECTOR, '.IndividualShippingInput input[type="text"]',
+                                             str.replace(ad_cfg["shipping_costs"], ".", ","))
+                        await self.web_click(By.XPATH, '//*[contains(@class, "ModalDialog--Actions")]//button[.//*[text()[contains(.,"Fertig")]]]')
                 except TimeoutError as ex:
                     LOG.debug(ex, exc_info = True)
                     raise TimeoutError(_("Unable to close shipping dialog!")) from ex


### PR DESCRIPTION
## ℹ️ Description
This PR fixes the shipping costs logic when using zero or none shipping costs and no shipping options are set.

- Link to the related issue(s): Issue #458


## 📋 Changes Summary
- shipping_costs with value 0 lead to use 0,00EUR Versandkosten
- empty shipping_costs lead to default value (three shippers), when no shipping options are selected

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ x] 🐞 Bug fix (non-breaking change which fixes an issue)



## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have run security scans and addressed any identified issues (`pdm run audit`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
