### PR TITLE
fix: handle security message during ad update

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -713,7 +713,8 @@ class KleinanzeigenBot(WebScrapingMixin):
             count += 1
 
             await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads, AdUpdateStrategy.REPLACE)
-            await self.web_await(lambda: self.web_check(By.ID, "checking-done", Is.DISPLAYED), timeout = 5 * 60)
+            await self.web_await(lambda: self.web_check(By.ID, "checking-done", Is.DISPLAYED) or
+                                         self.web_check(By.ID, "not-completed", Is.DISPLAYED), timeout=5 * 60)
 
             if self.config.publishing.delete_old_ads == "AFTER_PUBLISH" and not self.keep_old_ads:
                 await self.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = False)


### PR DESCRIPTION
## ℹ️ Description
Sometimes, kleinanzeigen places ads in quarantine before publication to review them. This is confirmed with a special message.
This message is now recognized and treated like the message confirming successful publication.

- Link to the related issue(s): Issue #597 


## 📋 Changes Summary
- added waiting for not-completed message 

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
