### PR TITLE
fix: setting special attribute when key is art_s

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -855,8 +855,8 @@ class KleinanzeigenBot(WebScrapingMixin):
             "new_with_tag": "Neu mit Etikett",
             "new": "Neu",
             "like_new": "Sehr Gut",
-            "alright": "Gut",
-            "ok": "In Ordnung",
+            "ok": "Gut",
+            "alright": "In Ordnung",
             "defect": "Defekt",
         }
         mapped_condition = condition_mapping.get(condition_value)

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -433,6 +433,14 @@ class TestAdExtractorContent:
                     raw_description,  # Raw description (without affixes)
                     "03.02.2025"  # Creation date
                 ]),
+                web_execute=AsyncMock(return_value={
+                    "universalAnalyticsOpts": {
+                        "dimensions": {
+                            "dimension92": "",
+                            "dimension108": ""
+                        }
+                    }
+                }),
                 _extract_category_from_ad_page = AsyncMock(return_value = "160"),
                 _extract_special_attributes_from_ad_page = AsyncMock(return_value = {}),
                 _extract_pricing_info_from_ad_page = AsyncMock(return_value = (None, "NOT_APPLICABLE")),
@@ -461,6 +469,14 @@ class TestAdExtractorContent:
                 TimeoutError("Timeout"),  # Description times out
                 "03.02.2025"  # Date succeeds
             ]),
+            web_execute=AsyncMock(return_value={
+                "universalAnalyticsOpts": {
+                    "dimensions": {
+                        "dimension92": "",
+                        "dimension108": ""
+                    }
+                }
+            }),
             _extract_category_from_ad_page = AsyncMock(return_value = "160"),
             _extract_special_attributes_from_ad_page = AsyncMock(return_value = {}),
             _extract_pricing_info_from_ad_page = AsyncMock(return_value = (None, "NOT_APPLICABLE")),
@@ -494,6 +510,14 @@ class TestAdExtractorContent:
                 raw_description,  # Description without affixes
                 "03.02.2025"  # Creation date
             ]),
+            web_execute = AsyncMock(return_value = {
+                "universalAnalyticsOpts": {
+                    "dimensions": {
+                        "dimension92": "",
+                        "dimension108": ""
+                    }
+                }
+            }),
             _extract_category_from_ad_page = AsyncMock(return_value = "160"),
             _extract_special_attributes_from_ad_page = AsyncMock(return_value = {}),
             _extract_pricing_info_from_ad_page = AsyncMock(return_value = (None, "NOT_APPLICABLE")),
@@ -575,8 +599,34 @@ class TestAdExtractorCategory:
                     }
                 }
             }
-            result = await extractor._extract_special_attributes_from_ad_page()
+            result = await extractor._extract_special_attributes_from_ad_page(mock_web_execute.return_value)
             assert result == {}
+
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    async def test_extract_special_attributes_not_empty(self, extractor: AdExtractor) -> None:
+        """Test extraction of special attributes when not empty."""
+
+        special_atts = {
+            "universalAnalyticsOpts": {
+                "dimensions": {
+                    "dimension108": "versand_s:t|color_s:creme|groesse_s:68|condition_s:alright|type_s:accessoires|art_s:maedchen"
+                }
+            }
+        }
+        result = await extractor._extract_special_attributes_from_ad_page(special_atts)
+        assert len(result) == 5
+        assert "versand_s" not in result
+        assert "color_s" in result
+        assert result["color_s"] == "creme"
+        assert "groesse_s" in result
+        assert result["groesse_s"] == "68"
+        assert "condition_s" in result
+        assert result["condition_s"] == "alright"
+        assert "type_s" in result
+        assert result["type_s"] == "accessoires"
+        assert "art_s" in result
+        assert result["art_s"] == "maedchen"
 
 
 class TestAdExtractorContact:


### PR DESCRIPTION
## ℹ️ Description
This PR fixes the handling of special attribute "art_s". Generally "art_s" is used for the subcategory, but sometimes it becomes the meaning of an special attribute.  So now the subcategory is taken from the BelenConf dictionary and "art_s" entry dont gets deleted anymore.

Actually the subcategory isn't really necessary, but when given, the appropriate special attribute gets preselected. 

- Link to the related issue(s): Issue #434 


## 📋 Changes Summary

- take subcategory from BelenConf
- removed deletion of "art_s" entry
- fixed condition translation table

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
