### PR TITLE
fix: eliminate duplicate auto price reduction wrapper methods

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -715,18 +715,6 @@ class KleinanzeigenBot(WebScrapingMixin):
     def load_ad(self, ad_cfg_orig:dict[str, Any]) -> Ad:
         return AdPartial.model_validate(ad_cfg_orig).to_ad(self.config.ad_defaults)
 
-    def __apply_auto_price_reduction(self, ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_relative:str) -> None:
-        """Delegate to the module-level function."""
-        apply_auto_price_reduction(ad_cfg, _ad_cfg_orig, ad_file_relative)
-
-    def __repost_cycle_ready(self, ad_cfg:Ad, ad_file_relative:str) -> bool:
-        """Delegate to the module-level function."""
-        return _repost_cycle_ready(ad_cfg, ad_file_relative)
-
-    def __day_delay_elapsed(self, ad_cfg:Ad, ad_file_relative:str) -> bool:
-        """Delegate to the module-level function."""
-        return _day_delay_elapsed(ad_cfg, ad_file_relative)
-
     async def check_and_wait_for_captcha(self, *, is_login_page:bool = True) -> None:
         try:
             captcha_timeout = self._timeout("captcha_detection")
@@ -941,7 +929,7 @@ class KleinanzeigenBot(WebScrapingMixin):
             except ValueError:
                 # On Windows, relative_to fails when paths are on different drives
                 ad_file_relative = ad_file
-            self.__apply_auto_price_reduction(ad_cfg, ad_cfg_orig, ad_file_relative)
+            apply_auto_price_reduction(ad_cfg, ad_cfg_orig, ad_file_relative)
 
             LOG.info("Publishing ad '%s'...", ad_cfg.title)
             await self.web_open(f"{self.root_url}/p-anzeige-aufgeben-schritt2.html")

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1112,7 +1112,7 @@ class TestKleinanzeigenBotShippingOptions:
 
         # Mock Path to use PureWindowsPath for testing cross-drive behavior
         with patch("kleinanzeigen_bot.Path", PureWindowsPath), \
-                patch.object(test_bot, "_KleinanzeigenBot__apply_auto_price_reduction", side_effect = mock_apply_auto_price_reduction), \
+                patch("kleinanzeigen_bot.apply_auto_price_reduction", side_effect = mock_apply_auto_price_reduction), \
                 patch.object(test_bot, "web_open", new_callable = AsyncMock), \
                 patch.object(test_bot, "delete_ad", new_callable = AsyncMock):
             # Call publish_ad and expect sentinel exception
@@ -1156,7 +1156,7 @@ class TestKleinanzeigenBotShippingOptions:
         ad_cfg_orig = ad_cfg.model_dump()
 
         # Mock the private __apply_auto_price_reduction method
-        with patch.object(test_bot, "_KleinanzeigenBot__apply_auto_price_reduction") as mock_apply:
+        with patch("kleinanzeigen_bot.apply_auto_price_reduction") as mock_apply:
             # Mock other dependencies
             mock_response = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}
             with patch.object(test_bot, "web_find", new_callable = AsyncMock), \


### PR DESCRIPTION
## ℹ️ Description

Eliminates duplicate wrapper methods for auto price reduction functionality

- **Motivation**: Remove unnecessary indirection and code duplication in auto price reduction logic
- **Context**: The class methods `__apply_auto_price_reduction()`, `__repost_cycle_ready()`, and `__day_delay_elapsed()` were merely delegating to module-level functions, creating maintenance overhead

## 📋 Changes Summary

- **Removed** 3 duplicate wrapper methods from `KleinanzeigenBot` class (lines 718-728 in `__init__.py`)
- **Updated** method call in `publish_ad()` to use module-level function directly (line 933)
- **Modified** tests to mock module-level functions instead of private methods
- **Maintained** all existing functionality and test coverage

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
Before requesting a review, confirm the following:

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal code structure with no changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->