### PR TITLE
fix(publish): stabilize condition trigger handling and speed probe checks

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2340,10 +2340,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         short_timeout = self._timeout("quick_dom")
         condition_trigger_xpath = "//label[contains(@for, '.condition')]/following::button[@aria-haspopup='dialog' or @aria-haspopup='true'][1]"
 
-        try:
-            condition_trigger = await self.web_find(By.XPATH, condition_trigger_xpath)
-        except TimeoutError:
-            LOG.debug("Condition dialog trigger not available for [%s]; falling back to generic handler.", condition_value, exc_info = True)
+        condition_trigger = await self.web_probe(By.XPATH, condition_trigger_xpath, timeout = short_timeout)
+        if condition_trigger is None:
+            LOG.debug("Condition dialog trigger not available for [%s]; falling back to generic handler.", condition_value)
             return False
 
         trigger_id = str(condition_trigger.attrs.get("id") or "")
@@ -2362,7 +2361,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             return False
 
         try:
-            await self.web_click(By.XPATH, condition_trigger_xpath)
+            await condition_trigger.click()
             await self.web_find(By.XPATH, '//*[self::dialog or @role="dialog"]', timeout = short_timeout)
             condition_radio = await self.web_find(
                 By.XPATH,

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2331,27 +2331,45 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         LOG.info("DONE: updated %s", pluralize("ad", count))
         LOG.info("############################################")
 
-    async def __set_condition(self, condition_value:str) -> None:
+    async def __set_condition(self, condition_value:str) -> bool:
+        """Try to set condition via dialog path.
+
+        Returns True when dialog handling succeeded, otherwise False to indicate
+        that caller should use generic special-attribute handling.
+        """
         short_timeout = self._timeout("quick_dom")
-        try:
-            # Open condition dialog
-            await self.web_click(
-                By.XPATH,
-                "//label[contains(@for, '.condition')]/following::button[@aria-haspopup='dialog' or @aria-haspopup='true'][1]",
-            )
-        except TimeoutError as ex:
-            LOG.debug("Unable to open condition dialog and select condition [%s]", condition_value, exc_info = True)
-            raise TimeoutError(_("Failed to set attribute '%s'") % "condition_s") from ex
+        condition_trigger_xpath = "//label[contains(@for, '.condition')]/following::button[@aria-haspopup='dialog' or @aria-haspopup='true'][1]"
 
         try:
+            condition_trigger = await self.web_find(By.XPATH, condition_trigger_xpath)
+        except TimeoutError:
+            LOG.debug("Condition dialog trigger not available for [%s]; falling back to generic handler.", condition_value, exc_info = True)
+            return False
+
+        trigger_id = str(condition_trigger.attrs.get("id") or "")
+        trigger_controls = str(condition_trigger.attrs.get("aria-controls") or "")
+        LOG.debug("Condition dialog trigger resolved: id='%s', aria-controls='%s'", trigger_id, trigger_controls)
+
+        # Some categories render condition as a combobox and the broad dialog-trigger XPath
+        # may accidentally resolve to shipping controls (for example: id='ad-shipping-options').
+        # In that case we deliberately skip the dialog path and fall back to generic handling.
+        if "shipping" in trigger_id.lower() or "shipping" in trigger_controls.lower():
+            LOG.debug(
+                "Condition dialog trigger appears to be shipping-related (id='%s', aria-controls='%s'); skipping dialog path for condition_s.",
+                trigger_id,
+                trigger_controls,
+            )
+            return False
+
+        try:
+            await self.web_click(By.XPATH, condition_trigger_xpath)
             await self.web_find(By.XPATH, '//*[self::dialog or @role="dialog"]', timeout = short_timeout)
             condition_radio = await self.web_find(
                 By.XPATH,
                 f"//*[self::dialog or @role='dialog']//input[@type='radio' and @value={_xpath_literal(condition_value)}]",
                 timeout = short_timeout,
             )
-            condition_radio_id_attr = condition_radio.attrs.get("id")
-            condition_radio_id = str(condition_radio_id_attr) if condition_radio_id_attr else ""
+            condition_radio_id = str(condition_radio.attrs.get("id") or "")
             if condition_radio_id:
                 try:
                     await self.web_click(By.XPATH, f"//*[self::dialog or @role='dialog']//label[@for={_xpath_literal(condition_radio_id)}]")
@@ -2368,6 +2386,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             await self.web_click(By.XPATH, '//*[self::dialog or @role="dialog"]//button[.//span[text()="Bestätigen"]]')
         except TimeoutError as ex:
             raise TimeoutError(_("Unable to close condition dialog!")) from ex
+
+        return True
 
     async def __set_category(self, category:str | None, ad_file:str) -> None:
         # click on something to trigger automatic category detection
@@ -2459,11 +2479,12 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key)
 
             if normalized_special_attribute_key == "condition":
