### PR TITLE
ci: fix generate-notes for moving latest/preview releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -448,7 +448,6 @@ jobs:
 
 
     - name: "Generate release notes"
-      id: release_notes
       if: steps.release.outputs.name && steps.release.outputs.name != ''
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -489,6 +488,8 @@ jobs:
         }
         trap cleanup EXIT
 
+        # Even with `fetch-depth: 0`, the previous channel release commit might not be part of the
+        # current branch's history (e.g. history rewrites / force-pushes). Fetch it explicitly if needed.
         if ! git cat-file -e "${PREVIOUS_RELEASE_SHA}^{commit}" 2>/dev/null; then
           git fetch --no-tags origin "${PREVIOUS_RELEASE_SHA}"
         fi


### PR DESCRIPTION
## ℹ️ Description
- Link to the related issue(s): n/a
- Fix empty release notes when updating the moving `latest`/`preview` releases by anchoring GitHub `generate-notes` to the previous channel release commit.

## 📋 Changes Summary
- Fetch full git history in the release job (`fetch-depth: 0`).
- Create a temporary tag pointing at the previous channel release commit, use it as `previous_tag_name` for `releases/generate-notes`, and delete it afterwards.
- Fail fast if `generate-notes` returns an empty body (no fallback).

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [ ] I have formatted the code (`pdm run format`).
- [ ] I have verified that linting passes (`pdm run lint`).
- [ ] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release notes generation: fetch full git history, stricter error handling, and validation to ensure non-empty notes.
  * Introduced anchored previous-release flow that creates, uses, and reliably cleans up a temporary tag for consistent diffs.
  * Switched to the GitHub release-notes API with guard rails and appended legal notice.
  * Applied the same robust flow to both build and publish-release workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->