### PR TITLE
ci: Enable manual workflow dispatch for PR binary artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,7 +248,7 @@ jobs:
 
     - name: Upload self-contained executable
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      if: (github.ref_name == 'main' || github.ref_name == 'release') && matrix.PUBLISH_RELEASE && !env.ACT
+      if: ((github.ref_name == 'main' || github.ref_name == 'release') && matrix.PUBLISH_RELEASE || github.event_name == 'workflow_dispatch') && !env.ACT
       with:
         name: artifacts-${{ matrix.os }}
         path: dist/kleinanzeigen-bot*


### PR DESCRIPTION
## ℹ️ Description

This PR enables manual triggering of the build workflow from any PR branch to generate platform-specific executables (Windows .exe, macOS, Linux binaries). 

**Motivation:** Windows users often need pre-built executables to test PRs without setting up a development environment. Currently, binaries are only generated for `main` and `release` branches. This change allows maintainers to manually trigger artifact generation for any PR when needed for testing.

## 📋 Changes Summary

- Modified `.github/workflows/build.yml` artifact upload condition to include `workflow_dispatch` event
- The `workflow_dispatch` trigger already existed but was gated at the artifact upload step
- All 8 platform/Python version matrix combinations now produce artifacts when manually triggered
- The `publish-release` job remains unchanged and only runs for `main`/`release` branches

**How to use:** Go to Actions → "Build" workflow → "Run workflow" → select the PR branch

### ⚙️ Type of Change
- [x] ✨ New feature (adds new functionality without breaking existing usage)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass.
- [x] I have verified that linting passes.
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to support manual deployment triggers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->