### PR TITLE
fix: improve login detection with fallback element

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -540,11 +540,18 @@ class KleinanzeigenBot(WebScrapingMixin):
 
     async def is_logged_in(self) -> bool:
         try:
+            # Try to find the standard element first
             user_info = await self.web_text(By.CLASS_NAME, "mr-medium")
             if self.config["login"]["username"].lower() in user_info.lower():
                 return True
         except TimeoutError:
-            return False
+            try:
+                # If standard element not found, try the alternative
+                user_info = await self.web_text(By.ID, "user-email")
+                if self.config["login"]["username"].lower() in user_info.lower():
+                    return True
+            except TimeoutError:
+                return False
         return False
 
     async def delete_ads(self, ad_cfgs:list[tuple[str, dict[str, Any], dict[str, Any]]]) -> None:

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -151,7 +151,7 @@ class TestAdExtractorShipping:
 
     @pytest.mark.asyncio
     # pylint: disable=protected-access
-    async def test_extract_shipping_info_with_all_matching_options(self, test_extractor: AdExtractor) -> None:
+    async def test_extract_shipping_info_with_all_matching_options(self, test_extractor:AdExtractor) -> None:
         """Test shipping info extraction with all matching options enabled."""
         shipping_response = {
             "content": json.dumps({
@@ -185,7 +185,7 @@ class TestAdExtractorShipping:
 
     @pytest.mark.asyncio
     # pylint: disable=protected-access
-    async def test_extract_shipping_info_with_excluded_options(self, test_extractor: AdExtractor) -> None:
+    async def test_extract_shipping_info_with_excluded_options(self, test_extractor:AdExtractor) -> None:
         """Test shipping info extraction with excluded options."""
         shipping_response = {
             "content": json.dumps({
@@ -222,7 +222,7 @@ class TestAdExtractorShipping:
 
     @pytest.mark.asyncio
     # pylint: disable=protected-access
-    async def test_extract_shipping_info_with_excluded_matching_option(self, test_extractor: AdExtractor) -> None:
+    async def test_extract_shipping_info_with_excluded_matching_option(self, test_extractor:AdExtractor) -> None:
         """Test shipping info extraction when the matching option is excluded."""
         shipping_response = {
             "content": json.dumps({

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -325,6 +325,15 @@ class TestKleinanzeigenBotAuthentication:
             assert await configured_bot.is_logged_in() is True
 
     @pytest.mark.asyncio
+    async def test_is_logged_in_returns_true_with_alternative_element(self, configured_bot:KleinanzeigenBot) -> None:
+        """Verify that login check returns true when logged in with alternative element."""
+        with patch.object(configured_bot, "web_text", side_effect = [
+            TimeoutError(),  # First try with mr-medium fails
+            "angemeldet als: testuser"  # Second try with user-email succeeds
+        ]):
+            assert await configured_bot.is_logged_in() is True
+
+    @pytest.mark.asyncio
     async def test_is_logged_in_returns_false_when_not_logged_in(self, configured_bot:KleinanzeigenBot) -> None:
         """Verify that login check returns false when not logged in."""
         with patch.object(configured_bot, "web_text", side_effect = TimeoutError):


### PR DESCRIPTION
## ℹ️ Description
The login detection has been improved by adding a fallback element. This increases the reliability of login detection as two different elements are now checked. If the primary element (`mr-medium`) is not found, an alternative element (`user-email`) is checked.

- Link to the related issue(s): N/A

## 📋 Changes Summary

- Implementation of a fallback check for the `user-email` element when `mr-medium` is not found
- Improvement of login detection reliability through redundant checking
- Addition of a test case for the alternative login element
- No additional dependencies or configuration changes required

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