-                try:
-                    await self.__set_condition(special_attribute_value_str)
+                LOG.debug("Special attribute [%s]: trying dedicated condition dialog path", special_attribute_key)
+                if await self.__set_condition(special_attribute_value_str):
+                    LOG.debug("Special attribute [%s]: condition dialog path succeeded", special_attribute_key)
                     continue
-                except TimeoutError:
-                    LOG.info("Condition dialog not available, falling back to generic attribute handler for [%s]...", special_attribute_key)
+
+                LOG.info("Condition dialog not available, falling back to generic attribute handler for [%s]...", special_attribute_key)
 
             LOG.debug("Setting special attribute [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
             id_suffix_literal = _xpath_literal(f".{normalized_special_attribute_key}")

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2394,12 +2394,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         await self.web_click(By.ID, "ad-description")
 
         is_category_auto_selected = False
-        try:
-            if await self.web_text(By.ID, "ad-category-path"):
-                is_category_auto_selected = True
-        except TimeoutError:
-            # Category auto-selection indicator not available within timeout.
-            pass
+        category_path_elem = await self.web_probe(By.ID, "ad-category-path")
+        if category_path_elem and await self._extract_visible_text(category_path_elem):
+            is_category_auto_selected = True
 
         if category:
             await self.web_sleep()  # workaround for https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/39
@@ -2676,11 +2673,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 # Dialog option not present; already on the individual shipping page.
                 pass
 
-            try:
-                # only click on "Individueller Versand" when the price input is not available, otherwise it's already checked
-                # (important for mode = UPDATE)
-                await self.web_find(By.ID, "ad-individual-shipping-price", timeout = short_timeout)
-            except TimeoutError:
+            # only click on "Individueller Versand" when the price input is not available, otherwise it's already checked
+            # (important for mode = UPDATE)
+            individual_price_elem = await self.web_probe(By.ID, "ad-individual-shipping-price", timeout = short_timeout)
+            if individual_price_elem is None:
                 # Input not visible yet; click the individual shipping option.
                 try:
                     await self.web_click(By.ID, "ad-individual-shipping-checkbox-control")

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -220,7 +220,6 @@ kleinanzeigen_bot/__init__.py:
 
   __set_condition:
     "Unable to close condition dialog!": "Kann den Dialog für Artikelzustand nicht schließen!"
-    "Unable to open condition dialog and select condition [%s]": "Zustandsdialog konnte nicht geöffnet und Zustand [%s] nicht ausgewählt werden"
     "Unable to select condition [%s]": "Zustand [%s] konnte nicht ausgewählt werden"
     "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"
 

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1058,6 +1058,22 @@ class WebScrapingMixin:
             attempt, description = f"web_find({selector_type.name}, {selector_value})", key = "default", override = timeout
         )
 
