### PR TITLE
fix: dimension92 may not be defined in universalAnalyticsOpts

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -287,8 +287,8 @@ class AdExtractor(WebScrapingMixin):
         # append subcategory and change e.g. category "161/172" to "161/172/lautsprecher_kopfhoerer"
         # take subcategory from dimension92 as key 'art_s' sometimes is a special attribute (e.g. gender for clothes)
         # the subcategory isn't really necessary, but when set, the appropriate special attribute gets preselected
-        if belen_conf["universalAnalyticsOpts"]["dimensions"]["dimension92"]:
-            info["category"] += f"/{belen_conf['universalAnalyticsOpts']['dimensions']['dimension92']}"
+        if dimension92 := belen_conf["universalAnalyticsOpts"]["dimensions"].get("dimension92"):
+            info["category"] += f"/{dimension92}"
 
         info["title"] = title
 


### PR DESCRIPTION
## ℹ️ Description

I got an error because the key dimension92 wasn't defined on one of my posts.


## 📋 Changes Summary

do not throw an KeyError when dimension92 is missing


### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [ ] I have formatted the code (`pdm run format`). -> changes stuff which I haven't touched. So I didnt commit these
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
