### PR TITLE
fix: update HTML element IDs after Kleinanzeigen site redesign (#920)

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2182,8 +2182,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
     async def __react_input(self, element_id:str, value:str) -> None:
         """Sets a React-controlled input value using the native setter to trigger onChange."""
         await self.web_find(By.ID, element_id)  # raises TimeoutError if element is absent
+        js_element_id = json.dumps(element_id)
+        js_value = json.dumps(value)
         await self.web_execute(
-            "(function(id,v){"
+            f"(function(id,v){{"
             "var el=document.getElementById(id);"
             "if(!el)return;"
             "var tag=el.tagName.toLowerCase();"
@@ -2192,7 +2194,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             "setter.call(el,v);"
             "el.dispatchEvent(new Event('input',{bubbles:true}));"
             "el.dispatchEvent(new Event('change',{bubbles:true}));"
-            "})('" + element_id + "'," + json.dumps(value) + ")"
+            f"}})({js_element_id},{js_value})"
         )
 
     async def __set_contact_fields(self, contact:Contact) -> None:
@@ -2448,8 +2450,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             try:
                 await self.web_click(By.ID, "ad-shipping-enabled-yes", timeout = short_timeout)
                 await self.web_sleep(500, 800)
-            except TimeoutError:
-                pass  # nosec — already selected or not present; proceed to open options dialog
+            except TimeoutError as ex:
+                LOG.debug("Shipping enabled toggle not found before options dialog: %s", ex)
             await self.web_click(By.ID, "ad-shipping-options")
 
             if mode == AdUpdateStrategy.MODIFY:
@@ -2485,8 +2487,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     try:
                         await self.web_click(By.ID, "ad-shipping-enabled-yes", timeout = short_timeout)
                         await self.web_sleep(500, 800)
-                    except TimeoutError:
-                        pass  # nosec — already selected or not present; proceed to open options dialog
+                    except TimeoutError as ex:
+                        LOG.debug("Shipping enabled toggle not found before options dialog: %s", ex)
                     # no options. only costs. Set custom shipping cost
                     await self.web_click(By.ID, "ad-shipping-options")
                     try:
@@ -2611,36 +2613,40 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # Wait for all images to be processed and thumbnails to appear
         expected_count = len(ad_cfg.images)
         LOG.info(" -> waiting for %s to be processed...", pluralize("image", ad_cfg.images))
+        thumbnail_selector = "ul#j-pictureupload-thumbnails > li:not(.is-placeholder)"
+        hidden_marker_selector = "input[name^='adImages'][name$='.url']"
+
+        async def count_processed_images() -> int:
+            thumbnail_count = 0
+            marker_count = 0
+
+            try:
+                thumbnails = await self.web_find_all(By.CSS_SELECTOR, thumbnail_selector, timeout = self._timeout("quick_dom"))
+                thumbnail_count = len(thumbnails)
+            except TimeoutError:
+                thumbnail_count = 0
+
+            try:
+                markers = await self.web_find_all(By.CSS_SELECTOR, hidden_marker_selector, timeout = self._timeout("quick_dom"))
+                marker_count = sum(1 for marker in markers if str(getattr(marker.attrs, "value", "") or "").strip())
+            except TimeoutError:
+                marker_count = 0
+
+            return max(thumbnail_count, marker_count)
 
         async def check_thumbnails_uploaded() -> bool:
-            try:
-                thumbnails = await self.web_find_all(
-                    By.CSS_SELECTOR,
-                    "ul#j-pictureupload-thumbnails > li:not(.is-placeholder)",
-                    timeout = self._timeout("quick_dom"),  # Fast timeout for polling
-                )
-                current_count = len(thumbnails)
-                if current_count < expected_count:
-                    LOG.debug(" -> %d of %d images processed", current_count, expected_count)
-                return current_count == expected_count
-            except TimeoutError:
-                # No thumbnails found yet, continue polling
-                return False
+            current_count = await count_processed_images()
+            if current_count < expected_count:
+                LOG.debug(" -> %d of %d images processed", current_count, expected_count)
+            return current_count >= expected_count
 
         try:
             await self.web_await(check_thumbnails_uploaded, timeout = self._timeout("image_upload"), timeout_error_message = _("Image upload timeout exceeded"))
         except TimeoutError as ex:
             # Get current count for better error message
-            try:
-                thumbnails = await self.web_find_all(
-                    By.CSS_SELECTOR, "ul#j-pictureupload-thumbnails > li:not(.is-placeholder)", timeout = self._timeout("quick_dom")
-                )
-                current_count = len(thumbnails)
-            except TimeoutError:
-                # Still no thumbnails after full timeout
-                current_count = 0
+            current_count = await count_processed_images()
             raise TimeoutError(
-                _("Not all images were uploaded within timeout. Expected %(expected)d, found %(found)d thumbnails.")
+                _("Not all images were uploaded within timeout. Expected %(expected)d, found %(found)d processed images.")
                 % {"expected": expected_count, "found": current_count}
             ) from ex
 

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -237,7 +237,7 @@ kleinanzeigen_bot/__init__.py:
     " -> waiting for %s to be processed...": " -> Warte auf Verarbeitung von %s..."
     " -> all images uploaded successfully": " -> Alle Bilder erfolgreich hochgeladen"
     "Image upload timeout exceeded": "Zeitüberschreitung beim Hochladen der Bilder"
-    "Not all images were uploaded within timeout. Expected %(expected)d, found %(found)d thumbnails.": "Nicht alle Bilder wurden innerhalb der Zeitüberschreitung hochgeladen. Erwartet: %(expected)d, gefunden: %(found)d Miniaturansichten."
+    "Not all images were uploaded within timeout. Expected %(expected)d, found %(found)d processed images.": "Nicht alle Bilder wurden innerhalb der Zeitüberschreitung hochgeladen. Erwartet: %(expected)d, gefunden: %(found)d verarbeitete Bilder."
 
   check_thumbnails_uploaded:
     " -> %d of %d images processed": " -> %d von %d Bildern verarbeitet"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3417,3 +3417,91 @@ class TestBuyNowRadioTimeout:
             if len(c.args) >= 2 and c.args[0] == By.ID and c.args[1] == "ad-buy-now-false"
         ]
         assert len(buy_now_click_calls) == 0, "web_click should not be called when already selected"
