### PR TITLE
fix(download): align INFO download logs with final destinations

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2693,18 +2693,23 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             if effective_selector == "all":  # download all of your ads
                 LOG.info("Starting download of all ads...")
 
-                success_count = 0
-                # call download function for each ad page
+                valid_ad_refs:list[tuple[str, int]] = []
                 for ad_url in own_ad_urls:
                     ad_id = ad_extractor.extract_ad_id_from_ad_url(ad_url)
                     if ad_id == -1:
                         # Skip ads with invalid URLs (warning already logged by extract_ad_id_from_ad_url)
                         continue
+                    valid_ad_refs.append((ad_url, ad_id))
+
+                success_count = 0
+                # call download function for each ad page
+                for idx, (ad_url, ad_id) in enumerate(valid_ad_refs, start = 1):
+                    LOG.info("Downloading %d/%d ads...", idx, len(valid_ad_refs))
 
                     if await ad_extractor.navigate_to_ad_page(ad_url):
                         await self._download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
                         success_count += 1
-                LOG.info("%d of %d ads were downloaded from your profile.", success_count, len(own_ad_urls))
+                LOG.info("%d of %d ads were downloaded from your profile.", success_count, len(valid_ad_refs))
 
             elif effective_selector == "new":  # download only unsaved ads
                 # check which ads already saved
@@ -2721,7 +2726,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 ad_id_by_url = {url: ad_extractor.extract_ad_id_from_ad_url(url) for url in own_ad_urls}
 
                 LOG.info("Starting download of not yet downloaded ads...")
-                new_count = 0
+                ads_to_download:list[tuple[str, int]] = []
                 for ad_url, ad_id in ad_id_by_url.items():
                     # Skip ads with invalid URLs (warning already logged by extract_ad_id_from_ad_url)
                     if ad_id == -1:
@@ -2731,6 +2736,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     if ad_id in saved_ad_ids:
                         LOG.info("The ad with id %d has already been saved.", ad_id)
                         continue
+                    ads_to_download.append((ad_url, ad_id))
+
+                new_count = 0
+                for idx, (ad_url, ad_id) in enumerate(ads_to_download, start = 1):
+                    LOG.info("Downloading %d/%d ads...", idx, len(ads_to_download))
 
                     if await ad_extractor.navigate_to_ad_page(ad_url):
                         await self._download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
@@ -2742,7 +2752,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             LOG.info("Starting download of ad(s) with the id(s):")
             LOG.info(" | ".join([str(ad_id) for ad_id in ids]))
 
-            for ad_id in ids:  # call download routine for every id
+            for idx, ad_id in enumerate(ids, start = 1):  # call download routine for every id
+                LOG.info("Downloading %d/%d ads...", idx, len(ids))
                 exists = await ad_extractor.navigate_to_ad_page(ad_id)
                 if exists:
                     resolved = self._resolve_download_ad_activity(ad_id, published_ads_by_id)

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -225,6 +225,7 @@ class AdExtractor(WebScrapingMixin):
 
         loop = asyncio.get_running_loop()
         backup_dir = final_dir.with_name(f"{_BACKUP_DIR_PREFIX}{ad_file_stem}")
+        final_yaml_path = final_dir / f"{ad_file_stem}.yaml"
         backup_created_by_us = False
         try:
             await loop.run_in_executor(None, lambda: dicts.save_dict(ad_file_path, ad_cfg.model_dump(mode = "json"), header = header_string))
@@ -237,6 +238,7 @@ class AdExtractor(WebScrapingMixin):
                 backup_created_by_us = True
 
             await loop.run_in_executor(None, staging_dir.rename, final_dir)
+            LOG.info("Saved ad config to: %s", final_yaml_path)
 
             if await files.exists(backup_dir):
                 try:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -268,6 +268,7 @@ kleinanzeigen_bot/__init__.py:
     "Found %s.": "%s gefunden."
     "ad URL": "Anzeigen-URL"
     "Starting download of all ads...": "Starte den Download aller Anzeigen..."
+    "Downloading %d/%d ads...": "Lade Anzeige %d/%d herunter..."
     "%d of %d ads were downloaded from your profile.": "%d von %d Anzeigen wurden aus Ihrem Profil heruntergeladen."
     "Starting download of not yet downloaded ads...": "Starte den Download noch nicht heruntergeladener Anzeigen..."
     "Skipping ad with non-numeric id: %s": "Überspringe Anzeige mit nicht-numerischer ID: %s"
@@ -313,6 +314,7 @@ kleinanzeigen_bot/extract.py:
 #################################################
   download_ad:
     "Using download directory: %s": "Verwende Download-Verzeichnis: %s"
+    "Saved ad config to: %s": "Anzeigen-Konfiguration gespeichert in: %s"
     "Backup directory %s already exists. Aborting download for ad %s to avoid data loss.": "Sicherungsverzeichnis %s existiert bereits. Download für Anzeige %s wird abgebrochen, um Datenverlust zu vermeiden."
     "Could not remove backup directory %s: %s": "Konnte Sicherungsverzeichnis %s nicht entfernen: %s"
     "Failed to restore backup directory %s to %s after download failure: %s": "Konnte Sicherungsverzeichnis %s nach %s nach einem Download-Fehler nicht wiederherstellen: %s"

--- a/src/kleinanzeigen_bot/utils/dicts.py
+++ b/src/kleinanzeigen_bot/utils/dicts.py
@@ -133,7 +133,7 @@ def save_dict(filepath:str | Path, content:dict[str, Any], *, header:str | None 
     # Create parent directory if needed
     filepath.parent.mkdir(parents = True, exist_ok = True)
 
-    LOG.info("Saving [%s]...", filepath)
+    LOG.debug("Saving [%s]...", filepath)
     with open(filepath, "w", encoding = "utf-8") as file:
         if header:
             file.write(header)
@@ -350,7 +350,7 @@ def save_commented_model(
     filepath = Path(unicodedata.normalize("NFC", str(filepath)))
     filepath.parent.mkdir(parents = True, exist_ok = True)
 
-    LOG.info("Saving [%s]...", filepath)
+    LOG.debug("Saving [%s]...", filepath)
 
     # Convert to commented structure directly from model (preserves metadata)
     commented_data = model_to_commented_yaml(model_instance, exclude = exclude)


### PR DESCRIPTION
## ℹ️ Description
*Provide a concise summary of the changes introduced in this pull request.*

- Link to the related issue(s): None (no linked issue)
- Describe the motivation and context for this change.
  This change fixes confusing download logs that exposed staging (`.tmp-*`) paths in user-facing INFO output. It keeps staging details at DEBUG level, logs the final YAML destination at INFO after the atomic rename succeeds, and adds per-item download progress logging.

## 📋 Changes Summary

- Downgraded `Saving [%s]...` logging in `utils/dicts.py` from INFO to DEBUG so staging write paths are no longer shown in normal user output.
- Added `Saved ad config to: %s` INFO log in `extract.download_ad()` after successful staging-to-final directory rename.
- Added `Downloading %d/%d ads...` progress logs in `download_ads()` for `--ads=all`, `--ads=new`, and numeric ID selectors.
- Updated `--ads=all` summary denominator to report against valid download candidates (excluding invalid ad IDs), matching the new progress reporting semantics.
- Added German translations for the two new log messages.
- Mention any dependencies, configuration changes, or additional requirements introduced.
  No dependencies or configuration changes were introduced.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.