### PR TITLE
fix: improve update check logic and UTC log clarity

### DIFF
--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -403,7 +403,7 @@ kleinanzeigen_bot/update_checker.py:
   _get_release_commit:
     "Could not get release commit: %s": "Konnte Release-Commit nicht ermitteln: %s"
   check_for_updates:
-    "A new version is available: %s from %s (current: %s from %s, channel: %s)": "Eine neue Version ist verfügbar: %s vom %s (aktuell: %s vom %s, Kanal: %s)"
+    "A new version is available: %s from %s UTC (current: %s from %s UTC, channel: %s)": "Eine neue Version ist verfügbar: %s vom %s UTC (aktuell: %s vom %s UTC, Kanal: %s)"
     "Could not determine commit dates for comparison.": "Konnte Commit-Daten für den Vergleich nicht ermitteln."
     "Could not determine local commit hash.": "Konnte lokalen Commit-Hash nicht ermitteln."
     "Could not determine local version.": "Konnte lokale Version nicht ermitteln."
@@ -417,8 +417,8 @@ kleinanzeigen_bot/update_checker.py:
     "Latest release from GitHub is a prerelease, but 'latest' channel expects a stable release.": "Die neueste GitHub-Version ist eine Vorabversion, aber der 'latest'-Kanal erwartet eine stabile Version."
     "No prerelease found for 'preview' channel.": "Keine Vorabversion für den 'preview'-Kanal gefunden."
     "Unknown update channel: %s": "Unbekannter Update-Kanal: %s"
-    ? "You are on a different commit than the release for channel '%s' (tag: %s). This may mean you are ahead, behind, or on a different branch. Local commit: %s (%s), Release commit: %s (%s)"
-    : "Sie befinden sich auf einem anderen Commit als das Release für Kanal '%s' (Tag: %s). Dies kann bedeuten, dass Sie voraus, hinterher oder auf einem anderen Branch sind. Lokaler Commit: %s (%s), Release-Commit: %s (%s)"
+    ? "You are on a different commit than the release for channel '%s' (tag: %s). This may mean you are ahead, behind, or on a different branch. Local commit: %s (%s UTC), Release commit: %s (%s UTC)"
+    : "Sie befinden sich auf einem anderen Commit als das Release für Kanal '%s' (Tag: %s). Dies kann bedeuten, dass Sie voraus, hinterher oder auf einem anderen Branch sind. Lokaler Commit: %s (%s UTC), Release-Commit: %s (%s UTC)"
 
 #################################################
 kleinanzeigen_bot/model/update_check_state.py:

--- a/src/kleinanzeigen_bot/update_checker.py
+++ b/src/kleinanzeigen_bot/update_checker.py
@@ -198,16 +198,18 @@ class UpdateChecker:
             return
 
         if local_commit == release_commit:
+            # If the commit hashes are identical, we are on the latest version. Do not proceed to other checks.
             logger.info(
                 "You are on the latest version: %s (compared to %s in channel %s)",
                 local_version,
                 self._get_short_commit_hash(release_commit),
                 self.config.update_check.channel
             )
-        # We cannot reliably determine ahead/behind without git. Use commit dates as a weak heuristic, but clarify in the log.
-        elif local_commit_date < release_commit_date:
+            return
+        # All commit dates are in UTC; append ' UTC' to timestamps in logs for clarity.
+        if local_commit_date < release_commit_date:
             logger.warning(
-                "A new version is available: %s from %s (current: %s from %s, channel: %s)",
+                "A new version is available: %s from %s UTC (current: %s from %s UTC, channel: %s)",
                 self._get_short_commit_hash(release_commit),
                 release_commit_date.strftime("%Y-%m-%d %H:%M:%S"),
                 local_version,
@@ -219,7 +221,7 @@ class UpdateChecker:
         else:
             logger.info(
                 "You are on a different commit than the release for channel '%s' (tag: %s). This may mean you are ahead, behind, or on a different branch. "
-                "Local commit: %s (%s), Release commit: %s (%s)",
+                "Local commit: %s (%s UTC), Release commit: %s (%s UTC)",
                 self.config.update_check.channel,
                 release.get("tag_name", "unknown"),
                 self._get_short_commit_hash(local_commit),

--- a/tests/unit/test_update_checker.py
+++ b/tests/unit/test_update_checker.py
@@ -127,7 +127,7 @@ class TestUpdateChecker:
 
         expected = (
             "You are on a different commit than the release for channel 'latest' (tag: latest). This may mean you are ahead, behind, or on a different branch. "
-            "Local commit: fb00f11 (2025-05-18 00:00:00), Release commit: e7a3d46 (2025-05-16 00:00:00)"
+            "Local commit: fb00f11 (2025-05-18 00:00:00 UTC), Release commit: e7a3d46 (2025-05-16 00:00:00 UTC)"
         )
         assert any(expected in r.getMessage() for r in caplog.records)
 
@@ -163,7 +163,7 @@ class TestUpdateChecker:
         expected = (
             "You are on a different commit than the release for channel 'preview' (tag: preview). "
             "This may mean you are ahead, behind, or on a different branch. "
-            "Local commit: fb00f11 (2025-05-18 00:00:00), Release commit: e7a3d46 (2025-05-16 00:00:00)"
+            "Local commit: fb00f11 (2025-05-18 00:00:00 UTC), Release commit: e7a3d46 (2025-05-16 00:00:00 UTC)"
         )
         assert any(expected in r.getMessage() for r in caplog.records)
 
@@ -195,7 +195,7 @@ class TestUpdateChecker:
         for r in caplog.records:
             print(f"{r.levelname}: {r.getMessage()}")
 
-        expected = "A new version is available: e7a3d46 from 2025-05-18 00:00:00 (current: 2025+fb00f11 from 2025-05-16 00:00:00, channel: latest)"
+        expected = "A new version is available: e7a3d46 from 2025-05-18 00:00:00 UTC (current: 2025+fb00f11 from 2025-05-16 00:00:00 UTC, channel: latest)"
         assert any(expected in r.getMessage() for r in caplog.records)
 
     def test_check_for_updates_same(self, config:Config, mocker:"MockerFixture", caplog:pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## ℹ️ Description
This PR improves the update check logic and log clarity in the update_checker module, and ensures translation completeness for new log messages.

- Link to the related issue(s): _N/A_
- Motivation: The update checker previously logged a misleading message when the local and release commit hashes were identical. Additionally, log timestamps did not explicitly indicate UTC, and translation checks failed due to outdated message keys.

## 📋 Changes Summary

- Fix update check logic: Only log "You are on the latest version" when local and release commit hashes are identical, and return early to avoid misleading logs.
- Add " UTC" to all commit timestamps in update_checker log messages for clarity.
- Update unit tests to expect new log message formats with UTC.
- Update German translations for update_checker log messages to match new formats and remove obsolete entries.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.