+    async def web_probe(self, selector_type:By, selector_value:str, *, parent:Element | None = None, timeout:int | float | None = None) -> Element | None:
+        """Single-attempt element lookup for branch probes.
+
+        Returns the element when found, otherwise None. Unlike web_find, this helper
+        intentionally does not apply retry/backoff because probe absence is a valid
+        branch outcome on settled DOM states.
+
+        :param timeout: timeout in seconds (defaults to quick_dom when omitted)
+        :raises Exception: non-timeout browser/runtime exceptions are propagated
+        """
+        probe_timeout = self._timeout("quick_dom", timeout)
+        try:
+            return await self._web_find_once(selector_type, selector_value, probe_timeout, parent = parent)
+        except TimeoutError:
+            return None
+
     async def web_find_all(self, selector_type:By, selector_value:str, *, parent:Element | None = None, timeout:int | float | None = None) -> list[Element]:
         """
         Locates multiple HTML elements by the given selector type and value.

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3174,6 +3174,7 @@ class TestShippingDialogFlow:
             await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
 
             click_args = [c.args for c in mock_click.await_args_list]
+            assert any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
             assert any("Fertig" in str(a[1]) for a in click_args if len(a) >= 2)
             mock_input.assert_awaited_once_with(By.ID, "ad-individual-shipping-price", "4,95")
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2925,7 +2925,9 @@ class TestConditionSelector:
 
             mock_find.side_effect = find_side_effect
 
-            await getattr(test_bot, "_KleinanzeigenBot__set_condition")("ok")
+            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("ok")
+
+            assert handled is True
 
             clicked_xpath_selectors = [str(call.args[1]) for call in mock_click.await_args_list if len(call.args) > 1]
             assert any("contains(@for, '.condition')" in selector for selector in clicked_xpath_selectors)
@@ -2933,18 +2935,18 @@ class TestConditionSelector:
             assert any("Bestätigen" in selector for selector in clicked_xpath_selectors)
 
     @pytest.mark.asyncio
-    async def test_condition_missing_selector_raises(self, test_bot:KleinanzeigenBot) -> None:
-        """Missing condition trigger should fail fast to avoid stale condition data."""
+    async def test_condition_missing_selector_returns_not_handled(self, test_bot:KleinanzeigenBot) -> None:
+        """Missing condition trigger should return not-handled and use generic fallback path."""
 
-        async def click_side_effect(selector_type:By, selector_value:str, *_:Any, **__:Any) -> None:
+        async def find_side_effect(selector_type:By, selector_value:str, *_:Any, **__:Any) -> Element:
             if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value and "@aria-haspopup='dialog'" in selector_value:
                 raise TimeoutError("missing trigger")
+            raise TimeoutError("unexpected selector")
 
-        with (
-            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = click_side_effect),
-            pytest.raises(TimeoutError, match = "Failed to set attribute 'condition_s'"),
-        ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_condition")("ok")
+        with patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect):
+            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("ok")
+
+        assert handled is False
 
     @pytest.mark.asyncio
     async def test_condition_unknown_value_raises(self, test_bot:KleinanzeigenBot) -> None:
@@ -2969,17 +2971,43 @@ class TestConditionSelector:
             with pytest.raises(TimeoutError, match = "Failed to set attribute 'condition_s'"):
                 await getattr(test_bot, "_KleinanzeigenBot__set_condition")("defect")
 
+    @pytest.mark.asyncio
+    async def test_condition_rejects_shipping_trigger(self, test_bot:KleinanzeigenBot) -> None:
+        """Condition dialog path should not click shipping trigger controls."""
+        trigger = MagicMock()
+        trigger.attrs = {
+            "id": "ad-shipping-options",
+            "aria-controls": None,
+            "aria-haspopup": "dialog",
+        }
+
+        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element:
+            if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
+                return trigger
+            raise TimeoutError("unexpected selector")
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("new")
+
+        assert handled is False
+        # Regression guard: wrong shipping trigger must never be clicked by condition handler
+        mock_click.assert_not_awaited()
+
 
 class TestConditionFallbackToGenericHandler:
-    """Regression tests for condition_s falling back to generic attribute handler when dialog is unavailable.
+    """Regression tests for condition_s fallback behavior.
 
-    When __set_condition raises TimeoutError (e.g. category uses a button-combobox instead of a dialog),
-    __set_special_attributes should fall through to the generic XPath-based handler.
+    When __set_condition reports "not handled" (e.g. category uses a button-combobox
+    instead of a dialog), __set_special_attributes should fall through to the generic
+    XPath-based handler.
     """
 
     @pytest.mark.asyncio
