### PR TITLE
fix: avoid mixed returns in pydantics

### DIFF
--- a/src/kleinanzeigen_bot/utils/pydantics.py
+++ b/src/kleinanzeigen_bot/utils/pydantics.py
@@ -202,4 +202,6 @@ def __get_message_template(error_code:str) -> str | None:
                 "Input should be a valid complex string following the rules at "
                 "https://docs.python.org/3/library/functions.html#complex"
             )
-        case _: return None
+        case _:
+            pass
+    return None


### PR DESCRIPTION
## ℹ️ Description
Fix remaining CodeQL mixed-returns warning in pydantics error message mapping.

- Link to the related issue(s): Issue #
- Motivation/context: eliminate implicit return path to satisfy CodeQL `py/mixed-returns` on `pydantics.__get_message_template`.

## 📋 Changes Summary
- Make the default `case _:` fall through and return `None` explicitly at function end.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor code style adjustment with no functional impact on application behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->