### PR TITLE
fix: restore build push triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:  # https://docs.github.com/en/actions/reference/workflows-and-actions/events
     # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
     - cron: '0 15 1 * *'
   push:
+    branches: ['**']  # build all branches
     tags-ignore: ['**'] # don't build tags
     paths-ignore:
     - '**/*.md'


### PR DESCRIPTION
## ℹ️ Description
Restore the Build workflow push trigger to ensure merges to `main` and `release` create preview/latest releases again.

- Link to the related issue(s): Issue #
- Describe the motivation and context for this change.
The Build workflow no longer triggered on push after the 2025-12-28 change that removed `push.branches`. This re-enables push runs so release creation resumes after merges and when the Publish Release workflow pushes to `release`.

## 📋 Changes Summary
- Re-add `push.branches: ['**']` in `.github/workflows/build.yml` to restore push-triggered builds.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [ ] I have formatted the code (`pdm run format`).
- [ ] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to trigger builds automatically on all branches by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->