-    async def test_condition_falls_back_to_generic_handler_on_dialog_timeout(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
-        """When condition dialog is not available, generic handler should be used as fallback."""
+    async def test_condition_falls_back_to_generic_handler_when_dialog_not_handled(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        """When condition dialog is not handled, generic handler should be used as fallback."""
         ad_cfg = Ad.model_validate(base_ad_config | {"category": "185/249", "special_attributes": {"condition_s": "new"}, "shipping_type": "PICKUP"})
 
         button_elem = MagicMock()
@@ -2998,7 +3026,7 @@ class TestConditionFallbackToGenericHandler:
                 test_bot,
                 "_KleinanzeigenBot__set_condition",
                 new_callable = AsyncMock,
-                side_effect = TimeoutError("dialog not available"),
+                return_value = False,
             ) as mock_set_condition,
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [button_elem]),
             patch.object(
@@ -3013,6 +3041,25 @@ class TestConditionFallbackToGenericHandler:
         mock_select_combobox.assert_awaited_once_with("modellbau.condition", "new")
 
     @pytest.mark.asyncio
+    async def test_condition_timeout_propagates_instead_of_falling_back(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        """Real condition dialog failures should propagate and not silently use generic fallback."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"category": "161/176", "special_attributes": {"condition_s": "ok"}})
+
+        with (
+            patch.object(
+                test_bot,
+                "_KleinanzeigenBot__set_condition",
+                new_callable = AsyncMock,
+                side_effect = TimeoutError("dialog timeout"),
+            ),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock) as mock_find_all,
+            pytest.raises(TimeoutError, match = "dialog timeout"),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+
+        mock_find_all.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_condition_uses_dialog_when_available(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
         """When condition dialog works, it should be used without falling back."""
         ad_cfg = Ad.model_validate(base_ad_config | {"category": "161/176", "special_attributes": {"condition_s": "ok"}})
@@ -3021,6 +3068,7 @@ class TestConditionFallbackToGenericHandler:
             test_bot,
             "_KleinanzeigenBot__set_condition",
             new_callable = AsyncMock,
+            return_value = True,
         ) as mock_set_condition:
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2529,6 +2529,7 @@ class TestKleinanzeigenBotShippingOptions:
             patch.object(test_bot, "web_execute", side_effect = mock_web_execute),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = category_path_elem),
             patch.object(test_bot, "web_select", new_callable = AsyncMock),
             patch.object(test_bot, "web_input", new_callable = AsyncMock),
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
@@ -2551,8 +2552,6 @@ class TestKleinanzeigenBotShippingOptions:
                     return shipping_size_radio
                 if selector_type == By.XPATH and '@type="checkbox"' in selector_value and "@value=" in selector_value:
                     return shipping_checkbox
-                if selector_value == "ad-category-path":
-                    return category_path_elem
                 return None
 
             mock_find.side_effect = mock_find_side_effect
@@ -3075,6 +3074,37 @@ class TestConditionFallbackToGenericHandler:
         mock_set_condition.assert_awaited_once_with("ok")
 
 
+class TestCategoryProbeBehavior:
+    """Tests for category marker probing without retry backoff."""
+
+    @pytest.mark.asyncio
+    async def test_set_category_uses_probe_for_auto_selected_marker(self, test_bot:KleinanzeigenBot) -> None:
+        """Category marker lookup should use web_probe with quick_dom timeout."""
+        category_marker = MagicMock()
+        category_marker.apply = AsyncMock(return_value = "Auto Category")
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = category_marker) as mock_probe,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock),
+            patch.object(test_bot, "web_open", new_callable = AsyncMock),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_category")("185/249", "data/my_ads/ad.yaml")
+
+        mock_probe.assert_awaited_once_with(By.ID, "ad-category-path")
+
+    @pytest.mark.asyncio
+    async def test_set_category_without_explicit_category_requires_probe_match(self, test_bot:KleinanzeigenBot) -> None:
+        """When no category is configured, missing marker should fail fast."""
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            pytest.raises(AssertionError, match = "No category specified"),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_category")(None, "data/my_ads/ad.yaml")
+
+
 class TestShippingDialogFlow:
     """Regression tests for shipping dialog flow using new radio selectors only."""
 
@@ -3119,6 +3149,7 @@ class TestShippingDialogFlow:
 
         with (
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
@@ -3140,11 +3171,33 @@ class TestShippingDialogFlow:
 
         with (
             patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = click_side_effect),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             pytest.raises(TimeoutError, match = "Unable to close shipping dialog!"),
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+
+    @pytest.mark.asyncio
+    async def test_shipping_without_options_does_not_toggle_checkbox_when_price_input_visible(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """When price input is already visible, individual-shipping checkbox is not toggled."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_input", new_callable = AsyncMock),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+
+        click_args = [c.args for c in mock_click.await_args_list]
+        assert not any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
 
 
 class TestShippingOptionsDialog:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2524,7 +2524,7 @@ class TestKleinanzeigenBotShippingOptions:
             patch.object(test_bot, "web_execute", side_effect = mock_web_execute),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = category_path_elem),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock) as mock_probe,
             patch.object(test_bot, "web_select", new_callable = AsyncMock),
             patch.object(test_bot, "web_input", new_callable = AsyncMock),
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
@@ -2536,6 +2536,14 @@ class TestKleinanzeigenBotShippingOptions:
             patch("builtins.input", return_value = ""),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
         ):
