### PR TITLE
fix: resolve #612 FileNotFoundError and improve ad download architecture

### DIFF
--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -174,10 +174,6 @@ kleinanzeigen_bot/extract.py:
 #################################################
   download_ad:
     "Created ads directory at ./%s.": "Verzeichnis für Anzeigen erstellt unter ./%s."
-    "Deleting current folder of ad %s...": "Lösche aktuellen Ordner der Anzeige %s..."
-    "New directory for ad created at %s.": "Neues Verzeichnis für Anzeige erstellt unter %s."
-    "Renaming folder from %s to %s for ad %s...": "Benenne Ordner von %s zu %s für Anzeige %s um..."
-    "Using existing folder for ad %s at %s.": "Verwende bestehenden Ordner für Anzeige %s unter %s."
 
   _download_images_from_ad_page:
     "Found %s.": "%s gefunden."
@@ -210,8 +206,12 @@ kleinanzeigen_bot/extract.py:
     "There is no ad under the given ID.": "Es gibt keine Anzeige unter der angegebenen ID."
     "A popup appeared!": "Ein Popup ist erschienen!"
 
-  _extract_ad_page_info:
-    "Extracting information from ad with title \"%s\"": "Extrahiere Informationen aus Anzeige mit Titel \"%s\""
+  _extract_ad_page_info_with_directory_handling:
+    "Extracting title from ad %s: \"%s\"": "Extrahiere Titel aus Anzeige %s: \"%s\""
+    "Deleting current folder of ad %s...": "Lösche aktuellen Ordner der Anzeige %s..."
+    "New directory for ad created at %s.": "Neues Verzeichnis für Anzeige erstellt unter %s."
+    "Renaming folder from %s to %s for ad %s...": "Benenne Ordner von %s zu %s für Anzeige %s um..."
+    "Using existing folder for ad %s at %s.": "Verwende bestehenden Ordner für Anzeige %s unter %s."
 
   _extract_contact_from_ad_page:
     "No street given in the contact.": "Keine Straße in den Kontaktdaten angegeben."


### PR DESCRIPTION
## ℹ️ Description
This PR fixes the FileNotFoundError reported in #612 and refactors the ad download architecture to eliminate redundancy and improve maintainability.

- **Issue**: Fixes #612 - FileNotFoundError when using named folders for ad downloads
- **Root Cause**: The original architecture used complex temporary directory handling that could lead to file system errors
- **Solution**: Complete refactor to single-pass architecture that eliminates the problematic temp folder logic

## 📋 Changes Summary

### Bug Fixes
- **Fixed #612 FileNotFoundError**: Eliminated the complex temporary directory logic that was causing the reported error
- **Fixed datetime formatting**: Changed `created_on` to be set as datetime object instead of string, ensuring proper YAML serialization with quoted timestamps

### Architecture Improvements
- **Eliminated redundant `temp_dir` logic**: Removed the problematic temporary directory handling that was causing the FileNotFoundError
- **Single-pass architecture**: Created `_extract_ad_page_info_with_directory_handling` method that handles directory creation, renaming, and ad extraction in one pass
- **Eliminated duplicate title extraction**: Added `_extract_title_from_ad_page()` method to extract title once and reuse it
- **Simplified `download_ad` method**: Reduced complexity by delegating directory handling to a dedicated helper method

### User Experience Improvements
- **Improved log messages**: Added ad ID to title extraction log message for better traceability
- **Better error handling**: Eliminated race conditions that could occur with the old temp folder approach

### Translation Updates
- **Updated German translations**: Added new translations for the refactored log messages
- **Removed obsolete translations**: Cleaned up translations that are no longer used

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.