### PR TITLE
fix: raise pydantic version for compatibility

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:2786f3461151a94a8f76ed4ca2b2f3d8d7242d0004e17f1e1ae326b0d6529acd"
+content_hash = "sha256:625042f20b8f0bdacfb3e24224fdc76a7495e48ddbc62100a5a091ad5c7017de"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "colorama",
   "jaraco.text", # required by pkg_resources during runtime
   "nodriver==0.47.*", # Pin to 0.47 until upstream fixes UTF-8 decoding issues introduced in 0.48
-  "pydantic>=2.0.0",
+  "pydantic>=2.11.0",
   "ruamel.yaml",
   "psutil",
   "wcmatch",


### PR DESCRIPTION
## ℹ️ Description
Raise Pydantic version cause we use features that require at least v2.11.

- Link to the related issue(s): PR #772

## 📋 Changes Summary

- Set min version to v2.11

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to improve compatibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->