+
+            async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+                if selector_type == By.ID and selector_value == "ad-category-path":
+                    return category_path_elem
+                return None
+
+            mock_probe.side_effect = probe_side_effect
+
             # Mock web_find to simulate element detection
             async def mock_find_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
                 if selector_value == "meta[name=_csrf]":
@@ -2896,6 +2904,9 @@ class TestConditionSelector:
     async def test_condition_selects_radio_by_value(self, test_bot:KleinanzeigenBot) -> None:
         """Condition selection should resolve radios by value in the new dialog."""
         dialog = MagicMock()
+        trigger = MagicMock()
+        trigger.attrs = {"id": "condition-trigger", "aria-controls": "condition-dialog"}
+        trigger.click = AsyncMock()
         radio = MagicMock()
         radio_attrs = MagicMock()
         radio_attrs.id = "radio-condition-ok"
@@ -2904,6 +2915,7 @@ class TestConditionSelector:
         radio.click = AsyncMock()
 
         with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = trigger),
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
@@ -2924,7 +2936,7 @@ class TestConditionSelector:
             assert handled is True
 
             clicked_xpath_selectors = [str(call.args[1]) for call in mock_click.await_args_list if len(call.args) > 1]
-            assert any("contains(@for, '.condition')" in selector for selector in clicked_xpath_selectors)
+            trigger.click.assert_awaited_once()
             assert any("label[@for=" in selector and "radio-condition-ok" in selector for selector in clicked_xpath_selectors)
             assert any("Bestätigen" in selector for selector in clicked_xpath_selectors)
 
@@ -2937,7 +2949,10 @@ class TestConditionSelector:
                 raise TimeoutError("missing trigger")
             raise TimeoutError("unexpected selector")
 
-        with patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect):
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
+        ):
             handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("ok")
 
         assert handled is False
@@ -2946,6 +2961,9 @@ class TestConditionSelector:
     async def test_condition_unknown_value_raises(self, test_bot:KleinanzeigenBot) -> None:
         """Unknown condition values should raise when no matching radio option is present."""
         dialog = MagicMock()
+        trigger = MagicMock()
+        trigger.attrs = {"id": "condition-trigger", "aria-controls": "condition-dialog"}
+        trigger.click = AsyncMock()
 
         async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element:
             if selector_type != By.XPATH:
@@ -2957,6 +2975,7 @@ class TestConditionSelector:
             raise TimeoutError("selector not found")
 
         with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = trigger),
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
         ):
@@ -2981,6 +3000,7 @@ class TestConditionSelector:
             raise TimeoutError("unexpected selector")
 
         with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = trigger),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
@@ -3186,13 +3206,14 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "web_input", new_callable = AsyncMock),
+            patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
 
         click_args = [c.args for c in mock_click.await_args_list]
         assert not any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
+        mock_input.assert_awaited_once_with(By.ID, "ad-individual-shipping-price", "4,95")
 
 
 class TestShippingOptionsDialog:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2993,6 +2993,7 @@ class TestConditionSelector:
             "aria-controls": None,
             "aria-haspopup": "dialog",
         }
