### PR TITLE
ci: remove scope restrictions and add refactor type to PR validation

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -33,13 +33,11 @@ jobs:
             enh
             feat
             refact
+            refactor
             revert
             perf
             style
             test
-          scopes: |
-            deps
-            i18n
           requireScope: false
 
       - name: "Label PR"


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #
- This change improves the PR title validation workflow to be more flexible and aligned with conventional commit best practices.

Previously, scopes were restricted to only `deps` and `i18n`, which caused valid PR titles like `fix(ci):` to be rejected. This change removes scope restrictions entirely, allowing any lowercase scope.

## 📋 Changes Summary

- Removed `scopes:` configuration from the workflow - scopes are now unrestricted
- Added `refactor` type alongside `refact` for better ecosystem compatibility

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation configuration to accept additional commit types and removed scope constraints.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->