+
+
+class TestImageUploadProcessedMarkerFallback:
+    """Regression tests for image upload completion detection via hidden marker inputs."""
+
+    @pytest.mark.asyncio
+    async def test_upload_images_succeeds_with_hidden_markers_when_thumbnails_absent(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        tmp_path:Path,
+    ) -> None:
+        """Hidden adImages markers should satisfy completion when thumbnail list is missing."""
+        image_a = tmp_path / "img_a.jpg"
+        image_b = tmp_path / "img_b.jpg"
+        image_a.write_bytes(b"")
+        image_b.write_bytes(b"")
+        ad_cfg = Ad.model_validate(base_ad_config | {"images": [str(image_a), str(image_b)]})
+
+        file_input = MagicMock()
+        file_input.send_file = AsyncMock()
+
+        marker_a = MagicMock()
+        marker_a.attrs.value = "https://img.example/a.jpg"
+        marker_b = MagicMock()
+        marker_b.attrs.value = "https://img.example/b.jpg"
+
+        async def find_all_side_effect(selector_type:By, selector_value:str, **_:Any) -> list[MagicMock]:
+            if selector_type == By.CSS_SELECTOR and selector_value == "ul#j-pictureupload-thumbnails > li:not(.is-placeholder)":
+                raise TimeoutError("no thumbnails")
+            if selector_type == By.CSS_SELECTOR and selector_value == "input[name^='adImages'][name$='.url']":
+                return [marker_a, marker_b]
+            return []
+
+        async def await_side_effect(condition:Callable[[], Awaitable[bool]], **_:Any) -> bool:
+            if await condition():
+                return True
+            raise TimeoutError("condition did not pass")
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = file_input),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, side_effect = find_all_side_effect),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = await_side_effect),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__upload_images")(ad_cfg)
+
+        file_input.send_file.assert_any_await(str(image_a))
+        file_input.send_file.assert_any_await(str(image_b))
+
+    @pytest.mark.asyncio
+    async def test_upload_images_timeout_reports_processed_marker_count(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        tmp_path:Path,
+    ) -> None:
+        """Timeout message should include processed count derived from hidden markers."""
+        image_a = tmp_path / "img_a.jpg"
+        image_b = tmp_path / "img_b.jpg"
+        image_a.write_bytes(b"")
+        image_b.write_bytes(b"")
+        ad_cfg = Ad.model_validate(base_ad_config | {"images": [str(image_a), str(image_b)]})
+
+        file_input = MagicMock()
+        file_input.send_file = AsyncMock()
+
+        marker_a = MagicMock()
+        marker_a.attrs.value = "https://img.example/a.jpg"
+
+        async def find_all_side_effect(selector_type:By, selector_value:str, **_:Any) -> list[MagicMock]:
+            if selector_type == By.CSS_SELECTOR and selector_value == "ul#j-pictureupload-thumbnails > li:not(.is-placeholder)":
+                raise TimeoutError("no thumbnails")
+            if selector_type == By.CSS_SELECTOR and selector_value == "input[name^='adImages'][name$='.url']":
+                return [marker_a]
+            return []
+
+        async def await_timeout(*_:Any, **__:Any) -> None:
+            raise TimeoutError("Image upload timeout exceeded")
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = file_input),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, side_effect = find_all_side_effect),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = await_timeout),
+            pytest.raises(TimeoutError, match = r"Expected 2, found 1 processed images\.$"),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__upload_images")(ad_cfg)


