### PR TITLE
fix: set category before title to prevent form field reset

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -945,14 +945,14 @@ class KleinanzeigenBot(WebScrapingMixin):
             await self.web_click(By.ID, "adType2")
 
         #############################
+        # set category (before title to avoid form reset clearing title)
+        #############################
+        await self.__set_category(ad_cfg.category, ad_file)
+
+        #############################
         # set title
         #############################
         await self.web_input(By.ID, "postad-title", ad_cfg.title)
-
-        #############################
-        # set category
-        #############################
-        await self.__set_category(ad_cfg.category, ad_file)
 
         #############################
         # set special attributes


### PR DESCRIPTION
## Problem

When publishing ads, the title field gets intermittently cleared because category selection navigates to a new URL which can reset form fields.

## Root Cause

In `src/kleinanzeigen_bot/__init__.py`, title is set BEFORE category:

```python
await self.web_input(By.ID, "postad-title", ad_cfg.title)  # Line 950
await self.__set_category(ad_cfg.category, ad_file)        # Line 955
```

The `__set_category` method navigates to:
```
https://www.kleinanzeigen.de/p-kategorie-aendern.html#?path=<category>
```

This URL navigation can reset form fields, clearing the title that was just set.

## Solution

Swap the order - set category BEFORE title:

```python
await self.__set_category(ad_cfg.category, ad_file)        # Category first
await self.web_input(By.ID, "postad-title", ad_cfg.title)  # Then title
```

## Validation

Tested and validated:
- Before fix: Title field cleared intermittently after category selection
- After fix: Title with numbers "Test Titel Mit Nummer 1234 In Der Mitte" published successfully
- Numbers in title are NOT the issue - the race condition due to order was the problem

## Testing Steps

1. Create an ad with a title containing numbers
2. Verify the ad publishes successfully without title being cleared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the ad title could be cleared when selecting a category during ad publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->