### PR TITLE
fix: refactored page ref selector

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -189,7 +189,7 @@ class AdExtractor(WebScrapingMixin):
             # Extract references using the CORRECTED selector
             try:
                 page_refs = [
-                    (await self.web_find(By.CSS_SELECTOR, "div.manageitems-item-ad h3 a.text-onSurface", parent = li)).attrs["href"]
+                    (await self.web_find(By.CSS_SELECTOR, "div h3 a.text-onSurface", parent = li)).attrs["href"]
                     for li in list_items
                 ]
                 refs.extend(page_refs)

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -392,7 +392,7 @@ class TestAdExtractorNavigation:
                 call(By.ID, "my-manageitems-adlist"),
                 call(By.CSS_SELECTOR, ".Pagination", timeout = 10),
                 call(By.ID, "my-manageitems-adlist"),
-                call(By.CSS_SELECTOR, "div.manageitems-item-ad h3 a.text-onSurface", parent = cardbox_mock),
+                call(By.CSS_SELECTOR, "div h3 a.text-onSurface", parent = cardbox_mock),
             ], any_order = False)  # Check order if important
 
             mock_web_find_all.assert_has_calls([


### PR DESCRIPTION
## ℹ️ Description
Due changes in site layout the page ref selector has changed. This PR refactors the selector to adapt the changes.

- Link to the related issue(s): Issue #592

## 📋 Changes Summary

- refactored CSS selector for ad references

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
