### PR TITLE
fix: condition dialog selector for special attributes

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -993,33 +993,22 @@ class KleinanzeigenBot(WebScrapingMixin):
         LOG.info("############################################")
 
     async def __set_condition(self, condition_value:str) -> None:
-        condition_mapping = {
-            "new_with_tag": "Neu mit Etikett",
-            "new": "Neu",
-            "like_new": "Sehr Gut",
-            "good": "Gut",
-            "ok": "Gut",
-            "alright": "In Ordnung",
-            "defect": "Defekt",
-        }
-        mapped_condition = condition_mapping.get(condition_value)
-
         try:
             # Open condition dialog
-            await self.web_click(By.XPATH, '//*[@id="j-post-listing-frontend-conditions"]//button[contains(@class, "SelectionButton")]')
+            await self.web_click(By.XPATH, '//*[@id="j-post-listing-frontend-conditions"]//button[@aria-haspopup="true"]')
         except TimeoutError:
             LOG.debug("Unable to open condition dialog and select condition [%s]", condition_value, exc_info = True)
             return
 
         try:
             # Click radio button
-            await self.web_click(By.CSS_SELECTOR, f'.SingleSelectionItem--Main input[type=radio][data-testid="{mapped_condition}"]')
+            await self.web_click(By.ID, f"radio-button-{condition_value}")
         except TimeoutError:
             LOG.debug("Unable to select condition [%s]", condition_value, exc_info = True)
 
         try:
             # Click accept button
-            await self.web_click(By.XPATH, '//*[contains(@id, "j-post-listing-frontend-conditions")]//dialog//button[contains(., "Bestätigen")]')
+            await self.web_click(By.XPATH, '//dialog//button[.//span[text()="Bestätigen"]]')
         except TimeoutError as ex:
             raise TimeoutError(_("Unable to close condition dialog!")) from ex
 


### PR DESCRIPTION
## ℹ️ Description
*Provide a concise summary of the changes introduced in this pull request.*

- Link to the related issue(s): Issue #648
- Fix condition dialog selector that was failing to open and select condition values for special attributes during ad publishing.

## 📋 Changes Summary

- Remove unused condition_mapping dictionary that was not needed
- Fix dialog button selector to use aria-haspopup attribute instead of non-existent SelectionButton class
- Fix radio button selection to use ID selector instead of data-testid approach
- Simplify confirm button XPath selector for better reliability

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.