### PR TITLE
fix(ci): remove obsolete pip-audit ignore for Pygments CVE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,10 +152,8 @@ jobs:
 
     - name: Check with pip-audit
       # until https://github.com/astral-sh/ruff/issues/8277
-      # TODO: Remove CVE-2026-4539 ignore once fixed (see https://github.com/pygments/pygments/issues/3058)
-      # CVE-2026-4539: Low-severity ReDoS in AdlLexer (local-only, no upstream fix available)
       run:
-        pdm run pip-audit --progress-spinner off --skip-editable --verbose --ignore-vuln CVE-2026-4539
+        pdm run pip-audit --progress-spinner off --skip-editable --verbose
 
 
     - name: Check with ruff


### PR DESCRIPTION
## ℹ️ Description
*Provide a concise summary of the changes introduced in this pull request.*

- Link to the related issue(s): Issue #918
- Describe the motivation and context for this change: PR #918 updated dependencies and Pygments is now patched, so the temporary `pip-audit` CVE ignore is no longer needed.

## 📋 Changes Summary

- Removed the temporary `--ignore-vuln CVE-2026-4539` flag from the `pip-audit` step in `.github/workflows/build.yml`.
- Removed the associated temporary TODO/context comments tied to that ignore.
- No new dependencies or configuration requirements were introduced.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to remove a vulnerability suppression, enabling proper detection and reporting of security issues during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->