### PR TITLE
fix: correct setting custom shipping costs

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -942,7 +942,7 @@ class KleinanzeigenBot(WebScrapingMixin):
                         await self.web_click(By.XPATH,
                                              '//*[contains(@class, "SubSection")]//*//button[contains(@class, "SelectionButton")]')
                         await self.web_click(By.XPATH, '//*[contains(@class, "CarrierSelectionModal")]//button[contains(text(),"Andere Versandmethoden")]')
-                        await self.web_click(By.XPATH, '//*[contains(@class, "CarrierOption--Main") and contains(@data-testid, "Individueller Versand")]')
+                        await self.web_click(By.XPATH, '//*[contains(@id, "INDIVIDUAL") and contains(@data-testid, "Individueller Versand")]')
 
                         if ad_cfg["shipping_costs"]:
                             await self.web_input(By.CSS_SELECTOR, '.IndividualShippingInput input[type="text"]',


### PR DESCRIPTION
## ℹ️ Description
Instead of using XPATH to identify the custom shipping checkbox now using the id of this input.

- Link to the related issue(s): Issue #474 
- Describe the motivation and context for this change.
The site changed structure and the xpath selectors were outdated. This caused the click for the custom shipping checkbox was wrong.

## 📋 Changes Summary

Bullet-point key changes introduced.
- changed click method from XPATh to ID with the propper id of the input element

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have run security scans and addressed any identified issues (`pdm run audit`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
