### PR TITLE
fix: Resolve publish-release workflow push rejection

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,5 +50,9 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+        # Fetch and merge remote release branch before pushing
+        git fetch origin release || true
+        git merge origin/release --no-edit || true
+
         # Push current main state to release branch to trigger release creation
         git push origin HEAD:release


### PR DESCRIPTION
## ℹ️ Description

This PR fixes the `publish-release` workflow failure caused by git push rejection when the remote `release` branch contains commits not present locally.

**Error encountered:**
```
! [rejected]        HEAD -> release (fetch first)
error: failed to push some refs
hint: Updates were rejected because the remote contains work that you do not have locally.
```

## 📋 Changes Summary

- Added `git fetch origin release || true` to fetch the remote release branch before pushing
- Added `git merge origin/release --no-edit || true` to integrate remote changes
- Used `|| true` to handle cases where the release branch doesn't exist yet (first run)
- Preserves history instead of using force-push approach

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.