### PR TITLE
fix: increase build timeout from 10 to 20 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           PUBLISH_RELEASE: true
 
     runs-on: ${{ matrix.os }} # https://github.com/actions/runner-images#available-images
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
     - name: "Show: GitHub context"


### PR DESCRIPTION
## ℹ️ Description
*Increase GitHub Actions build job timeout to resolve Python 3.14 build failures.*

- Link to the related issue(s): Resolves timeout issues in GitHub Actions runs
- Python 3.14 builds were consistently timing out after 10 minutes due to slower dependency resolution and compilation times compared to Python 3.10

## 📋 Changes Summary

- Increased `timeout-minutes` from 10 to 20 in `.github/workflows/build.yml` (line 90)
- Affects all build matrix combinations using Python 3.14 across all platforms
- Provides adequate buffer for complete build pipeline including dependency installation, linting, testing, and PyInstaller compilation

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.