### PR TITLE
fix: set Config.sandbox=False when --no-sandbox is in browser_args

### DIFF
--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -557,6 +557,12 @@ class WebScrapingMixin:
             user_data_dir = self.browser_config.user_data_dir,
         )
 
+        # When --no-sandbox is in browser_args, nodriver's Config.sandbox must also be set to False.
+        # Otherwise nodriver re-adds --no-sandbox itself but still runs internal sandbox-related logic
+        # that can cause startup failures in containerized environments (Docker, LXC, etc.).
+        if any(arg == "--no-sandbox" for arg in browser_args):
+            cfg.sandbox = False
+
         # already logged by nodriver:
         # LOG.debug("-> Effective browser arguments: \n\t\t%s", "\n\t\t".join(cfg.browser_args))
 


### PR DESCRIPTION
## Summary

- When `--no-sandbox` is added to `browser_args` in config.yaml (common in Docker/LXC containers), the flag is correctly appended to the browser args list but nodriver's `Config.sandbox` property remains `True`
- This causes nodriver to run internal sandbox-related logic that can lead to browser startup failures in containerized environments
- This fix explicitly sets `cfg.sandbox = False` after `NodriverConfig` instantiation when `--no-sandbox` is present in the resolved browser args

## Motivation

Running kleinanzeigen-bot in Docker with `--no-sandbox` in `browser.arguments` config can fail to connect to the browser because nodriver's internal sandbox handling contradicts the explicitly passed flag. The fix is a one-line property assignment that aligns the config object with the user's intent.

## Test plan

- [x] Verified fix resolves browser startup failure in Docker (Alpine 3.22, Chromium 142, nodriver 0.47)
- [ ] Existing tests should continue to pass (no behavioral change when `--no-sandbox` is not used)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web scraping stability in containerized environments by preventing sandbox-related startup issues that could cause initialization failures
  * Enhanced browser configuration handling for better compatibility with containerized deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->