### PR TITLE
fix(publish): support renamed selectors and city targeting

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -97,6 +97,7 @@ class ResolvedAdState(NamedTuple):
         owned: Whether the ad belongs to the current user (True) or is foreign (False).
             For "all"/"new" selectors this is typically True; for numeric IDs it may be False.
     """
+
     active:bool
     owned:bool
 
@@ -401,17 +402,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if published_ad is None:
             return ResolvedAdState(active = False, owned = False)
 
-        return ResolvedAdState(
-            active = published_ad.get("state") == "active",
-            owned = True
-        )
+        return ResolvedAdState(active = published_ad.get("state") == "active", owned = True)
 
-    async def _download_ad_with_resolved_state(
-        self,
-        ad_extractor:extract.AdExtractor,
-        ad_id:int,
-        published_ads_by_id:dict[int, dict[str, Any]]
-    ) -> None:
+    async def _download_ad_with_resolved_state(self, ad_extractor:extract.AdExtractor, ad_id:int, published_ads_by_id:dict[int, dict[str, Any]]) -> None:
         """Download an ad with proper active state resolution and logging.
 
         Resolves the ad's activity state from the published profile, logs appropriately
@@ -434,18 +427,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if not resolved.owned:
             # Ad not in user's published profile - unexpected for "all"/"new" selectors
             # since these only list the user's own ads from the overview page
-            LOG.warning(
-                "Ad %d found in overview but not in published profile. Saving as inactive.",
-                ad_id
-            )
+            LOG.warning("Ad %d found in overview but not in published profile. Saving as inactive.", ad_id)
         elif not resolved.active:
             # Ad is in published profile but not in active state (paused, inactive, etc.)
             published_ad = published_ads_by_id.get(ad_id, {})
-            LOG.debug(
-                "Ad %d has state '%s'. Saving as inactive.",
-                ad_id,
-                published_ad.get("state", "unknown")
-            )
+            LOG.debug("Ad %d has state '%s'. Saving as inactive.", ad_id, published_ad.get("state", "unknown"))
 
         await ad_extractor.download_ad(ad_id, active = resolved.active)
 
@@ -2113,7 +2099,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 await self.web_click(By.XPATH, submit_button_xpath)
 
             try:
-                await self.web_click(By.ID, "imprint-guidance-submit")
+                await self.web_click(By.ID, "imprint-guidance-submit", timeout = self._timeout("quick_dom"))
             except TimeoutError as imprint_error:
                 # imprint guidance submit button not present on all page variants
                 LOG.debug("Imprint guidance submit not found, continuing publish flow: %s", imprint_error)
@@ -2304,14 +2290,21 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             LOG.debug("ad-city text not available, returning no city selection text")
         return None
 
-    async def __select_city_combobox_option_exact(self, target:str) -> bool:
+    async def __select_city_combobox_option_exact(self, target:str) -> bool | None:
         await self.web_click(By.ID, "ad-city")
 
         option_selector = "[role='option'], li[aria-selected='true'], li[aria-selected='false'], button[aria-selected='true'], button[aria-selected='false']"
+        quick_dom_timeout = self._timeout("quick_dom")
         try:
-            candidates = await self.web_find_all(By.CSS_SELECTOR, option_selector, timeout = self._timeout("quick_dom"))
-        except TimeoutError:
-            return False
+            candidates = await self.web_find_all(By.CSS_SELECTOR, option_selector, timeout = quick_dom_timeout)
+        except TimeoutError as ex:
+            LOG.warning(
+                "City combobox options did not load within %.1fs for selector [%s]: %s",
+                quick_dom_timeout,
+                option_selector,
+                ex,
+            )
+            return None
 
         def normalize(value:str) -> str:
             return " ".join(value.split()).casefold()
@@ -2321,11 +2314,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         exact_match = next((elem for elem in candidates if normalize(elem.text or "") == target_norm), None)
         city_match = next(
-            (
-                elem
-                for elem in candidates
-                if normalize(elem.text or "") and normalize(elem.text or "").rsplit(" - ", maxsplit = 1)[-1] == target_city
-            ),
+            (elem for elem in candidates if normalize(elem.text or "") and normalize(elem.text or "").rsplit(" - ", maxsplit = 1)[-1] == target_city),
             None,
         )
 
