### PR TITLE
fix: handle Unicode normalization in save_dict for umlauts (#728)

### DIFF
--- a/src/kleinanzeigen_bot/utils/dicts.py
+++ b/src/kleinanzeigen_bot/utils/dicts.py
@@ -112,8 +112,9 @@ def load_dict_from_module(module:ModuleType, filename:str, content_label:str = "
 
 
 def save_dict(filepath:str | Path, content:dict[str, Any], *, header:str | None = None) -> None:
-    # Normalize path to NFC to match sanitize_folder_name() behavior (issue #728)
-    # This ensures consistency across platforms with different Unicode normalization (macOS HFS+, Linux, Nextcloud)
+    # Normalize filepath to NFC for cross-platform consistency (issue #728)
+    # Ensures file paths match NFC-normalized directory names from sanitize_folder_name()
+    # Also handles edge cases where paths don't originate from sanitize_folder_name()
     filepath = Path(unicodedata.normalize("NFC", str(filepath)))
 
     # Create parent directory if needed

--- a/src/kleinanzeigen_bot/utils/misc.py
+++ b/src/kleinanzeigen_bot/utils/misc.py
@@ -289,8 +289,12 @@ def sanitize_folder_name(name:str, max_length:int = 100) -> str:
     if not raw:
         return "untitled"
 
-    raw = unicodedata.normalize("NFC", raw)
+    # Apply sanitization, then normalize to NFC
+    # Note: sanitize-filename converts to NFD, so we must normalize AFTER sanitizing
+    # to ensure consistent NFC encoding across platforms (macOS HFS+, Linux, Windows)
+    # This prevents path mismatches when saving files to sanitized directories (issue #728)
     safe:str = sanitize(raw)
+    safe = unicodedata.normalize("NFC", safe)
 
     # Truncate with word-boundary preference
     if len(safe) > max_length:

--- a/tests/unit/test_dicts.py
+++ b/tests/unit/test_dicts.py
@@ -7,11 +7,12 @@ from pathlib import Path
 
 
 def test_save_dict_normalizes_unicode_paths(tmp_path:Path) -> None:
-    """Test that save_dict normalizes paths to NFC, preventing duplicate directories (issue #728).
+    """Test that save_dict normalizes paths to NFC for cross-platform consistency (issue #728).
 
-    When a directory is created with NFC normalization (e.g., "ä" as single character),
-    but save_dict is called with an NFD path (e.g., "ä" as "a" + combining diacritic),
-    it should normalize to NFC and use the existing directory instead of creating a duplicate.
+    Directories are created with NFC normalization (via sanitize_folder_name).
+    This test verifies save_dict's defensive normalization handles edge cases where
+    an NFD path is passed (e.g., "ä" as "a" + combining diacritic vs single character).
+    It should normalize to NFC and use the existing NFC directory.
     """
     from kleinanzeigen_bot.utils import dicts  # noqa: PLC0415
 

--- a/tests/unit/test_utils_misc.py
+++ b/tests/unit/test_utils_misc.py
@@ -144,9 +144,9 @@ def test_ensure_non_callable_truthy_and_falsy() -> None:
         # Basic sanitization
         ("My Ad Title!", "My Ad Title!", "Basic sanitization"),
 
-        # Unicode normalization (sanitize-filename changes normalization)
-        ("café", "cafe\u0301", "Unicode normalization"),
-        ("caf\u00e9", "cafe\u0301", "Unicode normalization from escaped"),
+        # Unicode normalization - sanitize-filename converts to NFD, then we normalize to NFC (issue #728)
+        ("café", "café", "Unicode NFC → NFD (by sanitize) → NFC (by normalize)"),
+        ("caf\u00e9", "café", "Unicode NFC (escaped) → NFD → NFC"),
 
         # Edge cases
         ("", "untitled", "Empty string"),


### PR DESCRIPTION
## ℹ️ Description
Fix FileNotFoundError when downloading ads with German umlauts (ä, ö, ü) in titles on Linux/Windows filesystems due to Unicode normalization mismatches.

- Link to the related issue(s): Fixes #728
- This addresses a specific Unicode normalization bug that is different from the general filesystem sync issue fixed in #692. The user confirmed that replacing umlauts (ä → ae, ö → oe, ü → ue) makes the issue disappear, indicating a Unicode-specific problem.

## 📋 Changes Summary

**Root Cause:**
- The `sanitize-filename` library converts NFC to NFD Unicode normalization
- `sanitize_folder_name()` was normalizing to NFC BEFORE calling `sanitize()`, which was immediately undone
- Directories were created with NFD encoding on Linux/Windows
- The original fix only normalized in `save_dict()`, creating a path mismatch
- macOS auto-normalizes to NFD, masking the bug completely

**Example:**
- NFC: "ä" = single character (U+00E4, bytes: `\xc3\xa4`)
- NFD: "ä" = "a" + combining diaeresis (U+0061 U+0308, bytes: `a\xcc\x88`)

**Solution:**
- Modified `sanitize_folder_name()` in `src/kleinanzeigen_bot/utils/misc.py` to normalize to NFC AFTER calling `sanitize()`
- This ensures directories are created with NFC-normalized names
- Kept NFC normalization in `save_dict()` as defensive programming for edge cases
- Both functions now produce consistent NFC encoding across all platforms

**Testing:**
- Added `test_download_ad_with_umlauts_in_title()` for end-to-end testing with umlaut-containing titles
- Added `test_save_dict_normalizes_unicode_paths()` to verify NFC normalization in save_dict
- Updated `test_sanitize_folder_name_basic()` to expect NFC output instead of NFD
- All tests use the exact title from the bug report: "KitchenAid Zuhälter - nie benutzt"
- Tests verify no FileNotFoundError occurs and paths match correctly

### ⚙️ Type of Change
- [X] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
- [X] I have reviewed my changes to ensure they meet the project's standards.
- [X] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [X] I have formatted the code (`pdm run format`).
- [X] I have verified that linting passes (`pdm run lint`).
- [X] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure parent directories are created and file paths are Unicode-normalized (NFC) before saving to prevent failures or duplicate files when titles/paths contain special characters (e.g., German umlauts).

* **Behavioral Change**
  * Folder-name sanitization now applies normalization after sanitization to produce consistent NFC-safe directory names.

* **Tests**
  * Added unit tests validating directory creation and NFC/NFD normalization handling when saving ad data; note: a duplicate test entry was added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->