### PR TITLE
fix(shipping): handle missing .versand_s for service categories like …

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -752,16 +752,18 @@ class KleinanzeigenBot(WebScrapingMixin):
         #############################
         # set shipping type/options/costs
         #############################
-        if ad_cfg.type == "WANTED":
-            # special handling for ads of type WANTED since shipping is a special attribute for these
-            if ad_cfg.shipping_type in {"PICKUP", "SHIPPING"}:
-                shipping_value = "ja" if ad_cfg.shipping_type == "SHIPPING" else "nein"
-                try:
-                    await self.web_select(By.XPATH, "//select[contains(@id, '.versand_s')]", shipping_value)
-                except TimeoutError:
-                    LOG.warning("Failed to set shipping attribute for type '%s'!", ad_cfg.shipping_type)
-        else:
-            await self.__set_shipping(ad_cfg, mode)
+        shipping_type = ad_cfg.shipping_type
+        if shipping_type != "NOT_APPLICABLE":
+            if ad_cfg.type == "WANTED":
+                # special handling for ads of type WANTED since shipping is a special attribute for these
+                if shipping_type in {"PICKUP", "SHIPPING"}:
+                    shipping_value = "ja" if shipping_type == "SHIPPING" else "nein"
+                    try:
+                        await self.web_select(By.XPATH, "//select[contains(@id, '.versand_s')]", shipping_value)
+                    except TimeoutError:
+                        LOG.warning("Failed to set shipping attribute for type '%s'!", shipping_type)
+            else:
+                await self.__set_shipping(ad_cfg, mode)
 
         #############################
         # set price


### PR DESCRIPTION
There are categories which are not require shipping and there is no shipping field

## ℹ️ Description
For example category 297/298 does not require shipping, because its a service category.
The current code did not handle that case and was searching for a path with .versand_s, but in this category, there is no such path.

## 📋 Changes Summary

If the shipping_type is set to NOT_APPLICABLE in the configuration, the shipping assignment step is skipped instead of being forced.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