@@ -2339,6 +2328,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         return self.__location_matches_target(target, selected_city)
 
     async def __set_contact_location(self, location:str) -> None:
+        """Set city using prioritized UI variants with graceful fallbacks.
+
+        Precedence is selected button/combobox (exact match), combobox warning fallback, readonly/editable ad-city input, then legacy dropdown options.
+        Any TimeoutError on a higher-priority path triggers the next fallback path.
+        """
         target = location.strip()
         if not target:
             return
@@ -2365,9 +2359,13 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 return
 
             try:
-                if await self.__select_city_combobox_option_exact(target):
+                combobox_match = await self.__select_city_combobox_option_exact(target)
+                if combobox_match:
                     return
-                LOG.warning("No exact city combobox option matched location: %s", location)
+                if combobox_match is None:
+                    LOG.warning("City combobox options unavailable; falling back to legacy dropdown for location: %s", location)
+                else:
+                    LOG.warning("No exact city combobox option matched location: %s", location)
             except TimeoutError:
                 # Fall back to legacy dropdown handling below.
                 pass

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -228,8 +228,12 @@ kleinanzeigen_bot/__init__.py:
     ? "Phone number field not present on page. This is expected for many private accounts; commercial accounts may still support phone numbers."
     : "Telefonnummernfeld auf der Seite nicht vorhanden. Dies ist bei vielen privaten Konten zu erwarten; gewerbliche Konten unterstützen Telefonnummern möglicherweise weiterhin."
 
+  __select_city_combobox_option_exact:
+    "City combobox options did not load within %.1fs for selector [%s]: %s": "Ortsoptionen der Kombobox wurden innerhalb von %.1fs für Selektor [%s] nicht geladen: %s"
+
   __set_contact_location:
     "Could not set contact location: %s": "Kontaktort konnte nicht gesetzt werden: %s"
+    "City combobox options unavailable; falling back to legacy dropdown for location: %s": "Ortsoptionen der Kombobox nicht verfügbar; falle für Ort auf das Legacy-Dropdown zurück: %s"
     "No exact city combobox option matched location: %s": "Keine exakte Ortsoption in der Kombobox passte zum Ort: %s"
     "No city dropdown option matched location: %s": "Kein Eintrag im Orts-Dropdown passte zum Ort: %s"
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -362,13 +362,16 @@ class TestKleinanzeigenBotInitialization:
         mock_extractor.assert_called_once()
         assert mock_extractor.call_args.args[2] == (tmp_path / "ads").resolve()
 