### PR DESCRIPTION
## Summary

Fixes #920 — Kleinanzeigen.de renamed all form element IDs site-wide. This PR updates all selectors to match the new `ad-*` prefix pattern.

### Login form changes
| Old | New |
|-----|-----|
| `login-email` | `username` |
| `login-password` | `password` |
| `form#login-form button[type='submit']` | `button[type='submit']` |

### Ad form changes
| Old | New |
|-----|-----|
| `adType2` | `ad-type-WANTED` |
| `postad-title` | `ad-title` |
| `select#price-type-react` (SELECT element) | `button#ad-price-type` + `li#ad-price-type-menu-option-{N}` (dropdown) |
| `input#pstad-price` | `input#ad-price-amount` |
| `#pstad-descrptn` | `#ad-description` |
| `pstad-zip` | `ad-zip-code` |
| `#pstad-citychsr` (SELECT with options) | `ad-city` (text input) |
| `pstad-street` | `ad-street` |
| `addressVisibility` | `ad-address-visibility` |
| `postad-contactname` | `ad-name` |
| `postad-phonenumber` | `ad-phone` |
| `phoneNumberVisibility` | `ad-phone-visibility` |
| `pstad-submit` / `fieldset#postad-publish` | `//button[contains(., 'Anzeige aufgeben')]` |

### Category selection changes
| Old | New |
|-----|-----|
| `pstad-descrptn` (trigger click) | `ad-description` |
| `postad-category-path` | `ad-category-path` |
| `pstad-lnk-chngeCtgry` | XPath by text `//a[contains(., 'Kategorie')] \| //button[contains(., 'Kategorie')]` |
| `//*[@id='postad-step1-sbmt']/button` | `//button[@type='submit']` |

### Notable behavioral changes
- **Price type**: The price type selector changed from a `<select>` element to a button-triggered dropdown (`<ul>` with `<li>` options). The mapping is: `FIXED` → option 0, `NEGOTIABLE` → option 1, `GIVE_AWAY` → option 2.
- **City**: Changed from a `<select>` dropdown populated after ZIP entry to a plain text `<input>` (`ad-city`).
- **Submit**: `pstad-submit` no longer exists; the form now has a `<button>` with text "Anzeige aufgeben" (no `id` attribute).

## Test plan
- [ ] Verify login works with new `username`/`password` field IDs
- [ ] Verify ad title field `ad-title` accepts input
- [ ] Verify price type dropdown opens via `ad-price-type` button and selects correct option
- [ ] Verify description sets via `#ad-description`
- [ ] Verify ZIP/city fields `ad-zip-code` and `ad-city` work
- [ ] Verify ad submits via `//button[contains(., 'Anzeige aufgeben')]`
- [ ] Verify category selection flow with updated XPath selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored ad publishing flow to match the site's revised UI: updated field handling for title/description, pricing, buy‑now, submit/confirmation, and more resilient category detection and dialog handling.
  * Improved pricing and submission reliability; timeouts now surface locally.

* **Chores**
  * Updated contact, address, shipping and special-attribute handling to align with the site's changed controls and React-managed inputs.

* **Tests**
  * Adjusted unit tests and mocks to reflect the updated page interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->