### PR TITLE
chore: harden version helper

### DIFF
--- a/version.py
+++ b/version.py
@@ -3,11 +3,21 @@ SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """
-from datetime import datetime
+import shutil
 import subprocess
+from datetime import datetime, timezone
 
 
 # used in pyproject.toml [tool.pdm.version]
 def get_version() -> str:
-    commit_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode().strip()
-    return f"{datetime.now().year}+{commit_hash}"
+    git = shutil.which("git")
+    if git is None:
+        raise RuntimeError("git executable not found, unable to compute version")
+    result = subprocess.run(  # noqa: S603 running git is safe here
+        [git, "rev-parse", "--short", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    commit_hash = result.stdout.strip()
+    return f"{datetime.now(timezone.utc).year}+{commit_hash}"


### PR DESCRIPTION
## ℹ️ Description
Currently version.py isn't checked by the linters. Ran linters manually and fixed all lints.

- Link to the related issue(s): none

## 📋 Changes Summary

  - Introduced shutil.which("git") so the helper explicitly locates the Git binary and raises a clear error when it’s absent rather than relying on a relative PATH.
  - Switched to subprocess.run(..., capture_output=True, text=True) with the located executable, guarding the call with check=True and # noqa: S603 since the arguments are trusted.
  - Made the timestamp timezone-aware with datetime.now(timezone.utc) to avoid implicit local-time assumptions when creating the YYYY+<commit> version string.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
