### PR TITLE
fix: Handle missing dimension108 in special attributes extraction

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -466,7 +466,9 @@ class AdExtractor(WebScrapingMixin):
         """
 
         # e.g. "art_s:lautsprecher_kopfhoerer|condition_s:like_new|versand_s:t"
-        special_attributes_str = belen_conf["universalAnalyticsOpts"]["dimensions"]["dimension108"]
+        special_attributes_str = belen_conf["universalAnalyticsOpts"]["dimensions"].get("dimension108")
+        if not special_attributes_str:
+            return {}
         special_attributes = dict(item.split(":") for item in special_attributes_str.split("|") if ":" in item)
         special_attributes = {k: v for k, v in special_attributes.items() if not k.endswith(".versand_s") and k != "versand_s"}
         return special_attributes

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -754,6 +754,20 @@ class TestAdExtractorCategory:
         assert "art_s" in result
         assert result["art_s"] == "maedchen"
 
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    async def test_extract_special_attributes_missing_dimension108(self, extractor:AdExtractor) -> None:
+        """Test extraction of special attributes when dimension108 key is missing."""
+        belen_conf:dict[str, Any] = {
+            "universalAnalyticsOpts": {
+                "dimensions": {
+                    # dimension108 key is completely missing
+                }
+            }
+        }
+        result = await extractor._extract_special_attributes_from_ad_page(belen_conf)
+        assert result == {}
+
 
 class TestAdExtractorContact:
     """Tests for contact information extraction."""


### PR DESCRIPTION
## ℹ️ Description

Fixes a `KeyError` that occurred during ad download when the `dimension108` key is missing from the `belen_conf` analytics data structure. 

Related Issue: #705 

- **Issue**: When downloading ads, the code assumed `dimension108` would always be present in the analytics dimensions, causing a crash when it was missing.
- **Root Cause**: Direct dictionary access `["dimension108"]` instead of safe `.get()` method.
- **Solution**: Changed to use `.get("dimension108")` and return an empty dict when the key is missing, which aligns with the function's documented behavior.

## 📋 Changes Summary

- **`src/kleinanzeigen_bot/extract.py`**: 
  - Changed `_extract_special_attributes_from_ad_page()` to use `.get()` for safe key access
  - Added null check to return empty dict when `dimension108` is missing or empty
  - Follows the same pattern used elsewhere in the codebase (line 303)

- **`tests/unit/test_extract.py`**:
  - Added `test_extract_special_attributes_missing_dimension108()` to cover the bug scenario
  - All three code paths now have test coverage:
    - Empty string scenario (existing test)
    - Missing key scenario (new test)
    - Valid data scenario (existing test)

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience by safely handling missing optional analytics attributes, preventing errors when expected data isn't present.

* **Tests**
  * Added a unit test ensuring no attributes are produced when the optional analytics attribute is absent, validating correct behavior in that scenario.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->