### PR TITLE
feat: add configurable download directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ Full documentation including timeout tuning, browser settings, ad defaults, diag
 
 Each ad is defined in a separate YAML/JSON file (default pattern: `ad_*.yaml`). These files specify the title, description, price, category, images, and other ad-specific settings.
 
+The `publish` workflow reads files matched by the `ad_files` glob pattern. The `download` workflow writes files into `download.dir` (default: the literal `downloaded-ads/` directory in the workspace root).
+
+In XDG mode, the bare default `downloaded-ads/` stays in the workspace default download location. If you want a config-relative shared tree, set `download.dir` to `./downloaded-ads` and ensure the `ad_files` glob pattern matches files inside that tree.
+
 **Quick example (`ad_laptop.yaml`):**
 
 ```yaml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -170,11 +170,18 @@ Download configuration for the `download` command.
 
 ```yaml
 download:
+  dir: "downloaded-ads"  # default literal keeps workspace-mode download-folder behavior
+                        # custom relative paths are resolved relative to config.yaml
   include_all_matching_shipping_options: false  # if true, all shipping options matching the package size will be included
   excluded_shipping_options: []  # list of shipping options to exclude, e.g. ['DHL_2', 'DHL_5']
   folder_name_max_length: 100  # maximum length for folder names when downloading ads (default: 100)
   rename_existing_folders: false  # if true, rename existing folders without titles to include titles (default: false)
 ```
+
+- `download.dir` controls where `download` writes ad files.
+- Leaving `download.dir` at the default literal `downloaded-ads` keeps workspace-mode behavior (portable workspace folder in portable mode, XDG workspace folder in XDG mode).
+- Custom relative `download.dir` values are resolved relative to `config.yaml`, not the current shell working directory.
+- Absolute `download.dir` values are used as-is.
 
 ### publishing
 

--- a/docs/config.default.yaml
+++ b/docs/config.default.yaml
@@ -114,6 +114,12 @@ categories: {}
 # ################################################################################
 download:
 
+  # directory where downloaded ads are written. The default literal 'downloaded-ads' uses workspace-specific resolution; custom relative paths are resolved against the config file location
+  # Examples (choose one):
+  #   • "downloaded-ads"
+  #   • "./ads"
+  dir: downloaded-ads
+
   # if true, all shipping options matching the package size will be included
   include_all_matching_shipping_options: false
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -468,6 +468,16 @@
     },
     "DownloadConfig": {
       "properties": {
+        "dir": {
+          "default": "downloaded-ads",
+          "description": "directory where downloaded ads are written. The default literal 'downloaded-ads' uses workspace-specific resolution; custom relative paths are resolved against the config file location",
+          "examples": [
+            "\"downloaded-ads\"",
+            "\"./ads\""
+          ],
+          "title": "Dir",
+          "type": "string"
+        },
         "include_all_matching_shipping_options": {
           "default": false,
           "description": "if true, all shipping options matching the package size will be included",

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -17,7 +17,7 @@ from wcmatch import glob
 from . import extract, resources
 from ._version import __version__
 from .model.ad_model import MAX_DESCRIPTION_LENGTH, Ad, AdPartial, Contact, calculate_auto_price, calculate_auto_price_with_trace
-from .model.config_model import Config
+from .model.config_model import DEFAULT_DOWNLOAD_DIR, Config
 from .update_checker import UpdateChecker
 from .utils import diagnostics, dicts, error_handlers, loggers, misc, xdg_paths
 from .utils.exceptions import CaptchaEncountered, PublishSubmissionUncertainError
@@ -335,6 +335,13 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
     @property
     def _update_check_state_path(self) -> Path:
         return self._workspace_or_raise().state_dir / "update_check_state.json"
+
+    def _resolve_download_dir(self) -> Path:
+        workspace = self._workspace_or_raise()
+        trimmed_dir = self.config.download.dir.strip()
+        if trimmed_dir == DEFAULT_DOWNLOAD_DIR:
+            return workspace.download_dir
+        return Path(abspath(trimmed_dir, relative_to = str(Path(self.config_file_path).parent))).resolve()
 
     def _resolve_workspace(self) -> None:
         """
@@ -2422,9 +2429,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 LOG.warning("Skipping ad with non-numeric id: %s", published_ad.get("id"))
         LOG.info("Loaded %s published ads.", len(published_ads_by_id))
 
-        workspace = self._workspace_or_raise()
-        xdg_paths.ensure_directory(workspace.download_dir, "downloaded ads directory")
-        ad_extractor = extract.AdExtractor(self.browser, self.config, workspace.download_dir, published_ads_by_id = published_ads_by_id)
+        download_dir = self._resolve_download_dir()
+        xdg_paths.ensure_directory(download_dir, "downloaded ads directory")
+        LOG.info("Ads download directory: %s", download_dir)
+        ad_extractor = extract.AdExtractor(self.browser, self.config, download_dir, published_ads_by_id = published_ads_by_id)
 
         # Normalize comma-separated keyword selectors; set deduplication collapses "new,new" → {"new"}
         selector_tokens = {s.strip() for s in self.ads_selector.split(",")}

--- a/src/kleinanzeigen_bot/model/config_model.py
+++ b/src/kleinanzeigen_bot/model/config_model.py
@@ -18,6 +18,7 @@ from kleinanzeigen_bot.utils.pydantics import ContextualModel
 LOG:Final[loggers.Logger] = loggers.get_logger(__name__)
 
 _MAX_PERCENTAGE:Final[int] = 100
+DEFAULT_DOWNLOAD_DIR:Final[str] = "downloaded-ads"
 
 
 class AutoPriceReductionConfig(ContextualModel):
@@ -116,6 +117,15 @@ class AdDefaults(ContextualModel):
 
 
 class DownloadConfig(ContextualModel):
+    dir:str = Field(
+        default = DEFAULT_DOWNLOAD_DIR,
+        description = (
+            "directory where downloaded ads are written. "
+            "The default literal 'downloaded-ads' uses workspace-specific resolution; "
+            "custom relative paths are resolved against the config file location"
+        ),
+        examples = ['"downloaded-ads"', '"./ads"'],
+    )
     include_all_matching_shipping_options:bool = Field(
         default = False,
         description = "if true, all shipping options matching the package size will be included",
@@ -135,6 +145,13 @@ class DownloadConfig(ContextualModel):
         default = False,
         description = "if true, rename existing folders without titles to include titles (default: false)",
     )
+
+    @model_validator(mode = "after")
+    def _validate_dir(self) -> "DownloadConfig":
+        self.dir = self.dir.strip()
+        if not self.dir:
+            raise ValueError(_("download.dir must be a non-empty path"))
+        return self
 
 
 class BrowserConfig(ContextualModel):

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -258,6 +258,7 @@ kleinanzeigen_bot/__init__.py:
     "Attribute field '%s' seems to be a Combobox (i.e. text input with filtering dropdown)...": "Attributfeld '%s' scheint eine Combobox zu sein (d.h. Texteingabefeld mit Dropdown-Filter)..."
 
   download_ads:
+    "Ads download directory: %s": "Anzeigen-Download-Verzeichnis: %s"
     "Fetching published ads...": "Lade veröffentlichte Anzeigen..."
     "Loaded %s published ads.": "%s veröffentlichte Anzeigen geladen."
     "Scanning your ad overview...": "Scanne Anzeigenübersicht..."
@@ -675,6 +676,8 @@ kleinanzeigen_bot/model/config_model.py:
     "Deprecated: 'publish_error_capture' is replaced by 'capture_on.publish'. Please update your config.": "Veraltet: 'publish_error_capture' wurde durch 'capture_on.publish' ersetzt. Bitte aktualisieren Sie Ihre Konfiguration."
   _validate_glob_pattern:
     "must be a non-empty, non-blank glob pattern": "muss ein nicht-leeres Glob-Muster sein"
+  _validate_dir:
+    "download.dir must be a non-empty path": "download.dir muss ein nicht-leerer Pfad sein"
   _validate_pause_requires_capture:
     "pause_on_login_detection_failure requires capture_on.login_detection to be enabled": "pause_on_login_detection_failure erfordert, dass capture_on.login_detection aktiviert ist"
 

--- a/tests/unit/test_config_model.py
+++ b/tests/unit/test_config_model.py
@@ -3,7 +3,7 @@
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 import pytest
 
-from kleinanzeigen_bot.model.config_model import AdDefaults, Config, TimeoutConfig
+from kleinanzeigen_bot.model.config_model import DEFAULT_DOWNLOAD_DIR, AdDefaults, Config, TimeoutConfig
 
 
 def test_migrate_legacy_description_prefix() -> None:
@@ -72,6 +72,45 @@ def test_validate_glob_pattern_rejects_blank_strings() -> None:
         {"ad_files": ["*.yaml"], "ad_defaults": {"contact": {"name": "dummy", "zipcode": "12345"}}, "login": {"username": "dummy", "password": "dummy"}}
     )
     assert cfg.ad_files == ["*.yaml"]
+
+
+def test_download_config_defaults_to_workspace_download_dir_literal() -> None:
+    cfg = Config.model_validate(
+        {
+            "login": {"username": "dummy", "password": "dummy"},
+        }
+    )
+    assert cfg.download.dir == DEFAULT_DOWNLOAD_DIR
+
+
+def test_download_config_accepts_custom_dir_and_trims_whitespace() -> None:
+    cfg = Config.model_validate(
+        {
+            "download": {"dir": "  ./ads  "},
+            "login": {"username": "dummy", "password": "dummy"},
+        }
+    )
+    assert cfg.download.dir == "./ads"
+
+
+def test_download_config_rejects_null_dir() -> None:
+    with pytest.raises(ValueError, match = r"download\.dir\s+Input should be a valid string"):
+        Config.model_validate(
+            {
+                "download": {"dir": None},
+                "login": {"username": "dummy", "password": "dummy"},
+            }
+        )
+
+
+def test_download_config_rejects_blank_dir() -> None:
+    with pytest.raises(ValueError, match = "download.dir must be a non-empty path"):
+        Config.model_validate(
+            {
+                "download": {"dir": "   "},
+                "login": {"username": "dummy", "password": "dummy"},
+            }
+        )
 
 
 def test_timeout_config_resolve_returns_specific_value() -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -285,8 +285,10 @@ class TestKleinanzeigenBotInitialization:
 
     @pytest.mark.asyncio
     async def test_download_ads_passes_download_dir_and_published_ads(self, test_bot:KleinanzeigenBot, tmp_path:Path) -> None:
-        """Ensure download_ads wires download_dir and published_ads_by_id into AdExtractor."""
-        test_bot.workspace = xdg_paths.Workspace.for_config(tmp_path / "config.yaml", "kleinanzeigen-bot")
+        """Ensure download_ads wires resolved download_dir and published_ads_by_id into AdExtractor."""
+        config_file = tmp_path / "config.yaml"
+        test_bot.workspace = xdg_paths.Workspace.for_config(config_file, "kleinanzeigen-bot")
+        test_bot.config_file_path = str(config_file)
         test_bot.ads_selector = "all"
         test_bot.browser = MagicMock()
 
@@ -308,6 +310,53 @@ class TestKleinanzeigenBotInitialization:
             test_bot.workspace.download_dir,
             published_ads_by_id = {123: mock_published_ads[0], 456: mock_published_ads[1]},
         )
+
+    def test_resolve_download_dir_uses_workspace_default_for_literal_default(self, test_bot:KleinanzeigenBot, tmp_path:Path) -> None:
+        config_file = tmp_path / "config.yaml"
+        test_bot.workspace = xdg_paths.Workspace.for_config(config_file, "kleinanzeigen-bot")
+        test_bot.config_file_path = str(config_file)
+        test_bot.browser = cast(Any, None)
+
+        assert test_bot._resolve_download_dir() == test_bot.workspace.download_dir
+
+    def test_resolve_download_dir_uses_config_relative_path(self, test_bot:KleinanzeigenBot, tmp_path:Path) -> None:
+        config_file = tmp_path / "config.yaml"
+        test_bot.workspace = xdg_paths.Workspace.for_config(config_file, "kleinanzeigen-bot")
+        test_bot.config_file_path = str(config_file)
+        test_bot.browser = cast(Any, None)
+        test_bot.config.download.dir = "./my-ads"
+
+        assert test_bot._resolve_download_dir() == (tmp_path / "my-ads").resolve()
+
+    def test_resolve_download_dir_uses_absolute_path(self, test_bot:KleinanzeigenBot, tmp_path:Path) -> None:
+        config_file = tmp_path / "config.yaml"
+        test_bot.workspace = xdg_paths.Workspace.for_config(config_file, "kleinanzeigen-bot")
+        test_bot.config_file_path = str(config_file)
+        test_bot.browser = cast(Any, None)
+        test_bot.config.download.dir = str((tmp_path / "absolute-target").resolve())
+
+        assert test_bot._resolve_download_dir() == (tmp_path / "absolute-target").resolve()
+
+    @pytest.mark.asyncio
+    async def test_download_ads_uses_configured_relative_download_dir(self, test_bot:KleinanzeigenBot, tmp_path:Path) -> None:
+        config_file = tmp_path / "config.yaml"
+        test_bot.workspace = xdg_paths.Workspace.for_config(config_file, "kleinanzeigen-bot")
+        test_bot.config_file_path = str(config_file)
+        test_bot.config.download.dir = "./ads"
+        test_bot.ads_selector = "all"
+        test_bot.browser = MagicMock()
+
+        extractor_mock = MagicMock()
+        extractor_mock.extract_own_ads_urls = AsyncMock(return_value = [])
+
+        with (
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = []),
+            patch("kleinanzeigen_bot.extract.AdExtractor", return_value = extractor_mock) as mock_extractor,
+        ):
+            await test_bot.download_ads()
+
+        mock_extractor.assert_called_once()
+        assert mock_extractor.call_args.args[2] == (tmp_path / "ads").resolve()
 
 
 class TestKleinanzeigenBotLogging:


### PR DESCRIPTION
## ℹ️ Description

This pull request extracts the first reviewable chunk from PR #851 by adding configurable `download.dir` support without pulling in naming-template, staged-write, or foreign-ad activity changes.

- Link to the related issue(s): Issue #893
- PR #851 became too large to review effectively, so I split it into smaller PRs. This first PR isolates download-directory configuration while preserving the current default workspace behavior.

## 📋 Changes Summary

- Add `download.dir` to `DownloadConfig`, including validation for blank values.
- Preserve existing behavior when `download.dir` remains the default literal `downloaded-ads`.
- Resolve custom relative `download.dir` values relative to `config.yaml`; use absolute paths as-is.
- Wire the resolved download directory into `download_ads()` and log the effective directory.
- Update `docs/CONFIGURATION.md`, `docs/config.default.yaml`, and `schemas/config.schema.json` for the new setting.
- Add focused tests for default, relative, absolute, null, and blank-path handling.
- This PR intentionally excludes download naming templates, staged/rollback-safe writes, foreign numeric-id inactive handling, and selector wording cleanup.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `download.dir` setting to specify where downloaded ads are stored; supports relative paths (resolved relative to config file) and absolute paths.

* **Documentation**
  * Updated configuration guide documenting the new `download.dir` option and path resolution behavior.
  * Clarified how publish and download workflows handle file paths in workspace and XDG modes.

* **Tests**
  * Added test coverage for the new `download.dir` configuration option and path resolution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->