+        trigger.click = AsyncMock()
 
         async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element:
             if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
@@ -3008,6 +3009,7 @@ class TestConditionSelector:
 
         assert handled is False
         # Regression guard: wrong shipping trigger must never be clicked by condition handler
+        trigger.click.assert_not_awaited()
         mock_click.assert_not_awaited()
 
 
@@ -3094,7 +3096,7 @@ class TestCategoryProbeBehavior:
 
     @pytest.mark.asyncio
     async def test_set_category_uses_probe_for_auto_selected_marker(self, test_bot:KleinanzeigenBot) -> None:
-        """Category marker lookup should use web_probe with quick_dom timeout."""
+        """In __set_category, category marker lookup should go through web_probe."""
         category_marker = MagicMock()
         category_marker.apply = AsyncMock(return_value = "Auto Category")
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -147,11 +147,6 @@ class TestKleinanzeigenBotInitialization:
         assert test_bot.log_file_path is not None
         assert test_bot.file_log is None
 
-    def test_get_version_returns_correct_version(self, test_bot:KleinanzeigenBot) -> None:
-        """Verify version retrieval works correctly."""
-        with patch("kleinanzeigen_bot.__version__", "1.2.3"):
-            assert test_bot.get_version() == "1.2.3"
-
     def test_resolve_workspace_skips_help(self, test_bot:KleinanzeigenBot) -> None:
         """Ensure workspace resolution returns early for help."""
         test_bot.command = "help"

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -839,12 +839,15 @@ class TestSelectorTimeoutMessages:
         web_scraper.config.timeouts.retry_max_attempts = 5
 
         once_mock = AsyncMock(side_effect = TimeoutError("still missing"))
+        retry_mock = AsyncMock()
         cast(Any, web_scraper)._web_find_once = once_mock
+        cast(Any, web_scraper)._run_with_timeout_retries = retry_mock
 
         result = await web_scraper.web_probe(By.CSS_SELECTOR, ".missing")
 
         assert result is None
         once_mock.assert_awaited_once()
+        retry_mock.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_web_check_unsupported_attribute(self, web_scraper:WebScrapingMixin, mock_page:TrulyAwaitableMockPage) -> None:
@@ -989,27 +992,18 @@ class TestWebScrapingSessionManagement:
         stop_mock.assert_called_once()
         mock_child.kill.assert_called_once()
 
-    def test_close_browser_session_skips_psutil_when_pid_is_none(self) -> None:
-        """When _process_pid is None, psutil.Process should not be called but stop() should."""
+    @pytest.mark.parametrize(
+        "pid_value",
+        [
+            pytest.param(None, id = "none-pid"),
+            pytest.param(MagicMock(), id = "non-int-pid"),
+        ],
+    )
+    def test_close_browser_session_skips_psutil_when_pid_is_invalid(self, pid_value:object) -> None:
+        """When _process_pid is not a valid int, psutil.Process should not be called but stop() should."""
         scraper = WebScrapingMixin()
         scraper.browser = MagicMock()
-        scraper.browser._process_pid = None
-        stop_mock = scraper.browser.stop = MagicMock()
-        scraper.page = MagicMock(spec = Page)
-
-        with patch("psutil.Process") as mock_proc:
-            scraper.close_browser_session()
-
-        mock_proc.assert_not_called()
-        stop_mock.assert_called_once()
-        assert scraper.browser is None
-        assert scraper.page is None
-
-    def test_close_browser_session_skips_psutil_when_pid_is_non_int(self) -> None:
-        """When _process_pid is non-integer (e.g., MagicMock), psutil.Process should not be called."""
-        scraper = WebScrapingMixin()
-        scraper.browser = MagicMock()
-        scraper.browser._process_pid = MagicMock()  # Simulate mock object in tests
+        scraper.browser._process_pid = pid_value
         stop_mock = scraper.browser.stop = MagicMock()
         scraper.page = MagicMock(spec = Page)
 

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -797,6 +797,56 @@ class TestSelectorTimeoutMessages:
         assert once_call.args[2] == 0.42
 
     @pytest.mark.asyncio
