### PR TITLE
fix: setting location from zipcode

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -744,9 +744,8 @@ class KleinanzeigenBot(WebScrapingMixin):
                     await self.web_sleep(1)  # Wait for city dropdown to populate
                     options = await self.web_find_all(By.CSS_SELECTOR, "#pstad-citychsr option")
                     for option in options:
-                        option_text = await self.web_text(By.CSS_SELECTOR, "option", parent = option)
-                        if option_text == ad_cfg.contact.location:
-                            await self.web_select(By.ID, "pstad-citychsr", option_text)
+                        if option.text == ad_cfg.contact.location:
+                            await self.web_select(By.ID, "pstad-citychsr", option.attrs.value)
                             break
                 except TimeoutError:
                     LOG.debug("Could not set city from location")


### PR DESCRIPTION
## ℹ️ Description
The location according to the zipcode was not set, since the text couldn't be found with web_text method.

- Link to the related issue(s): Issue #545 

## 📋 Changes Summary
- refactored setting location value in city dropdown 

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
