### PR TITLE
fix: resolve nodriver RemoteObject conversion bug

### DIFF
--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -44,6 +44,7 @@ METACHAR_ESCAPER:Final[dict[int, str]] = str.maketrans({ch: f"\\{ch}" for ch in 
 
 # Constants for RemoteObject handling
 _REMOTE_OBJECT_TYPE_VALUE_PAIR_SIZE:Final[int] = 2
+_KEY_VALUE_PAIR_SIZE:Final[int] = 2
 
 
 def _is_admin() -> bool:
@@ -580,7 +581,7 @@ class WebScrapingMixin:
             return self._convert_remote_object_result(result)
 
         # Fix for nodriver 0.47+ bug: convert list-of-pairs back to dict
-        if isinstance(result, list) and all(isinstance(item, list) and len(item) == 2 for item in result):
+        if isinstance(result, list) and all(isinstance(item, list) and len(item) == _KEY_VALUE_PAIR_SIZE for item in result):
             # This looks like a list of [key, value] pairs that should be a dict
             converted_dict = {}
             for key, value in result:
@@ -638,7 +639,7 @@ class WebScrapingMixin:
             if "type" in data and "value" in data and len(data) == _REMOTE_OBJECT_TYPE_VALUE_PAIR_SIZE:
                 # Extract the actual value and recursively convert it
                 value = data["value"]
-                if isinstance(value, list) and all(isinstance(item, list) and len(item) == 2 for item in value):
+                if isinstance(value, list) and all(isinstance(item, list) and len(item) == _KEY_VALUE_PAIR_SIZE for item in value):
                     # This is a list of [key, value] pairs that should be a dict
                     converted_dict = {}
                     for key, val in value:
@@ -649,7 +650,7 @@ class WebScrapingMixin:
             return {key: self._convert_remote_object_dict(value) for key, value in data.items()}
         if isinstance(data, list):
             # Check if this is a list of [key, value] pairs that should be a dict
-            if all(isinstance(item, list) and len(item) == 2 for item in data):
+            if all(isinstance(item, list) and len(item) == _KEY_VALUE_PAIR_SIZE for item in data):
                 converted_dict = {}
                 for key, value in data:
                     converted_dict[key] = self._convert_remote_object_dict(value)


### PR DESCRIPTION
## ℹ️ Description
*Fixes the nodriver 0.47.0 RemoteObject conversion bug that was causing KeyError and TypeError when accessing BelenConf dimensions.*

- Link to the related issue(s): Issue #650
- The bot was crashing when downloading ads because nodriver 0.47.0 was returning JavaScript objects as lists of [key, value] pairs instead of proper Python dictionaries, causing BelenConf dimensions to be inaccessible.

## 📋 Changes Summary

- **Fixed nodriver RemoteObject conversion bug** in `web_scraping_mixin.py`:
  - Added detection logic for list-of-pairs format in `web_execute` method
  - Enhanced `_convert_remote_object_dict` to recursively convert nested structures
  - Now properly converts JavaScript objects to Python dictionaries
- **Bot functionality fully restored** - can now download ads with subcategories and special attributes

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.