### PR TITLE
fix: except AttributeError when creation_date isn't found over XPATH

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -306,7 +306,7 @@ class AdExtractor(WebScrapingMixin):
 
         try:  # try different locations known for creation date element
             creation_date = await self.web_text(By.XPATH, "/html/body/div[1]/div[2]/div/section[2]/section/section/article/div[3]/div[2]/div[2]/div[1]/span")
-        except TimeoutError:
+        except (AttributeError, TimeoutError):
             creation_date = await self.web_text(By.CSS_SELECTOR, "#viewad-extra-info > div:nth-child(1) > span:nth-child(2)")
 
         # convert creation date to ISO format


### PR DESCRIPTION
## ℹ️ Description

fixed a try-except clause when scraping the creation date via XPATH is not possible and fails with an AttributeError

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [ ] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creation date extraction robustness with enhanced error handling to catch additional exception types, increasing reliability of data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->