-    @pytest.mark.parametrize(("published_ads_by_id", "ad_id", "expected_active", "expected_owned"), [
-        ({123: {"id": 123, "state": "active"}}, 123, True, True),
-        ({123: {"id": 123, "state": "inactive"}}, 123, False, True),
-        ({123: {"id": 123, "state": "paused"}}, 123, False, True),
-        ({123: {"id": 123}}, 123, False, True),  # Missing "state" key - treated as inactive
-        ({}, 123, False, False),
-    ])
+    @pytest.mark.parametrize(
+        ("published_ads_by_id", "ad_id", "expected_active", "expected_owned"),
+        [
+            ({123: {"id": 123, "state": "active"}}, 123, True, True),
+            ({123: {"id": 123, "state": "inactive"}}, 123, False, True),
+            ({123: {"id": 123, "state": "paused"}}, 123, False, True),
+            ({123: {"id": 123}}, 123, False, True),  # Missing "state" key - treated as inactive
+            ({}, 123, False, False),
+        ],
+    )
     def test_resolve_download_ad_activity(
         self,
         test_bot:KleinanzeigenBot,
@@ -632,7 +635,12 @@ class TestKleinanzeigenBotInitialization:
 
         # Mock load_ads to return the saved_ad_ids
         saved_ads:list[tuple[str, MagicMock, dict[str, Any]]] = [
-            (f"ad_{ad_id}.yaml", MagicMock(spec = Ad, id = ad_id), {}) for ad_id in scenario["saved_ad_ids"]
+            (
+                f"ad_{ad_id}.yaml",
+                MagicMock(spec = Ad, id = ad_id),
+                {},
+            )
+            for ad_id in scenario["saved_ad_ids"]
         ]
 
         with (
@@ -3332,8 +3340,7 @@ class TestBuyNowRadioTimeout:
     def _assert_quick_dom_timeout_for_buy_now_check(self, mock_check:MagicMock, test_bot:KleinanzeigenBot) -> None:
         """Assert that web_check was called with quick_dom timeout for buy-now opt-out selector."""
         buy_now_check_calls = [
-            c for c in mock_check.call_args_list
-            if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
+            c for c in mock_check.call_args_list if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
         ]
         assert len(buy_now_check_calls) == 1, "web_check should be called once for buy-now opt-out selector"
         assert buy_now_check_calls[0].kwargs["timeout"] == test_bot._timeout("quick_dom")
@@ -3363,8 +3370,7 @@ class TestBuyNowRadioTimeout:
 
         # web_click must NOT have been called for buy-now opt-out selector (TimeoutError was swallowed)
         buy_now_click_calls = [
-            c for c in mock_click.call_args_list
-            if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
+            c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
         ]
         assert len(buy_now_click_calls) == 0, "web_click should not be called when TimeoutError occurs"
 
@@ -3392,8 +3398,7 @@ class TestBuyNowRadioTimeout:
 
         # web_click must have been called with quick_dom timeout
         buy_now_click_calls = [
-            c for c in mock_click.call_args_list
-            if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
+            c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
         ]
         assert len(buy_now_click_calls) == 1, "web_click should be called once"
         assert buy_now_click_calls[0].kwargs["timeout"] == test_bot._timeout("quick_dom")
@@ -3422,8 +3427,7 @@ class TestBuyNowRadioTimeout:
 
         # web_click must NOT have been called (already selected)
         buy_now_click_calls = [
-            c for c in mock_click.call_args_list
-            if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
+            c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
         ]
         assert len(buy_now_click_calls) == 0, "web_click should not be called when already selected"
 
@@ -3455,16 +3459,10 @@ class TestBuyNowRadioTimeout:
         with self._mock_publish_ad_dependencies(test_bot, mock_page, check_side_effect) as (mock_check, mock_click):
             await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
 
-        yes_check_calls = [
-            c for c in mock_check.call_args_list
-            if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_YES_SELECTOR
-        ]
+        yes_check_calls = [c for c in mock_check.call_args_list if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_YES_SELECTOR]
         assert len(yes_check_calls) == 1, "web_check should be called once for buy-now yes selector"
 
-        yes_click_calls = [
-            c for c in mock_click.call_args_list
-            if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_YES_SELECTOR
-        ]
+        yes_click_calls = [c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_YES_SELECTOR]
         assert len(yes_click_calls) == 1, "web_click should be called once for buy-now yes selector"
 
     @pytest.mark.asyncio
@@ -3495,23 +3493,18 @@ class TestBuyNowRadioTimeout:
         with self._mock_publish_ad_dependencies(test_bot, mock_page, check_side_effect) as (mock_check, mock_click):
             await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
 
-        no_check_calls = [
-            c for c in mock_check.call_args_list
-            if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
-        ]
+        no_check_calls = [c for c in mock_check.call_args_list if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR]
         assert len(no_check_calls) == 1, "web_check should be called once for buy-now no selector"
 
-        no_click_calls = [
-            c for c in mock_click.call_args_list
-            if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR
-        ]
+        no_click_calls = [c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[0] == By.CSS_SELECTOR and c.args[1] == self.BUY_NOW_NO_SELECTOR]
         assert len(no_click_calls) == 1, "web_click should be called once for buy-now no selector"
 
 
 class TestPublishDomSelectorFallbacks:
     """Regression tests for publish flow selector fallbacks after DOM changes."""
 
-    def _make_dropdown_option(self, text:str, value:str) -> MagicMock:
+    @staticmethod
+    def _make_dropdown_option(text:str, value:str) -> MagicMock:
         option = MagicMock()
         option.text = text
         option.attrs = MagicMock()
@@ -3576,7 +3569,7 @@ class TestPublishDomSelectorFallbacks:
             By.XPATH,
             "(//fieldset[@id='postad-publish']//button | //button)[normalize-space(.)='Anzeige aufgeben']",
         )
-        mock_click.assert_any_await(By.ID, "imprint-guidance-submit")
+        mock_click.assert_any_await(By.ID, "imprint-guidance-submit", timeout = test_bot._timeout("quick_dom"))
 
     @pytest.mark.asyncio
     async def test_publish_ad_attempts_imprint_submit_after_primary_submit(
@@ -3623,10 +3616,9 @@ class TestPublishDomSelectorFallbacks:
             await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
 
         mock_click.assert_any_await(By.CSS_SELECTOR, "#pstad-submit, #postad-publish button[type='submit']")
-        mock_click.assert_any_await(By.ID, "imprint-guidance-submit")
+        mock_click.assert_any_await(By.ID, "imprint-guidance-submit", timeout = test_bot._timeout("quick_dom"))
         fallback_calls = [
-            call for call in mock_click.await_args_list
-            if len(call.args) >= 2 and call.args[0] == By.XPATH and call.args[1] == submit_button_xpath
+            call for call in mock_click.await_args_list if len(call.args) >= 2 and call.args[0] == By.XPATH and call.args[1] == submit_button_xpath
         ]
         assert not fallback_calls, "Fallback submit XPath should not be used when primary submit selector succeeds"
 
@@ -3895,6 +3887,23 @@ class TestPublishDomSelectorFallbacks:
         )
         mock_input.assert_not_called()
         option_two.click.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_select_city_combobox_option_exact_returns_none_when_options_timeout(
+        self,
+        test_bot:KleinanzeigenBot,
+        caplog:pytest.LogCaptureFixture,
+    ) -> None:
+        """Timeout loading combobox options should return None so callers can distinguish unavailable options."""
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, side_effect = TimeoutError("options did not load")),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = await getattr(test_bot, "_KleinanzeigenBot__select_city_combobox_option_exact")("Example State - Targettown")
+
+        assert result is None
+        assert "City combobox options did not load within" in caplog.text
 
     @pytest.mark.asyncio
     async def test_read_city_selection_text_input_empty_value_falls_back_to_selected_option(


### PR DESCRIPTION
## ℹ️ Description
*Provide a concise summary of the changes introduced in this pull request.*

- Link to the related issue(s): Issue #920, Follow-up #925
- Describe the motivation and context for this change.
  Kleinanzeigen rolled out renamed publish-form DOM IDs and mixed city selector widgets, which broke stable publish-field targeting and could select wrong locations.

## 📋 Changes Summary

- Migrate publish/contact/category selectors to `ad-*` IDs with fallbacks to legacy `pstad-/postad-` IDs.
- Harden submit and imprint flows across page variants, including a button-only fallback XPath with exact normalized text matching for `Anzeige aufgeben`.
- Refactor contact location handling to support readonly/input/combobox city widgets with exact matching and safe fallback to legacy dropdown options.
- Replace silent timeout fallthroughs in city-selection helpers with explicit debug logging to improve diagnostics.
- Add focused regression tests for selector fallbacks, category fallback matching (including numeric-only paths), city selection correctness, shipping/buy-now selector fallbacks, and stricter combobox selector assertions.
- Update German i18n entries for the moved `__set_contact_location` warnings.
- Intentionally excluded from this PR scope: hidden image-marker upload completion enhancements and related tests/wording.
- Deferred follow-up for numeric-only category-retention edge case: #925.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened form-field, radio and button targeting with multi-selector fallbacks for more reliable publish/update across UI variants
  * Safer price, title, description, contact and location handling with normalized matching, combobox support, and non-fatal fallbacks when controls (including imprint guidance) are missing
  * Submit flow now tries multiple publish targets and XPath fallbacks; buy-now/shipping selectors expanded
  * Improved image upload completion detection using hidden upload markers when thumbnails are absent

* **Tests**
  * Expanded regression tests covering publish flow, selector fallbacks, imprint/submit behavior, contact/location flows, shipping/buy-now radios, category handling, and image upload markers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->