### PR TITLE
fix(pagination): continue when paging.last is absent

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1688,12 +1688,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 _handle_incomplete_fetch("Invalid 'pageNum' in paging info: %s, stopping pagination", paging.get("pageNum"))
                 break
 
-            if total_pages is None:
-                LOG.debug("No pagination info found, assuming single page")
-                break
-
-            # Stop if reached last page
-            if current_page_num >= total_pages:
+            # Stop if reached last page (only when API provides 'last')
+            if total_pages is not None and current_page_num >= total_pages:
                 LOG.info("Reached last page %s of %s, stopping pagination", current_page_num, total_pages)
                 break
 
@@ -1707,8 +1703,12 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             # Use API's next field for navigation (more robust than our counter)
             next_page = misc.coerce_page_number(paging.get("next"))
             if next_page is None:
-                LOG.warning("Invalid 'next' page value in paging info: %s, stopping pagination", paging.get("next"))
-                _handle_incomplete_fetch("Invalid 'next' page value in paging info: %s, stopping pagination", paging.get("next"))
+                if total_pages is not None:
+                    LOG.warning("Invalid 'next' page value in paging info: %s, stopping pagination", paging.get("next"))
+                    _handle_incomplete_fetch("Invalid 'next' page value in paging info: %s, stopping pagination", paging.get("next"))
+                else:
+                    LOG.debug("No 'next' in paging on page %s, assuming last page", page)
+                    _handle_incomplete_fetch("No 'next' in paging on page %s, assuming last page", page)
                 break
             page = next_page
 

--- a/tests/unit/test_json_pagination.py
+++ b/tests/unit/test_json_pagination.py
@@ -309,3 +309,60 @@ class TestJSONPagination:
                 pytest.fail(f"expected empty result on non-string content, got: {result}")
             if "Unexpected response content type on page 1: NoneType" not in caplog.text:
                 pytest.fail(f"expected non-string content warning in logs, got: {caplog.text}")
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_multi_page_without_last_field(self, bot:KleinanzeigenBot) -> None:
+        """Pagination should continue using 'next' when 'last' is absent (issue #917)."""
+        page1 = {"ads": [{"id": 1, "state": "active"}, {"id": 2, "state": "active"}], "paging": {"pageNum": 1, "pageSize": 25, "numFound": 3, "next": 2}}
+        page2 = {"ads": [{"id": 3, "state": "active"}], "paging": {"pageNum": 2, "pageSize": 25, "numFound": 3}}
+
+        with patch.object(bot, "web_request", new_callable = AsyncMock) as mock_request:
+            mock_request.side_effect = [
+                {"content": json.dumps(page1)},
+                {"content": json.dumps(page2)},
+            ]
+
+            result = await bot._fetch_published_ads()
+
+            if [ad["id"] for ad in result] != [1, 2, 3]:
+                pytest.fail(f"Expected ids [1, 2, 3] but got {[ad['id'] for ad in result]}")
+            if mock_request.call_count != 2:
+                pytest.fail(f"Expected 2 web_request calls but got {mock_request.call_count}")
+            requested_pages = [int(call.args[0].rsplit("pageNum=", maxsplit = 1)[1]) for call in mock_request.await_args_list]
+            if requested_pages != [1, 2]:
+                pytest.fail(f"Expected page requests [1, 2] but got {requested_pages}")
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_single_page_no_last_no_next(self, bot:KleinanzeigenBot) -> None:
+        """Paging dict with pageNum=1 but no 'last' and no 'next' should return ads and stop cleanly."""
+        response_data = {
+            "ads": [{"id": 10, "state": "active"}, {"id": 20, "state": "active"}],
+            "paging": {"pageNum": 1},
+        }
+
+        with patch.object(bot, "web_request", new_callable = AsyncMock) as mock_request:
+            mock_request.return_value = {"content": json.dumps(response_data)}
+
+            result = await bot._fetch_published_ads()
+
+            if len(result) != 2:
+                pytest.fail(f"Expected 2 ads, got {len(result)}")
+            if [ad["id"] for ad in result] != [10, 20]:
+                pytest.fail(f"Expected ids [10, 20] but got {[ad['id'] for ad in result]}")
+            mock_request.assert_awaited_once_with(
+                f"{bot.root_url}/m-meine-anzeigen-verwalten.json?sort=DEFAULT&pageNum=1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_single_page_no_last_no_next_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should fail when paging omits both 'last' and 'next'."""
+        response_data = {
+            "ads": [{"id": 10, "state": "active"}],
+            "paging": {"pageNum": 1},
+        }
+
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps(response_data)}),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = r"No 'next' in paging on page 1"),
+        ):
+            await bot._fetch_published_ads(strict = True)


### PR DESCRIPTION
## ℹ️ Description
*Provide a concise summary of the changes introduced in this pull request.*

- Link to the related issue(s): Issue #917
- Describe the motivation and context for this change.
  The manage-ads JSON API can omit `paging.last`, which previously caused pagination to stop after page 1 even when more pages were available via `paging.next`.

## 📋 Changes Summary

- Continue pagination when `paging.last` is missing and follow `paging.next` until completion.
- Keep strict-mode incomplete-fetch signaling for malformed/missing `next` situations.
- Add regression tests for multi-page no-`last` responses plus single-page no-`last`/no-`next` behavior (normal + strict mode).

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pagination handling when fetching published advertisements to properly manage incomplete pagination metadata, ensuring accurate detection of the final page and appropriate error reporting in strict mode.

* **Tests**
  * Added comprehensive unit test coverage for pagination scenarios including cases where pagination metadata is incomplete or missing, validating correct behavior across multiple page fetches and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->