### PR TITLE
fix: clearing password input while logging in

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -523,6 +523,7 @@ class KleinanzeigenBot(WebScrapingMixin):
     async def fill_login_data_and_send(self) -> None:
         LOG.info("Logging in as [%s]...", self.config.login.username)
         await self.web_input(By.ID, "email", self.config.login.username)
+        await self.web_input(By.ID, "password", "")
         await self.web_input(By.ID, "password", self.config.login.password)
         await self.web_click(By.CSS_SELECTOR, "form#login-form button[type='submit']")
 

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -523,7 +523,10 @@ class KleinanzeigenBot(WebScrapingMixin):
     async def fill_login_data_and_send(self) -> None:
         LOG.info("Logging in as [%s]...", self.config.login.username)
         await self.web_input(By.ID, "email", self.config.login.username)
+
+        # clearing password input in case browser has stored login data set
         await self.web_input(By.ID, "password", "")
+
         await self.web_input(By.ID, "password", self.config.login.password)
         await self.web_click(By.CSS_SELECTOR, "form#login-form button[type='submit']")
 


### PR DESCRIPTION
## ℹ️ Description
Before the password in the login funtion is send, now an empty string is send to clear an preassigned value from the browser passwordmanager.

- Link to the related issue(s): Issue #530 


## 📋 Changes Summary
- fill_login_data_and_send now send an empty string before the password

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
