### PR TITLE
fix: default image configuration is ignored

### DIFF
--- a/src/kleinanzeigen_bot/model/ad_model.py
+++ b/src/kleinanzeigen_bot/model/ad_model.py
@@ -153,7 +153,7 @@ class AdPartial(ContextualModel):
         """
         Returns a complete, validated Ad by merging this partial with values from ad_defaults.
 
-        Any field that is `None` or `""` is filled from `ad_defaults`.
+        Any field that is `None` or `""` is filled from `ad_defaults` when it's not a list.
 
         Raises `ValidationError` when, after merging with `ad_defaults`, not all fields required by `Ad` are populated.
         """
@@ -162,7 +162,7 @@ class AdPartial(ContextualModel):
             target = ad_cfg,
             defaults = ad_defaults.model_dump(),
             ignore = lambda k, _: k == "description",  # ignore legacy global description config
-            override = lambda _, v: v in {None, ""}  # noqa: PLC1901 can be simplified
+            override = lambda _, v: not isinstance(v, list) and v in {None, ""}  # noqa: PLC1901 can be simplified
         )
         return Ad.model_validate(ad_cfg)
 

--- a/src/kleinanzeigen_bot/model/config_model.py
+++ b/src/kleinanzeigen_bot/model/config_model.py
@@ -36,6 +36,7 @@ class AdDefaults(ContextualModel):
     price_type:Literal["FIXED", "NEGOTIABLE", "GIVE_AWAY", "NOT_APPLICABLE"] = "NEGOTIABLE"
     shipping_type:Literal["PICKUP", "SHIPPING", "NOT_APPLICABLE"] = "SHIPPING"
     sell_directly:bool = Field(default = False, description = "requires shipping_type SHIPPING to take effect")
+    images:List[str] | None = Field(default = None)
     contact:ContactDefaults = Field(default_factory = ContactDefaults)
     republication_interval:int = 7
 


### PR DESCRIPTION
## ℹ️ Description
This PR fixes the publishing with default image configuration. The attribute "images" was ignored in default configuration.

- Link to the related issue(s): Issue #533 

## 📋 Changes Summary

- added attribute "images" to AdDefault class
- refactored function "to_ad" so that list object are ignored since they couldn't be hashed

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
