### PR TITLE
fix: tolerate missing single ad links in own-ad extraction

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -164,13 +164,24 @@ class AdExtractor(WebScrapingMixin):
                 list_items = await self.web_find_all(By.CLASS_NAME, "cardbox", parent = ad_list_container)
                 LOG.info("Found %s ad items on page %s.", len(list_items), page_num)
 
-                page_refs:list[str] = [str((await self.web_find(By.CSS_SELECTOR, "div h3 a.text-onSurface", parent = li)).attrs["href"]) for li in list_items]
+                page_refs:list[str] = []
+                for index, li in enumerate(list_items, start = 1):
+                    try:
+                        link_elem = await self.web_find(By.CSS_SELECTOR, "div h3 a.text-onSurface", parent = li)
+                        page_refs.append(str(link_elem.attrs["href"]))
+                    except TimeoutError:
+                        LOG.warning(
+                            "Skipping ad item %s/%s on page %s: no ad reference link found (likely unpublished or draft item).",
+                            index,
+                            len(list_items),
+                            page_num,
+                        )
                 refs.extend(page_refs)
                 LOG.info("Successfully extracted %s refs from page %s.", len(page_refs), page_num)
                 return False  # Continue to next page
 
             except TimeoutError:
-                LOG.warning("Could not find ad list container or items on page %s.", page_num)
+                LOG.warning("Could not find ad list container or ad items on page %s.", page_num)
                 return True  # Stop pagination (ads disappeared)
             except Exception as e:
                 # Continue despite error for resilience against transient web scraping issues

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -299,9 +299,10 @@ kleinanzeigen_bot/extract.py:
     "No ad URLs were extracted.": "Es wurden keine Anzeigen-URLs extrahiert."
 
   extract_page_refs:
-    "Could not find ad list container or items on page %s.": "Anzeigenlistencontainer oder Elemente auf Seite %s nicht gefunden."
+    "Could not find ad list container or ad items on page %s.": "Anzeigenlistencontainer oder Anzeigenelemente auf Seite %s nicht gefunden."
     "Error extracting refs on page %s: %s": "Fehler beim Extrahieren der Referenzen auf Seite %s: %s"
     "Found %s ad items on page %s.": "%s Anzeigen-Elemente auf Seite %s gefunden."
+    "Skipping ad item %s/%s on page %s: no ad reference link found (likely unpublished or draft item).": "Überspringe Anzeigenelement %s/%s auf Seite %s: kein Anzeigenlink gefunden (wahrscheinlich unveröffentlicht oder Entwurf)."
     "Successfully extracted %s refs from page %s.": "%s Referenzen von Seite %s erfolgreich extrahiert."
 
   navigate_to_ad_page:

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -708,6 +708,27 @@ class TestAdExtractorNavigation:
             assert refs == []
 
     @pytest.mark.asyncio
+    async def test_extract_own_ads_urls_skips_single_item_timeout(self, test_extractor:extract_module.AdExtractor) -> None:
+        """Timeout on one ad item should skip that item but keep extracting others."""
+        ad_list_container_mock = MagicMock()
+        first_item = MagicMock()
+        second_item = MagicMock()
+        valid_link = MagicMock()
+        valid_link.attrs = {"href": "/s-anzeige/ok/999"}
+
+        with (
+            patch.object(test_extractor, "web_open", new_callable = AsyncMock),
+            patch.object(test_extractor, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_extractor, "web_scroll_page_down", new_callable = AsyncMock),
+            patch.object(test_extractor, "web_find_by_rule", new_callable = AsyncMock, side_effect = [ad_list_container_mock, TimeoutError()]),
+            patch.object(test_extractor, "web_find_all", new_callable = AsyncMock, return_value = [first_item, second_item]),
+            patch.object(test_extractor, "web_find", new_callable = AsyncMock, side_effect = [ad_list_container_mock, TimeoutError(), valid_link]),
+        ):
+            refs = await test_extractor.extract_own_ads_urls()
+
+        assert refs == ["/s-anzeige/ok/999"]
+
+    @pytest.mark.asyncio
     async def test_extract_own_ads_urls_generic_exception_in_callback(self, test_extractor:extract_module.AdExtractor) -> None:
         """Test that generic Exception in extract_page_refs callback continues pagination."""
         with (


### PR DESCRIPTION
## ℹ️ Description
This pull request integrates the extraction robustness suggestion from issue #840 comment and ensures single-item failures do not abort own-ad URL extraction.

- Link to the related issue(s): Issue #840
- Describe the motivation and context for this change.
  - In `extract_own_ads_urls`, a missing link in one ad item could previously fail extraction for the whole page callback path.
  - We want per-item resilience: skip broken/unpublished entries and continue processing remaining ads.

## 📋 Changes Summary

- Updated `extract_own_ads_urls` item extraction logic:
  - replaced list comprehension with explicit loop
  - catches `TimeoutError` per item while extracting ad link
  - skips only that item and continues with others on the same page
- Clarified page-level timeout message:
  - from `ad list container or items` to `ad list container or ad items`
- Added item-level warning log:
  - identifies skipped item index and likely cause (unpublished/draft item)
- Updated/added tests:
  - added test to verify one timed-out item is skipped while valid items are still extracted
- Updated German translations for changed/new log strings
- Validation executed in this branch:
  - `pdm run format`
  - `pdm run lint`
  - `pdm run test`

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