+    async def test_web_probe_returns_element_without_retry(self, web_scraper:WebScrapingMixin) -> None:
+        """web_probe should use a single _web_find_once attempt and skip retry helper."""
+        element = AsyncMock(spec = Element)
+        once_mock = AsyncMock(return_value = element)
+        retry_mock = AsyncMock()
+
+        cast(Any, web_scraper)._web_find_once = once_mock
+        cast(Any, web_scraper)._run_with_timeout_retries = retry_mock
+
+        result = await web_scraper.web_probe(By.ID, "probe-id")
+
+        assert result is element
+        once_call = once_mock.await_args_list[0]
+        assert once_call.args[:2] == (By.ID, "probe-id")
+        assert once_call.args[2] == web_scraper._timeout("quick_dom")
+        retry_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_web_probe_returns_none_on_timeout_without_retries(self, web_scraper:WebScrapingMixin) -> None:
+        """web_probe should return None on TimeoutError and never use retry helper."""
+        once_mock = AsyncMock(side_effect = TimeoutError("not found"))
+        retry_mock = AsyncMock()
+
+        cast(Any, web_scraper)._web_find_once = once_mock
+        cast(Any, web_scraper)._run_with_timeout_retries = retry_mock
+
+        result = await web_scraper.web_probe(By.ID, "missing-id", timeout = 0.2)
+
+        assert result is None
+        once_call = once_mock.await_args_list[0]
+        assert once_call.args[:2] == (By.ID, "missing-id")
+        assert once_call.args[2] == 0.2
+        once_mock.assert_awaited_once()
+        retry_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_web_probe_ignores_global_retry_config(self, web_scraper:WebScrapingMixin) -> None:
+        """Global retry settings should not change web_probe single-attempt behavior."""
+        web_scraper.config.timeouts.retry_enabled = True
+        web_scraper.config.timeouts.retry_max_attempts = 5
+
+        once_mock = AsyncMock(side_effect = TimeoutError("still missing"))
+        cast(Any, web_scraper)._web_find_once = once_mock
+
+        result = await web_scraper.web_probe(By.CSS_SELECTOR, ".missing")
+
+        assert result is None
+        once_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_web_check_unsupported_attribute(self, web_scraper:WebScrapingMixin, mock_page:TrulyAwaitableMockPage) -> None:
         """web_check should raise for unsupported attribute queries."""
         mock_element = AsyncMock(spec = Element)


### PR DESCRIPTION
## ℹ️ Description
*Provide a concise summary of the changes introduced in this pull request.*

- Link to the related issue(s): Issue #956, Issue #938
- This change addresses a selector-collision regression where `condition_s` handling could resolve to shipping controls (`ad-shipping-options`) and open the wrong dialog, and improves publish performance by replacing retry-heavy branch probes with a single-attempt probe API for settled DOM checks.

## 📋 Changes Summary

- Added `web_probe(...)` in `WebScrapingMixin` for single-attempt, no-retry DOM presence checks (returns `Element | None`).
- Migrated two high-cost probe call sites to `web_probe`:
  - category auto-selected marker lookup (`ad-category-path`) in `__set_category`
  - individual shipping price visibility probe (`ad-individual-shipping-price`) in `__set_shipping`
- Polished `condition_s` handling to avoid condition/shipping trigger collisions and keep fallback behavior explicit when dialog handling is not applicable.
- Added/updated high-signal tests for:
  - probe semantics (no retry even when global retries are enabled)
  - migrated category/shipping probe branches
  - condition trigger collision and fallback behavior
- Applied targeted test-scout cleanup in touched files:
  - removed one low-signal version getter test
  - consolidated duplicate invalid-pid close-session tests into one parametrized test
- No dependency, schema, or configuration changes were introduced.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced spurious errors and blocking waits when setting condition, category, and shipping options; probe-based checks improve automatic selection, fallback behavior, and avoid incorrect clicks.

* **Tests**
  * Expanded and refactored unit tests to cover probe behavior, dialog handling, fallback scenarios, and category/shipping regressions to ensure more robust, faster interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->