### PR TITLE
fix: CSS selector 'button' not found

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -153,7 +153,7 @@ class AdExtractor(WebScrapingMixin):
             LOG.warning('There are currently no ads on your profile!')
             return []
 
-        n_buttons = len(await self.web_find_all(By.CSS_SELECTOR, 'button',
+        n_buttons = len(await self.web_find_all(By.CSS_SELECTOR, 'em',
                 parent = await self.web_find(By.CSS_SELECTOR, 'div:nth-of-type(1)', parent = pagination)))
         if n_buttons > 1:
             multi_page = True


### PR DESCRIPTION
Element button was changed to em.

## ℹ️ Description
Changing element button to 'em'

- Link to the related issue(s): Issue #475


## 📋 Changes Summary
- now searching for element 'em' to find pagination

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have run security scans and addressed any identified issues (`pdm run audit`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
