### PR TITLE
feat: preview auto price reduction decisions in verify command

### DIFF
--- a/docs/AD_CONFIGURATION.md
+++ b/docs/AD_CONFIGURATION.md
@@ -111,9 +111,9 @@ When `auto_price_reduction.enabled` is set to `true`, the bot lowers the configu
 
 **Note:** `repost_count` and price reduction counters are only incremented and persisted after a successful publish. Failed publish attempts do not advance the counters.
 
-When automatic price reduction is enabled, each `publish` run logs a concise decision line that states whether the reduction was applied or skipped and why (repost delay/day delay), including the earliest next eligible reduction condition.
+When automatic price reduction is enabled, each `publish` run logs one clear INFO message per ad summarizing the outcome—whether the price was reduced, kept, or the reduction was delayed (and why). The `verify` command also previews these outcomes for all configured ads so you can validate your pricing configuration without triggering a publish cycle. Ads without `auto_price_reduction` configured are silently skipped at default log level.
 
-If you run with `-v` / `--verbose`, the bot additionally logs the full cycle-by-cycle calculation trace (base price, reduction value, rounded step result, and floor clamp).
+If you run with `-v` / `--verbose`, the bot additionally logs structured decision details (repost counts, cycle state, day delay, reference timestamps) and the full cycle-by-cycle calculation trace (base price, reduction value, rounded step result, and floor clamp).
 
 ```yaml
 auto_price_reduction:
@@ -323,7 +323,7 @@ republication_interval: 7
 ## Troubleshooting
 
 - **Schema validation errors**: Run `kleinanzeigen-bot verify` (binary) or `pdm run app verify` (source) to see which fields fail validation.
-- **Price reduction not applying**: Confirm `auto_price_reduction.enabled` is `true`, `min_price` is set, and you are using `publish` (not `update`). Remember ad-level values override `ad_defaults`.
+- **Price reduction not applying**: Confirm `auto_price_reduction.enabled` is `true`, `min_price` is set, and you are using `publish` (not `update`). Run `kleinanzeigen-bot verify` to preview outcomes, or add `-v` for detailed decision data including repost/day-delay state. Remember ad-level values override `ad_defaults`.
 - **Shipping configuration issues**: Use `shipping_type: SHIPPING` when setting `shipping_costs` or `shipping_options`, and pick options from a single size group (S/M/L).
 - **Category not found**: Verify the category name or ID and check any custom mappings in `config.yaml`.
 - **File naming/prefix mismatch**: Ensure ad files match your `ad_files` glob and prefix (default `ad_`).

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -75,7 +75,7 @@ def _repost_cycle_ready(
         return False
 
     if eligible_cycles <= applied_cycles:
-        LOG.debug(
+        LOG.info(
             "Auto price reduction already applied for [%s]: %s reductions match %s eligible reposts", ad_file_relative, applied_cycles, eligible_cycles
         )
         return False
@@ -170,6 +170,7 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
     :param ad_file_relative: Relative path to the ad file for logging
     """
     if not ad_cfg.auto_price_reduction.enabled:
+        LOG.debug("Auto price reduction: not configured for [%s]", ad_file_relative)
         return
 
     base_price = ad_cfg.price
@@ -191,7 +192,7 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
 
     if not _repost_cycle_ready(ad_cfg, ad_file_relative, repost_state = repost_state):
         next_repost = delay_reposts + 1 if total_reposts <= delay_reposts else delay_reposts + applied_cycles + 1
-        LOG.info(
+        LOG.debug(
             "Auto price reduction decision for [%s]: skipped (repost delay). next reduction earliest at repost >= %s and day delay %s/%s days."
             " repost_count=%s eligible_cycles=%s applied_cycles=%s reference=%s",
             ad_file_relative,
@@ -206,7 +207,7 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
         return
 
     if not _day_delay_elapsed(ad_cfg, ad_file_relative, day_delay_state = day_delay_state):
-        LOG.info(
+        LOG.debug(
             "Auto price reduction decision for [%s]: skipped (day delay). next reduction earliest when elapsed_days >= %s."
             " elapsed_days=%s repost_count=%s eligible_cycles=%s applied_cycles=%s reference=%s",
             ad_file_relative,
@@ -219,7 +220,7 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
         )
         return
 
-    LOG.info(
+    LOG.debug(
         "Auto price reduction decision for [%s]: applying now (eligible_cycles=%s, applied_cycles=%s, elapsed_days=%s/%s).",
         ad_file_relative,
         eligible_cycles,

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -165,11 +165,6 @@ kleinanzeigen_bot/__init__.py:
   apply_auto_price_reduction:
     "Auto price reduction is enabled for [%s] but no price is configured.": "Automatische Preisreduzierung ist für [%s] aktiviert, aber es wurde kein Preis konfiguriert."
     "Auto price reduction is enabled for [%s] but min_price equals price (%s) - no reductions will occur.": "Automatische Preisreduzierung ist für [%s] aktiviert, aber min_price entspricht dem Preis (%s) - es werden keine Reduktionen auftreten."
-    ? "Auto price reduction decision for [%s]: skipped (repost delay). next reduction earliest at repost >= %s and day delay %s/%s days. repost_count=%s eligible_cycles=%s applied_cycles=%s reference=%s"
-    : "Entscheidung automatische Preisreduzierung für [%s]: übersprungen (Repost-Verzögerung). Nächste Reduktion frühestens bei Repost >= %s und Tagesverzögerung %s/%s Tage. repost_count=%s eligible_cycles=%s applied_cycles=%s reference=%s"
-    ? "Auto price reduction decision for [%s]: skipped (day delay). next reduction earliest when elapsed_days >= %s. elapsed_days=%s repost_count=%s eligible_cycles=%s applied_cycles=%s reference=%s"
-    : "Entscheidung automatische Preisreduzierung für [%s]: übersprungen (Tagesverzögerung). Nächste Reduktion frühestens bei elapsed_days >= %s. elapsed_days=%s repost_count=%s eligible_cycles=%s applied_cycles=%s reference=%s"
-    "Auto price reduction decision for [%s]: applying now (eligible_cycles=%s, applied_cycles=%s, elapsed_days=%s/%s).": "Entscheidung automatische Preisreduzierung für [%s]: wird jetzt angewendet (eligible_cycles=%s, applied_cycles=%s, elapsed_days=%s/%s)."
     "Auto price reduction applied: %s -> %s after %s reduction cycles": "Automatische Preisreduzierung angewendet: %s -> %s nach %s Reduktionszyklen"
     "Auto price reduction kept price %s after attempting %s reduction cycles": "Automatische Preisreduzierung hat Preis %s beibehalten nach dem Versuch von %s Reduktionszyklen"
   _repost_cycle_ready:

--- a/tests/smoke/test_smoke_health.py
+++ b/tests/smoke/test_smoke_health.py
@@ -273,4 +273,4 @@ def test_verify_shows_auto_price_reduction_decisions(tmp_path:Path, test_bot_con
     assert result.returncode == 0
     out = (result.stdout + "\n" + result.stderr).lower()
     assert "no configuration errors found" in out, f"Expected 'no configuration errors found' in output.\n{out}"
-    assert "auto price reduction decision for" in out, f"Expected auto price reduction decision log in output.\n{out}"
+    assert "auto price reduction applied" in out, f"Expected auto price reduction applied log in output.\n{out}"

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -275,7 +275,7 @@ def test_apply_auto_price_reduction_respects_repost_delay(caplog:pytest.LogCaptu
 
     ad_orig:dict[str, Any] = {}
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.DEBUG):
         apply_auto_price_reduction(ad_cfg, ad_orig, "ad_delay.yaml")
 
     assert ad_cfg.price == 200


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Discussion #824
- Users had no way to preview auto price reduction decisions without triggering a full publish cycle. The `verify` command now loads all ads (including already-published ones) and runs `apply_auto_price_reduction()` to show pricing decisions — purely in-memory, no side effects.

## 📋 Changes Summary

- **`verify` command now loads all ads** (`ads_selector = "all"`, `exclude_ads_with_id=False`) and calls `apply_auto_price_reduction()` for each, outputting decision/trace logs
- **Added `-> LOADED:` log line** for included ads in `load_ads()`, matching the existing `-> SKIPPED:` pattern so every discovered ad gets explicit feedback
- **Extracted `_relative_ad_path()` helper** to deduplicate the relative path computation between `verify` and `publish_ad()`
- **Added German translation** for the new `-> LOADED:` message
- **Added smoke test** `test_verify_shows_auto_price_reduction_decisions` that creates an ad with `auto_price_reduction` enabled and asserts decision logs appear in verify output

Sample output:
```bash
[INFO] Auto price reduction delayed for [data/my_ads/1 Test/xxx.yaml]: waiting 1 more reposts (completed 0, applied 0 reductions)
[INFO] Auto price reduction decision for [data/my_ads/1 Test/xxx.yaml]: skipped (repost delay). next reduction earliest at repost >= 1 and day delay 0/0 days. repost_count=0 eligible_cycles=0 applied_cycles=0 reference=missing
```

### ⚙️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized automatic price-reduction behavior across verify, publish, and update flows for consistent results.
  * Enhanced logging to show per-ad paths and clear INFO messages indicating whether each ad’s price was reduced, kept, or delayed (with reasons).

* **Documentation**
  * Expanded configuration docs to describe previewing outcomes with verify and how to view detailed decision data with verbose output.

* **Tests**
  * Added a smoke test to validate auto-price-reduction decisions; adjusted unit test logging verbosity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->