### PR TITLE
feat: Add Chrome 136+ safe defaults for browser configuration

### DIFF
--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -152,7 +152,7 @@
               "type": "null"
             }
           ],
-          "default": null,
+          "default": ".temp/browser-profile",
           "description": "See https://github.com/chromium/chromium/blob/main/docs/user_data_dir.md",
           "title": "User Data Dir"
         },

--- a/src/kleinanzeigen_bot/model/config_model.py
+++ b/src/kleinanzeigen_bot/model/config_model.py
@@ -80,7 +80,7 @@ class DownloadConfig(ContextualModel):
 
 class BrowserConfig(ContextualModel):
     arguments:List[str] = Field(
-        default_factory = list,
+        default_factory = lambda: ["--user-data-dir=.temp/browser-profile"],
         description = "See https://peter.sh/experiments/chromium-command-line-switches/"
     )
     binary_location:str | None = Field(
@@ -93,7 +93,7 @@ class BrowserConfig(ContextualModel):
     )
     use_private_window:bool = True
     user_data_dir:str | None = Field(
-        default = None,
+        default = ".temp/browser-profile",
         description = "See https://github.com/chromium/chromium/blob/main/docs/user_data_dir.md"
     )
     profile_name:str | None = None


### PR DESCRIPTION
## ℹ️ Description

This PR updates the default browser configuration to be safe for Chrome/Chromium 136+ out of the box.

Chrome 136+ (released March 2025) requires `--user-data-dir` to be specified when using `--remote-debugging-port` for security reasons. Since nodriver relies on remote debugging, the bot needs proper defaults to avoid validation errors.

**Motivation:** Eliminate Chrome 136+ configuration validation errors for fresh installations and ensure session persistence by default.

## 📋 Changes Summary

- Set `browser.arguments` default to include `--user-data-dir=.temp/browser-profile`
- Set `browser.user_data_dir` default to `.temp/browser-profile` (previously `None`)
- Regenerated JSON schema (`config.schema.json`) with new defaults

**Benefits:**
- ✅ Chrome 136+ compatible out of the box (no validation errors)
- ✅ Browser session/cookies persist across runs (better UX)
- ✅ Consistent with existing `.temp` directory pattern (update state, caches)
- ✅ Already gitignored - no accidental commits of browser profiles

**No breaking changes:** Existing configs with explicit `browser.arguments: []` continue to work (users can override defaults).

### ⚙️ Type of Change
- [x] ✨ New feature (adds new functionality without breaking existing usage)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized browser profile configuration with improved default user data directory settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->