### PR TITLE
fix: don't pass extra to BaseModel.model_validate

### DIFF
--- a/src/kleinanzeigen_bot/utils/pydantics.py
+++ b/src/kleinanzeigen_bot/utils/pydantics.py
@@ -37,6 +37,7 @@ class ContextualModel(BaseModel):
         is accepted for backward-compatibility but ignored.
         """
         try:
+            _ = extra  # kept for backward-compatibility; intentionally ignored
             return super().model_validate(
                 obj,
                 strict = strict,


### PR DESCRIPTION
## ℹ️ Description

  Fixes a crash when loading configs on Pydantic v2 by not forwarding the unsupported call-time argument extra to
  BaseModel.model_validate().

  - Link to the related issue(s): Issue #
  - Motivation/context: After a git reset (and with Pydantic 2.x), running pdm run app publish / config loading fails
    with TypeError: BaseModel.model_validate() got an unexpected keyword argument 'extra'. The wrapper
    ContextualModel.model_validate() accepted extra and forwarded it, which is not supported in Pydantic v2. This PR
    keeps the argument for compatibility but ignores it and documents the behavior.

  ## Changes Summary

  - Stop passing extra=... from ContextualModel.model_validate() to BaseModel.model_validate().
  - Add a short note in the docstring explaining that call-time extra is ignored on Pydantic v2.
  - No dependency/config changes.

  ### ⚙️ Type of Change

  - [x]  Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (adds new functionality without breaking existing usage)
  - [ ]  Breaking change (changes that might break existing user setups, scripts, or configurations)

  ## ✅ Checklist

  - [x] I have reviewed my changes to ensure they meet the project's standards.
  - [ ] I have tested my changes and ensured that all tests pass  (pdm run test). (not run)
  - [ ] I have formatted the code (pdm run format). (not run)
  - [ ] I have verified that linting passes (pdm run lint). (not run)
  - [ ] I have updated documentation where necessary. (not needed)

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under
  the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified behavior for parameter handling with Pydantic v2, noting the parameter is accepted for compatibility but ignored.
* **Bug Fixes**
  * Preserved backward-compatible method signature while ensuring the ignored parameter no longer affects validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->