### PR TITLE
fix: ignore CVE-2026-4539 in pip-audit until upstream fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,8 @@ jobs:
 
 
     - name: Check with pip-audit
-      # TODO: Remove CVE-2026-4539 ignore once pygments fix is released
+      # until https://github.com/astral-sh/ruff/issues/8277
+      # TODO: Remove CVE-2026-4539 ignore once fixed (see https://github.com/pygments/pygments/issues/3058)
       # CVE-2026-4539: Low-severity ReDoS in AdlLexer (local-only, no upstream fix available)
       run:
         pdm run pip-audit --progress-spinner off --skip-editable --verbose --ignore-vuln CVE-2026-4539


### PR DESCRIPTION
## ℹ️ Description
- Link to the related issue(s): Issue N/A
- Temporarily ignore CVE-2026-4539 in pip-audit CI check since no upstream fix is available.

CVE-2026-4539 is a low-severity ReDoS vulnerability in pygments' `AdlLexer`:
- **Severity**: LOW (CVSS 3.3/1.9)
- **Attack vector**: Local only
- **Impact**: Availability only (no data exposure)
- **Status**: No upstream fix available yet

Pygments is a transitive dependency via `rich`/`pytest`. The affected `AdlLexer` (Archetype Definition Language - a medical modeling language) is not used by this project.

## 📋 Changes Summary
- Added `--ignore-vuln CVE-2026-4539` to pip-audit in CI workflow
- Added TODO comment to track removal when upstream fix is released

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build verification to temporarily suppress a known dependency vulnerability (CVE-2026-4539) during automated audit checks and added a TODO note to remove this suppression once the issue is resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->