### PR TITLE
feat(pricing): support update-mode reductions and verify previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Usage: kleinanzeigen-bot COMMAND [OPTIONS]
 
 Commands:
   publish  - (re-)publishes ads
-  verify   - verifies the configuration files
+  verify   - verifies the configuration files and previews auto-price-reduction outcomes
   delete   - deletes ads
   update   - updates published ads
   download - downloads one or multiple ads

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Usage: kleinanzeigen-bot COMMAND [OPTIONS]
 
 Commands:
   publish  - (re-)publishes ads
-  verify   - verifies the configuration files and previews auto-price-reduction outcomes
+  verify   - verifies the configuration files and previews automatic price reduction outcomes
   delete   - deletes ads
   update   - updates published ads
   download - downloads one or multiple ads

--- a/docs/AD_CONFIGURATION.md
+++ b/docs/AD_CONFIGURATION.md
@@ -101,9 +101,9 @@ price_type:  # one of: FIXED, NEGOTIABLE, GIVE_AWAY (default: NEGOTIABLE)
 
 ### Automatic Price Reduction
 
-When `auto_price_reduction.enabled` is set to `true`, the bot lowers the configured `price` every time the ad is reposted via the `publish` command.
+When `auto_price_reduction.enabled` is set to `true`, the bot evaluates whether a price reduction is due each time the ad is republished via the `publish` command — the price is only lowered when all eligibility gates (repost cycle, day delay, minimum floor) are satisfied.
 
-**Important:** By default, price reductions only apply when using the `publish` command (which deletes the old ad and creates a new one). Using the `update` command does NOT trigger price reductions or increment `repost_count`. Set `on_update: true` (see below) to also apply reductions during update runs.
+**Important:** By default, price reductions only apply when using the `publish` command (which deletes the old ad and creates a new one). Using the `update` command does NOT advance the reduction cycle. Set `on_update: true` (see below) to also apply reductions during update runs. Regardless of the `on_update` setting, the effective reduced price is always restored before submitting an update — this prevents previously applied reductions from being silently lost.
 
 `repost_count` is tracked for every ad (and persisted inside the corresponding `ad_*.yaml`) so reductions continue across runs.
 
@@ -200,7 +200,7 @@ This ensures price reductions accumulate correctly regardless of whether you use
 The `verify` command previews pricing outcomes for both modes:
 
 - **Publish preview**: Always shown when `auto_price_reduction.enabled` is `true`. Shows the effective price after applying reductions based on the current `repost_count`, `price_reduction_count`, and delay settings.
-- **Update preview**: Always shown when `auto_price_reduction.enabled` is `true`. If `on_update` is `true`, it shows the update-mode reduction outcome. If `on_update` is `false` (default), it explicitly reports updates as disabled and shows no reduction.
+- **Update preview**: Always shown when `auto_price_reduction.enabled` is `true`. Reports the update-mode outcome: if `on_update` is `true`, it shows the reduction result; if `on_update` is `false` (default), it reports that update-mode reductions are disabled and shows the restored effective price (no new cycle).
 
 ```yaml
 # Example: enable reductions for both publish and update

--- a/docs/AD_CONFIGURATION.md
+++ b/docs/AD_CONFIGURATION.md
@@ -200,7 +200,7 @@ This ensures price reductions accumulate correctly regardless of whether you use
 The `verify` command previews pricing outcomes for both modes:
 
 - **Publish preview**: Always shown when `auto_price_reduction.enabled` is `true`. Shows the effective price after applying reductions based on the current `repost_count`, `price_reduction_count`, and delay settings.
-- **Update preview**: Shown when `on_update` is `true`. Displays what the price would be after an update-mode reduction. When `on_update` is `false` (default), the update preview notes that price reductions are disabled for updates and shows no reduction.
+- **Update preview**: Always shown when `auto_price_reduction.enabled` is `true`. If `on_update` is `true`, it shows the update-mode reduction outcome. If `on_update` is `false` (default), it explicitly reports updates as disabled and shows no reduction.
 
 ```yaml
 # Example: enable reductions for both publish and update

--- a/docs/AD_CONFIGURATION.md
+++ b/docs/AD_CONFIGURATION.md
@@ -321,7 +321,10 @@ created_on:  # ISO timestamp when the ad was first published
 updated_on:  # ISO timestamp when the ad was last published
 content_hash:  # Hash of the ad content, used to detect changes
 repost_count:  # How often the ad has been (re)published; used for automatic price reductions
+price_reduction_count:  # Auto-managed reduction cycle counter (starts at 0); used with price to recompute effective reduced price
 ```
+
+`price_reduction_count` is maintained by the bot after successful runs and should not be edited manually.
 
 ## Complete Example
 

--- a/docs/AD_CONFIGURATION.md
+++ b/docs/AD_CONFIGURATION.md
@@ -101,9 +101,9 @@ price_type:  # one of: FIXED, NEGOTIABLE, GIVE_AWAY (default: NEGOTIABLE)
 
 ### Automatic Price Reduction
 
-When `auto_price_reduction.enabled` is set to `true`, the bot lowers the configured `price` every time the ad is reposted.
+When `auto_price_reduction.enabled` is set to `true`, the bot lowers the configured `price` every time the ad is reposted via the `publish` command.
 
-**Important:** Price reductions only apply when using the `publish` command (which deletes the old ad and creates a new one). Using the `update` command to modify ad content does NOT trigger price reductions or increment `repost_count`.
+**Important:** By default, price reductions only apply when using the `publish` command (which deletes the old ad and creates a new one). Using the `update` command does NOT trigger price reductions or increment `repost_count`. Set `on_update: true` (see below) to also apply reductions during update runs.
 
 `repost_count` is tracked for every ad (and persisted inside the corresponding `ad_*.yaml`) so reductions continue across runs.
 
@@ -111,7 +111,7 @@ When `auto_price_reduction.enabled` is set to `true`, the bot lowers the configu
 
 **Note:** `repost_count` and price reduction counters are only incremented and persisted after a successful publish. Failed publish attempts do not advance the counters.
 
-When automatic price reduction is enabled, each `publish` run logs one clear INFO message per ad summarizing the outcome—whether the price was reduced, kept, or the reduction was delayed (and why). The `verify` command also previews these outcomes for all configured ads so you can validate your pricing configuration without triggering a publish cycle. Ads without `auto_price_reduction` configured are silently skipped at default log level.
+When automatic price reduction is enabled, each `publish` (and optionally `update`) run logs one clear INFO message per ad summarizing the outcome—whether the price was reduced, kept, or the reduction was delayed (and why). The `verify` command also previews these outcomes for all configured ads so you can validate your pricing configuration without triggering a publish cycle. Ads without `auto_price_reduction` configured are silently skipped at default log level.
 
 If you run with `-v` / `--verbose`, the bot additionally logs structured decision details (repost counts, cycle state, day delay, reference timestamps) and the full cycle-by-cycle calculation trace (base price, reduction value, rounded step result, and floor clamp).
 
@@ -125,6 +125,7 @@ auto_price_reduction:
               # (use 0 for no lower bound, prefer whole euros for predictability)
   delay_reposts:  # Number of reposts to wait before first reduction (default: 0)
   delay_days:     # Number of days to wait after publication before reductions (default: 0)
+  on_update:      # Also apply price reductions during the update command (default: false)
 ```
 
 **Note:** All prices are rounded to whole euros after each reduction step.
@@ -173,9 +174,51 @@ Combined timeline example: with `republication_interval: 3`, `delay_reposts: 1`,
 - day 4: second publish, still waiting for repost delay
 - day 8: third publish, first reduction can apply
 
+#### Update-Mode Price Reductions (`on_update`)
+
+By default (`on_update: false`), price reductions only apply during `publish` (full republish). Set `on_update: true` to also apply reductions when running the `update` command (in-place ad modification).
+
+**Update-mode semantics differ from publish-mode in two ways:**
+
+- `delay_days` applies normally — the bot still checks that enough days have elapsed since the last publication before reducing.
+- `delay_reposts` is **ignored** — update-mode reductions always evaluate based on the current `price_reduction_count` regardless of `repost_count`, because `update` does not increment `repost_count`.
+
+This means an ad with `delay_reposts: 2` that has only been published once can still receive a price reduction via `update` if `on_update: true` and `delay_days` has elapsed.
+
+#### Restore-First Behavior
+
+When `on_update` is enabled, the reduced effective price is preserved across mixed `publish`/`update` runs:
+
+1. The ad file keeps the configured base `price`.
+2. The bot persists `price_reduction_count` after successful runs and recalculates the effective reduced price from `price` + `price_reduction_count` on each run.
+3. If you manually edit the `price` field in the ad file, the next run uses the new value as the base for recalculation.
+
+This ensures price reductions accumulate correctly regardless of whether you use `publish`, `update`, or both.
+
+#### Verify Command Preview
+
+The `verify` command previews pricing outcomes for both modes:
+
+- **Publish preview**: Always shown when `auto_price_reduction.enabled` is `true`. Shows the effective price after applying reductions based on the current `repost_count`, `price_reduction_count`, and delay settings.
+- **Update preview**: Shown when `on_update` is `true`. Displays what the price would be after an update-mode reduction. When `on_update` is `false` (default), the update preview notes that price reductions are disabled for updates and shows no reduction.
+
+```yaml
+# Example: enable reductions for both publish and update
+auto_price_reduction:
+  enabled: true
+  strategy: PERCENTAGE
+  amount: 10
+  min_price: 90
+  delay_reposts: 0
+  delay_days: 7
+  on_update: true
+```
+
+With this configuration, the price is reduced on every `publish` and also on `update` runs, as long as at least 7 days have passed since the last publication.
+
 Set `auto_price_reduction.enabled: false` (or omit the entire `auto_price_reduction` section) to keep the existing behavior—prices stay fixed and `repost_count` only acts as tracked metadata for future changes.
 
-You can configure `auto_price_reduction` once under `ad_defaults` in `config.yaml`. The `min_price` can be set there or overridden per ad file as needed.
+You can configure `auto_price_reduction` once under `ad_defaults` in `config.yaml`. The `min_price` and `on_update` can be set there or overridden per ad file as needed.
 
 ### Special Attributes
 
@@ -307,6 +350,7 @@ auto_price_reduction:
   min_price: 90
   delay_reposts: 0
   delay_days: 0
+  on_update: false
 
 shipping_type: SHIPPING
 shipping_options:
@@ -338,7 +382,7 @@ republication_interval: 7
 ## Troubleshooting
 
 - **Schema validation errors**: Run `kleinanzeigen-bot verify` (binary) or `pdm run app verify` (source) to see which fields fail validation.
-- **Price reduction not applying**: Confirm `auto_price_reduction.enabled` is `true`, `min_price` is set, and you are using `publish` (not `update`). Run `kleinanzeigen-bot verify` to preview outcomes, or add `-v` for detailed decision data including repost/day-delay state. Remember ad-level values override `ad_defaults`.
+- **Price reduction not applying**: Confirm `auto_price_reduction.enabled` is `true`, `min_price` is set, and you are using `publish` (not `update`, unless `on_update: true`). Run `kleinanzeigen-bot verify` to preview outcomes, or add `-v` for detailed decision data including repost/day-delay state. Remember ad-level values override `ad_defaults`.
 - **Shipping configuration issues**: Use `shipping_type: SHIPPING` when setting `shipping_costs` or `shipping_options`, and pick options from a single size group (S/M/L).
 - **Category not found**: Verify the category name or ID and check any custom mappings in `config.yaml`.
 - **File naming/prefix mismatch**: Ensure ad files match your `ad_files` glob and prefix (default `ad_`).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,8 +107,7 @@ ad_defaults:
 ```
 
 - `ad_defaults.republication_interval` controls when ads become due for republishing.
-- Automatic price reductions (including `delay_reposts` and `delay_days`) are evaluated during `publish` runs.
-- When `on_update: true` is set, reductions also apply during `update` runs (using `delay_days` but ignoring `delay_reposts`).
+- Automatic price reductions are always evaluated during `publish` runs, and they also apply during `update` runs when `on_update: true` is set (using `delay_days` but ignoring `delay_reposts`).
 - Reductions do not run in the background between runs.
 - When auto price reduction is enabled, each `publish` (and optionally `update`) run logs the reduction decision.
 - The `verify` command previews pricing outcomes for both publish and update modes.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,11 +107,13 @@ ad_defaults:
 ```
 
 - `ad_defaults.republication_interval` controls when ads become due for republishing.
-- Automatic price reductions (including `delay_reposts` and `delay_days`) are evaluated only during `publish` runs.
-- Reductions do not run in the background between runs, and `update` does not evaluate or apply reductions.
-- When auto price reduction is enabled, each `publish` run logs the reduction decision.
+- Automatic price reductions (including `delay_reposts` and `delay_days`) are evaluated during `publish` runs.
+- When `on_update: true` is set, reductions also apply during `update` runs (using `delay_days` but ignoring `delay_reposts`).
+- Reductions do not run in the background between runs.
+- When auto price reduction is enabled, each `publish` (and optionally `update`) run logs the reduction decision.
+- The `verify` command previews pricing outcomes for both publish and update modes.
 - `-v/--verbose` adds a detailed reduction calculation trace.
-- For full behavior and examples (including timeline examples), see [AD_CONFIGURATION.md](./AD_CONFIGURATION.md).
+- For full behavior and examples (including timeline examples, update-mode semantics, and restore-first behavior), see [AD_CONFIGURATION.md](./AD_CONFIGURATION.md).
 
 > **Tip:** For current defaults of all timeout and diagnostic settings, run `kleinanzeigen-bot create-config` or see the [JSON schema](https://raw.githubusercontent.com/Second-Hand-Friends/kleinanzeigen-bot/main/schemas/config.schema.json).
 

--- a/docs/config.default.yaml
+++ b/docs/config.default.yaml
@@ -64,6 +64,9 @@ ad_defaults:
     # number of days to wait after publication before applying automatic price reductions
     delay_days: 0
 
+    # also apply automatic price reduction during update runs (MODIFY mode). delay_days applies, delay_reposts is ignored
+    on_update: false
+
   # shipping method for the item
   # Examples (choose one):
   #   • PICKUP

--- a/schemas/ad.schema.json
+++ b/schemas/ad.schema.json
@@ -80,6 +80,12 @@
           "minimum": 0,
           "title": "Delay Days",
           "type": "integer"
+        },
+        "on_update": {
+          "default": false,
+          "description": "also apply automatic price reduction during update runs (MODIFY mode). delay_days applies, delay_reposts is ignored",
+          "title": "On Update",
+          "type": "boolean"
         }
       },
       "title": "AutoPriceReductionConfig",

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -217,6 +217,12 @@
           "minimum": 0,
           "title": "Delay Days",
           "type": "integer"
+        },
+        "on_update": {
+          "default": false,
+          "description": "also apply automatic price reduction during update runs (MODIFY mode). delay_days applies, delay_reposts is ignored",
+          "title": "On Update",
+          "type": "boolean"
         }
       },
       "title": "AutoPriceReductionConfig",

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -205,7 +205,12 @@ class PriceReductionDecision:
 
 
 def evaluate_auto_price_reduction(ad_cfg:Ad, _ad_file_relative:str, *, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> PriceReductionDecision:
-    """Evaluate automatic price reduction without mutating ``ad_cfg``."""
+    """Evaluate automatic price reduction without mutating ``ad_cfg``.
+
+    Note:
+        ``_ad_file_relative`` is intentionally unused and kept for API parity
+        with :func:`apply_auto_price_reduction`.
+    """
     cfg = ad_cfg.auto_price_reduction
     on_update = bool(getattr(cfg, "on_update", False))
     base_price = ad_cfg.price

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -339,7 +339,29 @@ def evaluate_auto_price_reduction(ad_cfg:Ad, _ad_file_relative:str, *, mode:AdUp
 
     next_cycle = applied_cycles + 1
     result_price = calculate_auto_price(base_price = base_price, auto_price_reduction = cfg, target_reduction_cycle = next_cycle)
-    cycle_advanced = result_price is not None and result_price != restored_price
+
+    if result_price is None:
+        return PriceReductionDecision(
+            mode = mode,
+            enabled = True,
+            on_update = on_update,
+            base_price = base_price,
+            restored_price = restored_price,
+            result_price = None,
+            applied_cycles = applied_cycles,
+            next_cycle = None,
+            cycle_advanced = False,
+            reason = "calculation_failed",
+            total_reposts = total_reposts,
+            delay_reposts = delay_reposts,
+            eligible_cycles = eligible_cycles,
+            delay_days = delay_days,
+            elapsed_days = elapsed_days,
+            reference = reference,
+            delay_reposts_ignored = delay_reposts_ignored,
+        )
+
+    cycle_advanced = result_price != restored_price
 
     return PriceReductionDecision(
         mode = mode,
@@ -349,9 +371,9 @@ def evaluate_auto_price_reduction(ad_cfg:Ad, _ad_file_relative:str, *, mode:AdUp
         restored_price = restored_price,
         result_price = result_price,
         applied_cycles = applied_cycles,
-        next_cycle = next_cycle if cycle_advanced else None,
+        next_cycle = next_cycle,
         cycle_advanced = cycle_advanced,
-        reason = "eligible" if cycle_advanced else "no_visible_change",
+        reason = "eligible" if result_price != restored_price else "no_visible_change",
         total_reposts = total_reposts,
         delay_reposts = delay_reposts,
         eligible_cycles = eligible_cycles,
@@ -401,8 +423,9 @@ def _log_auto_price_reduction_preview(ad_file_relative:str, decision:PriceReduct
     )
     if decision.delay_reposts_ignored:
         LOG.debug(
-            "Auto price reduction preview for [%s] (update): delay_reposts=%s ignored in MODIFY mode",
+            "Auto price reduction preview for [%s] (%s): delay_reposts=%s ignored in MODIFY mode",
             ad_file_relative,
+            mode_label,
             decision.delay_reposts,
         )
 
@@ -456,6 +479,9 @@ def apply_auto_price_reduction(
 
     if decision.reason == "update_disabled":
         LOG.debug("Auto price reduction skipped for [%s] in update mode because on_update is false", ad_file_relative)
+        return
+
+    if decision.reason == "calculation_failed":
         return
 
     if decision.reason in {"repost_delay_waiting", "repost_delay_applied"}:
@@ -535,7 +561,12 @@ def apply_auto_price_reduction(
         )
 
     if decision.reason == "no_visible_change":
-        LOG.info("Auto price reduction kept price %s after attempting %s reduction cycles", decision.restored_price, applied_cycles + 1)
+        next_cycle = decision.next_cycle
+        if next_cycle is None:
+            LOG.debug("Auto price reduction skipped for [%s]: missing next_cycle for no_visible_change", ad_file_relative)
+            return
+        ad_cfg.price_reduction_count = int(next_cycle)
+        LOG.info("Auto price reduction kept price %s after attempting %s reduction cycles", decision.restored_price, next_cycle)
         return
 
     LOG.debug(

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2266,7 +2266,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             LOG.info("Publishing ad '%s'...", ad_cfg.title)
             await self.web_open(f"{self.root_url}/p-anzeige-aufgeben-schritt2.html", reload_if_already_open = True)
         else:
-            if ad_cfg.auto_price_reduction.on_update:
+            # Always run restore-first when enabled so previously applied reductions
+            # are restored even when on_update is false.  The evaluator handles
+            # the on_update guard internally (returns early without advancing).
+            if ad_cfg.auto_price_reduction.enabled:
                 apply_auto_price_reduction(ad_cfg, ad_cfg_orig, _relative_ad_path(ad_file, self.config_file_path), mode = AdUpdateStrategy.MODIFY)
 
             LOG.info("Updating ad '%s'...", ad_cfg.title)

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -260,7 +260,7 @@ def evaluate_auto_price_reduction(ad_cfg:Ad, _ad_file_relative:str, *, mode:AdUp
     if applied_cycles > 0:
         restored_price = calculate_auto_price(base_price = base_price, auto_price_reduction = cfg, target_reduction_cycle = applied_cycles)
 
-    if cfg.min_price is not None and cfg.min_price == base_price and applied_cycles <= 0:
+    if cfg.min_price is not None and cfg.min_price == base_price and applied_cycles == 0:
         return PriceReductionDecision(
             mode = mode,
             enabled = True,
@@ -565,7 +565,7 @@ def apply_auto_price_reduction(
         if next_cycle is None:
             LOG.debug("Auto price reduction skipped for [%s]: missing next_cycle for no_visible_change", ad_file_relative)
             return
-        ad_cfg.price_reduction_count = int(next_cycle)
+        ad_cfg.price_reduction_count = next_cycle
         LOG.info("Auto price reduction kept price %s after attempting %s reduction cycles", decision.restored_price, next_cycle)
         return
 

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -138,69 +138,6 @@ class ResolvedAdState(NamedTuple):
     owned:bool
 
 
-def _repost_cycle_ready(
-    ad_cfg:Ad,
-    ad_file_relative:str,
-    repost_state:tuple[int, int, int, int] | None = None,
-) -> bool:
-    """
-    Check if the repost cycle delay has been satisfied.
-
-    :param ad_cfg: The ad configuration
-    :param ad_file_relative: Relative path to the ad file for logging
-    :param repost_state: Optional precomputed repost-delay state tuple
-    :return: True if ready to apply price reduction, False otherwise
-    """
-    total_reposts, delay_reposts, applied_cycles, eligible_cycles = repost_state or _repost_delay_state(ad_cfg)
-
-    if total_reposts <= delay_reposts:
-        remaining = (delay_reposts + 1) - total_reposts
-        LOG.info(
-            "Auto price reduction delayed for [%s]: waiting %s more reposts (completed %s, applied %s reductions)",
-            ad_file_relative,
-            max(remaining, 1),  # Clamp to 1 to avoid showing "0 more reposts" when at threshold
-            total_reposts,
-            applied_cycles,
-        )
-        return False
-
-    if eligible_cycles <= applied_cycles:
-        LOG.info("Auto price reduction already applied for [%s]: %s reductions match %s eligible reposts", ad_file_relative, applied_cycles, eligible_cycles)
-        return False
-
-    return True
-
-
-def _day_delay_elapsed(
-    ad_cfg:Ad,
-    ad_file_relative:str,
-    day_delay_state:tuple[bool, int | None, datetime | None] | None = None,
-) -> bool:
-    """
-    Check if the day delay has elapsed since the ad was last published.
-
-    :param ad_cfg: The ad configuration
-    :param ad_file_relative: Relative path to the ad file for logging
-    :param day_delay_state: Optional precomputed day-delay state tuple
-    :return: True if the delay has elapsed, False otherwise
-    """
-    delay_days = ad_cfg.auto_price_reduction.delay_days
-    ready, elapsed_days, reference = day_delay_state or _day_delay_state(ad_cfg)
-
-    if delay_days == 0:
-        return True
-
-    if not reference:
-        LOG.info("Auto price reduction delayed for [%s]: waiting %s days but publish timestamp missing", ad_file_relative, delay_days)
-        return False
-
-    if not ready and elapsed_days is not None:
-        LOG.info("Auto price reduction delayed for [%s]: waiting %s days (elapsed %s)", ad_file_relative, delay_days, elapsed_days)
-        return False
-
-    return True
-
-
 def _repost_delay_state(ad_cfg:Ad) -> tuple[int, int, int, int]:
     """Return repost-delay state tuple.
 
@@ -246,7 +183,237 @@ def _relative_ad_path(ad_file:str, config_file_path:str) -> str:
         return ad_file
 
 
-def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_relative:str) -> None:
+@dataclass(frozen = True)
+class PriceReductionDecision:
+    mode:AdUpdateStrategy
+    enabled:bool
+    on_update:bool
+    base_price:int | None
+    restored_price:int | None
+    result_price:int | None
+    applied_cycles:int
+    next_cycle:int | None
+    cycle_advanced:bool
+    reason:str
+    total_reposts:int
+    delay_reposts:int
+    eligible_cycles:int
+    delay_days:int
+    elapsed_days:int | None
+    reference:datetime | None
+    delay_reposts_ignored:bool
+
+
+def evaluate_auto_price_reduction(ad_cfg:Ad, _ad_file_relative:str, *, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> PriceReductionDecision:
+    """Evaluate automatic price reduction without mutating ``ad_cfg``."""
+    cfg = ad_cfg.auto_price_reduction
+    on_update = bool(getattr(cfg, "on_update", False))
+    base_price = ad_cfg.price
+    total_reposts, delay_reposts, applied_cycles, eligible_cycles = _repost_delay_state(ad_cfg)
+    day_ready, elapsed_days, reference = _day_delay_state(ad_cfg)
+    delay_days = cfg.delay_days
+
+    restored_price = base_price
+
+    if not cfg.enabled:
+        return PriceReductionDecision(
+            mode = mode,
+            enabled = False,
+            on_update = on_update,
+            base_price = base_price,
+            restored_price = restored_price,
+            result_price = restored_price,
+            applied_cycles = applied_cycles,
+            next_cycle = None,
+            cycle_advanced = False,
+            reason = "not_configured",
+            total_reposts = total_reposts,
+            delay_reposts = delay_reposts,
+            eligible_cycles = eligible_cycles,
+            delay_days = delay_days,
+            elapsed_days = elapsed_days,
+            reference = reference,
+            delay_reposts_ignored = False,
+        )
+
+    if base_price is None:
+        return PriceReductionDecision(
+            mode = mode,
+            enabled = True,
+            on_update = on_update,
+            base_price = None,
+            restored_price = None,
+            result_price = None,
+            applied_cycles = applied_cycles,
+            next_cycle = None,
+            cycle_advanced = False,
+            reason = "missing_price",
+            total_reposts = total_reposts,
+            delay_reposts = delay_reposts,
+            eligible_cycles = eligible_cycles,
+            delay_days = delay_days,
+            elapsed_days = elapsed_days,
+            reference = reference,
+            delay_reposts_ignored = False,
+        )
+
+    if applied_cycles > 0:
+        restored_price = calculate_auto_price(base_price = base_price, auto_price_reduction = cfg, target_reduction_cycle = applied_cycles)
+
+    if cfg.min_price is not None and cfg.min_price == base_price and applied_cycles <= 0:
+        return PriceReductionDecision(
+            mode = mode,
+            enabled = True,
+            on_update = on_update,
+            base_price = base_price,
+            restored_price = restored_price,
+            result_price = restored_price,
+            applied_cycles = applied_cycles,
+            next_cycle = None,
+            cycle_advanced = False,
+            reason = "min_price_equals_price",
+            total_reposts = total_reposts,
+            delay_reposts = delay_reposts,
+            eligible_cycles = eligible_cycles,
+            delay_days = delay_days,
+            elapsed_days = elapsed_days,
+            reference = reference,
+            delay_reposts_ignored = False,
+        )
+
+    if mode == AdUpdateStrategy.MODIFY and not on_update:
+        return PriceReductionDecision(
+            mode = mode,
+            enabled = True,
+            on_update = False,
+            base_price = base_price,
+            restored_price = restored_price,
+            result_price = restored_price,
+            applied_cycles = applied_cycles,
+            next_cycle = None,
+            cycle_advanced = False,
+            reason = "update_disabled",
+            total_reposts = total_reposts,
+            delay_reposts = delay_reposts,
+            eligible_cycles = eligible_cycles,
+            delay_days = delay_days,
+            elapsed_days = elapsed_days,
+            reference = reference,
+            delay_reposts_ignored = False,
+        )
+
+    delay_reposts_ignored = False
+    if mode == AdUpdateStrategy.REPLACE:
+        if total_reposts <= delay_reposts:
+            reason = "repost_delay_waiting"
+        elif eligible_cycles <= applied_cycles:
+            reason = "repost_delay_applied"
+        elif not day_ready:
+            reason = "day_delay_missing_timestamp" if reference is None else "day_delay_waiting"
+        else:
+            reason = "eligible"
+    else:
+        delay_reposts_ignored = delay_reposts > 0
+        reason = ("day_delay_missing_timestamp" if reference is None else "day_delay_waiting") if not day_ready else "eligible"
+
+    if reason != "eligible":
+        return PriceReductionDecision(
+            mode = mode,
+            enabled = True,
+            on_update = on_update,
+            base_price = base_price,
+            restored_price = restored_price,
+            result_price = restored_price,
+            applied_cycles = applied_cycles,
+            next_cycle = None,
+            cycle_advanced = False,
+            reason = reason,
+            total_reposts = total_reposts,
+            delay_reposts = delay_reposts,
+            eligible_cycles = eligible_cycles,
+            delay_days = delay_days,
+            elapsed_days = elapsed_days,
+            reference = reference,
+            delay_reposts_ignored = delay_reposts_ignored,
+        )
+
+    next_cycle = applied_cycles + 1
+    result_price = calculate_auto_price(base_price = base_price, auto_price_reduction = cfg, target_reduction_cycle = next_cycle)
+    cycle_advanced = result_price is not None and result_price != restored_price
+
+    return PriceReductionDecision(
+        mode = mode,
+        enabled = True,
+        on_update = on_update,
+        base_price = base_price,
+        restored_price = restored_price,
+        result_price = result_price,
+        applied_cycles = applied_cycles,
+        next_cycle = next_cycle if cycle_advanced else None,
+        cycle_advanced = cycle_advanced,
+        reason = "eligible" if cycle_advanced else "no_visible_change",
+        total_reposts = total_reposts,
+        delay_reposts = delay_reposts,
+        eligible_cycles = eligible_cycles,
+        delay_days = delay_days,
+        elapsed_days = elapsed_days,
+        reference = reference,
+        delay_reposts_ignored = delay_reposts_ignored,
+    )
+
+
+def _log_auto_price_reduction_preview(ad_file_relative:str, decision:PriceReductionDecision) -> None:
+    mode_label = "publish" if decision.mode == AdUpdateStrategy.REPLACE else "update"
+    if not decision.enabled:
+        LOG.info("Auto price reduction preview for [%s] (%s): disabled", ad_file_relative, mode_label)
+        return
+
+    if decision.base_price is None:
+        LOG.info("Auto price reduction preview for [%s] (%s): missing price", ad_file_relative, mode_label)
+        return
+
+    if decision.mode == AdUpdateStrategy.MODIFY and not decision.on_update:
+        LOG.info(
+            "Auto price reduction preview for [%s] (%s): disabled (on_update=false, effective_price=%s)",
+            ad_file_relative,
+            mode_label,
+            decision.result_price,
+        )
+        return
+
+    if decision.cycle_advanced:
+        LOG.info(
+            "Auto price reduction preview for [%s] (%s): %s -> %s (cycle %s)",
+            ad_file_relative,
+            mode_label,
+            decision.restored_price,
+            decision.result_price,
+            decision.next_cycle,
+        )
+        return
+
+    LOG.info(
+        "Auto price reduction preview for [%s] (%s): no new reduction (effective_price=%s, reason=%s)",
+        ad_file_relative,
+        mode_label,
+        decision.result_price,
+        decision.reason,
+    )
+    if decision.delay_reposts_ignored:
+        LOG.debug(
+            "Auto price reduction preview for [%s] (update): delay_reposts=%s ignored in MODIFY mode",
+            ad_file_relative,
+            decision.delay_reposts,
+        )
+
+
+def apply_auto_price_reduction(
+    ad_cfg:Ad,
+    _ad_cfg_orig:dict[str, Any],
+    ad_file_relative:str,
+    *,
+    mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE,
+) -> None:
     """
     Apply automatic price reduction to an ad based on repost count and configuration.
 
@@ -256,29 +423,59 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
     :param ad_cfg: The ad configuration to potentially modify
     :param _ad_cfg_orig: The original ad configuration (unused, kept for compatibility)
     :param ad_file_relative: Relative path to the ad file for logging
+    :param mode: Price-reduction evaluation mode. REPLACE uses repost+day delays,
+        MODIFY uses day delay only and requires ``on_update``.
     """
-    if not ad_cfg.auto_price_reduction.enabled:
+    decision = evaluate_auto_price_reduction(ad_cfg, ad_file_relative, mode = mode)
+
+    if not decision.enabled:
         LOG.debug("Auto price reduction: not configured for [%s]", ad_file_relative)
         return
 
-    base_price = ad_cfg.price
+    base_price = decision.base_price
     if base_price is None:
         LOG.warning("Auto price reduction is enabled for [%s] but no price is configured.", ad_file_relative)
         return
 
-    if ad_cfg.auto_price_reduction.min_price is not None and ad_cfg.auto_price_reduction.min_price == base_price:
+    if decision.restored_price is not None:
+        ad_cfg.price = decision.restored_price
+
+    if decision.reason == "min_price_equals_price":
         LOG.warning("Auto price reduction is enabled for [%s] but min_price equals price (%s) - no reductions will occur.", ad_file_relative, base_price)
         return
 
-    repost_state = _repost_delay_state(ad_cfg)
-    day_delay_state = _day_delay_state(ad_cfg)
-    total_reposts, delay_reposts, applied_cycles, eligible_cycles = repost_state
-    _, elapsed_days, reference = day_delay_state
-    delay_days = ad_cfg.auto_price_reduction.delay_days
+    total_reposts = decision.total_reposts
+    delay_reposts = decision.delay_reposts
+    applied_cycles = decision.applied_cycles
+    eligible_cycles = decision.eligible_cycles
+    elapsed_days = decision.elapsed_days
+    reference = decision.reference
+    delay_days = decision.delay_days
     elapsed_display = "missing" if elapsed_days is None else str(elapsed_days)
     reference_display = "missing" if reference is None else reference.isoformat(timespec = "seconds")
 
-    if not _repost_cycle_ready(ad_cfg, ad_file_relative, repost_state = repost_state):
+    if decision.reason == "update_disabled":
+        LOG.debug("Auto price reduction skipped for [%s] in update mode because on_update is false", ad_file_relative)
+        return
+
+    if decision.reason in {"repost_delay_waiting", "repost_delay_applied"}:
+        if decision.reason == "repost_delay_waiting":
+            remaining = (delay_reposts + 1) - total_reposts
+            LOG.info(
+                "Auto price reduction delayed for [%s]: waiting %s more reposts (completed %s, applied %s reductions)",
+                ad_file_relative,
+                max(remaining, 1),
+                total_reposts,
+                applied_cycles,
+            )
+        else:
+            LOG.info(
+                "Auto price reduction already applied for [%s]: %s reductions match %s eligible reposts",
+                ad_file_relative,
+                applied_cycles,
+                eligible_cycles,
+            )
+
         next_repost = delay_reposts + 1 if total_reposts <= delay_reposts else delay_reposts + applied_cycles + 1
         LOG.debug(
             "Auto price reduction decision for [%s]: skipped (repost delay). next reduction earliest at repost >= %s and day delay %s/%s days."
@@ -294,7 +491,29 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
         )
         return
 
-    if not _day_delay_elapsed(ad_cfg, ad_file_relative, day_delay_state = day_delay_state):
+    if decision.reason in {"day_delay_waiting", "day_delay_missing_timestamp"}:
+        if decision.reason == "day_delay_missing_timestamp":
+            LOG.info("Auto price reduction delayed for [%s]: waiting %s days but publish timestamp missing", ad_file_relative, delay_days)
+        else:
+            LOG.info("Auto price reduction delayed for [%s]: waiting %s days (elapsed %s)", ad_file_relative, delay_days, elapsed_days)
+
+        if decision.mode == AdUpdateStrategy.MODIFY and decision.delay_reposts_ignored:
+            LOG.debug(
+                "Auto price reduction for [%s]: delay_reposts=%s ignored in MODIFY mode (only delay_days applies)",
+                ad_file_relative,
+                delay_reposts,
+            )
+            LOG.debug(
+                "Auto price reduction decision for [%s]: skipped (day delay, update mode). "
+                "next reduction earliest when elapsed_days >= %s. elapsed_days=%s price_reduction_count=%s reference=%s",
+                ad_file_relative,
+                delay_days,
+                elapsed_display,
+                applied_cycles,
+                reference_display,
+            )
+            return
+
         LOG.debug(
             "Auto price reduction decision for [%s]: skipped (day delay). next reduction earliest when elapsed_days >= %s."
             " elapsed_days=%s repost_count=%s eligible_cycles=%s applied_cycles=%s reference=%s",
@@ -308,6 +527,17 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
         )
         return
 
+    if decision.mode == AdUpdateStrategy.MODIFY and decision.delay_reposts_ignored:
+        LOG.debug(
+            "Auto price reduction for [%s]: delay_reposts=%s ignored in MODIFY mode (only delay_days applies)",
+            ad_file_relative,
+            delay_reposts,
+        )
+
+    if decision.reason == "no_visible_change":
+        LOG.info("Auto price reduction kept price %s after attempting %s reduction cycles", decision.restored_price, applied_cycles + 1)
+        return
+
     LOG.debug(
         "Auto price reduction decision for [%s]: applying now (eligible_cycles=%s, applied_cycles=%s, elapsed_days=%s/%s).",
         ad_file_relative,
@@ -317,7 +547,9 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
         delay_days,
     )
 
-    next_cycle = applied_cycles + 1
+    next_cycle = decision.next_cycle
+    if next_cycle is None:
+        return
 
     if loggers.is_debug(LOG):
         effective_price, reduction_steps, price_floor = calculate_auto_price_with_trace(
@@ -344,19 +576,20 @@ def apply_auto_price_reduction(ad_cfg:Ad, _ad_cfg_orig:dict[str, Any], ad_file_r
                 step.floor_applied,
             )
     else:
-        effective_price = calculate_auto_price(base_price = base_price, auto_price_reduction = ad_cfg.auto_price_reduction, target_reduction_cycle = next_cycle)
+        effective_price = decision.result_price
 
     if effective_price is None:
         return
 
-    if effective_price == base_price:
+    ad_cfg.price = effective_price
+
+    if decision.restored_price is not None and effective_price == decision.restored_price:
         # Still increment counter so small fractional reductions can accumulate over multiple cycles
         ad_cfg.price_reduction_count = next_cycle
         LOG.info("Auto price reduction kept price %s after attempting %s reduction cycles", effective_price, next_cycle)
         return
 
-    LOG.info("Auto price reduction applied: %s -> %s after %s reduction cycles", base_price, effective_price, next_cycle)
-    ad_cfg.price = effective_price
+    LOG.info("Auto price reduction applied: %s -> %s after %s reduction cycles", decision.restored_price, effective_price, next_cycle)
     ad_cfg.price_reduction_count = next_cycle
     # Note: price_reduction_count is persisted to ad_cfg_orig only after successful publish
 
@@ -543,9 +776,13 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     checker.check_for_updates()
                     self.ads_selector = "all"
                     if ads := self.load_ads(exclude_ads_with_id = False):
-                        for ad_file, ad_cfg, ad_cfg_orig in ads:
+                        for ad_file, ad_cfg, _ad_cfg_orig in ads:
                             ad_file_relative = _relative_ad_path(ad_file, self.config_file_path)
-                            apply_auto_price_reduction(ad_cfg, ad_cfg_orig, ad_file_relative)
+                            publish_decision = evaluate_auto_price_reduction(ad_cfg, ad_file_relative, mode = AdUpdateStrategy.REPLACE)
+                            _log_auto_price_reduction_preview(ad_file_relative, publish_decision)
+
+                            update_decision = evaluate_auto_price_reduction(ad_cfg, ad_file_relative, mode = AdUpdateStrategy.MODIFY)
+                            _log_auto_price_reduction_preview(ad_file_relative, update_decision)
                     LOG.info("############################################")
                     LOG.info("DONE: No configuration errors found.")
                     LOG.info("############################################")
@@ -1987,13 +2224,15 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             if self.config.publishing.delete_old_ads == "BEFORE_PUBLISH" and not self.keep_old_ads:
                 await self.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = self.config.publishing.delete_old_ads_by_title)
 
-            # Apply auto price reduction only for REPLACE operations (actual reposts)
-            # This ensures price reductions only happen on republish, not on UPDATE
-            apply_auto_price_reduction(ad_cfg, ad_cfg_orig, _relative_ad_path(ad_file, self.config_file_path))
+            # Apply auto price reduction in REPLACE mode (republish flow)
+            apply_auto_price_reduction(ad_cfg, ad_cfg_orig, _relative_ad_path(ad_file, self.config_file_path), mode = AdUpdateStrategy.REPLACE)
 
             LOG.info("Publishing ad '%s'...", ad_cfg.title)
             await self.web_open(f"{self.root_url}/p-anzeige-aufgeben-schritt2.html", reload_if_already_open = True)
         else:
+            if ad_cfg.auto_price_reduction.on_update:
+                apply_auto_price_reduction(ad_cfg, ad_cfg_orig, _relative_ad_path(ad_file, self.config_file_path), mode = AdUpdateStrategy.MODIFY)
+
             LOG.info("Updating ad '%s'...", ad_cfg.title)
             await self.web_open(f"{self.root_url}/p-anzeige-bearbeiten.html?adId={ad_cfg.id}", reload_if_already_open = True)
 
@@ -2193,8 +2432,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if not ad_cfg.created_on and not ad_cfg.id:
             ad_cfg_orig["created_on"] = ad_cfg_orig["updated_on"]
 
-        # Increment repost_count and persist price_reduction_count only for REPLACE operations (actual reposts)
-        # This ensures counters only advance on republish, not on UPDATE
+        # Increment repost_count only for REPLACE operations (actual reposts)
         if mode == AdUpdateStrategy.REPLACE:
             # Increment repost_count after successful publish
             # Note: This happens AFTER publish, so price reduction logic (which runs before publish)
@@ -2204,10 +2442,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             ad_cfg_orig["repost_count"] = current_reposts + 1
             ad_cfg.repost_count = ad_cfg_orig["repost_count"]
 
-            # Persist price_reduction_count after successful publish
-            # This ensures failed publishes don't incorrectly increment the reduction counter
-            if ad_cfg.price_reduction_count is not None and ad_cfg.price_reduction_count > 0:
-                ad_cfg_orig["price_reduction_count"] = ad_cfg.price_reduction_count
+        # Persist price_reduction_count after successful publish/update.
+        # This ensures failed submissions don't incorrectly increment the reduction counter.
+        if ad_cfg.price_reduction_count is not None and ad_cfg.price_reduction_count > 0:
+            ad_cfg_orig["price_reduction_count"] = ad_cfg.price_reduction_count
 
         if mode == AdUpdateStrategy.REPLACE:
             LOG.info(" -> SUCCESS: ad published with ID %s", ad_id)

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2150,9 +2150,15 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
             count += 1
             success = False
+            baseline_price = ad_cfg.price
+            baseline_price_reduction_count = ad_cfg.price_reduction_count
 
             for attempt in range(1, max_retries + 1):
                 try:
+                    # publish_ad mutates pricing fields before submit; reset them so retries
+                    # remain idempotent for a single eligible reduction cycle.
+                    ad_cfg.price = baseline_price
+                    ad_cfg.price_reduction_count = baseline_price_reduction_count
                     await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads, AdUpdateStrategy.REPLACE)
                     success = True
                     break  # Publish succeeded, exit retry loop

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -583,12 +583,6 @@ def apply_auto_price_reduction(
 
     ad_cfg.price = effective_price
 
-    if decision.restored_price is not None and effective_price == decision.restored_price:
-        # Still increment counter so small fractional reductions can accumulate over multiple cycles
-        ad_cfg.price_reduction_count = next_cycle
-        LOG.info("Auto price reduction kept price %s after attempting %s reduction cycles", effective_price, next_cycle)
-        return
-
     LOG.info("Auto price reduction applied: %s -> %s after %s reduction cycles", decision.restored_price, effective_price, next_cycle)
     ad_cfg.price_reduction_count = next_cycle
     # Note: price_reduction_count is persisted to ad_cfg_orig only after successful publish

--- a/src/kleinanzeigen_bot/model/config_model.py
+++ b/src/kleinanzeigen_bot/model/config_model.py
@@ -42,6 +42,10 @@ class AutoPriceReductionConfig(ContextualModel):
     )
     delay_reposts:int = Field(default = 0, ge = 0, description = "number of reposts to wait before applying the first automatic price reduction")
     delay_days:int = Field(default = 0, ge = 0, description = "number of days to wait after publication before applying automatic price reductions")
+    on_update:bool = Field(
+        default = False,
+        description = "also apply automatic price reduction during update runs (MODIFY mode). delay_days applies, delay_reposts is ignored",
+    )
 
     @model_validator(mode = "after")
     def _validate_config(self) -> "AutoPriceReductionConfig":
@@ -122,7 +126,7 @@ class AdDefaults(ContextualModel):
 class DownloadConfig(ContextualModel):
     dir:str = Field(
         default = DEFAULT_DOWNLOAD_DIR,
-        description = (
+        description=(
             "directory where downloaded ads are written. "
             "The default literal 'downloaded-ads' uses workspace-specific resolution; "
             "custom relative paths are resolved against the config file location"
@@ -146,7 +150,7 @@ class DownloadConfig(ContextualModel):
     )
     folder_name_template:str = Field(
         default = "ad_{id}_{title}",
-        description = (
+        description=(
             "folder naming template for downloaded ad directories. "
             "Allowed placeholders: {id}, {title}. "
             "Each placeholder may appear at most once. "
@@ -156,7 +160,7 @@ class DownloadConfig(ContextualModel):
     )
     ad_file_name_template:str = Field(
         default = "ad_{id}",
-        description = (
+        description=(
             "base name template for downloaded ad files. "
             "The bot writes the ad config as <base>.yaml and downloaded images as <base>__imgN.<ext>. "
             "Supported placeholders: {id}, {title}. "

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -188,15 +188,19 @@ kleinanzeigen_bot/__init__.py:
   apply_auto_price_reduction:
     "Auto price reduction is enabled for [%s] but no price is configured.": "Automatische Preisreduzierung ist für [%s] aktiviert, aber es wurde kein Preis konfiguriert."
     "Auto price reduction is enabled for [%s] but min_price equals price (%s) - no reductions will occur.": "Automatische Preisreduzierung ist für [%s] aktiviert, aber min_price entspricht dem Preis (%s) - es werden keine Reduktionen auftreten."
-    "Auto price reduction applied: %s -> %s after %s reduction cycles": "Automatische Preisreduzierung angewendet: %s -> %s nach %s Reduktionszyklen"
-    "Auto price reduction kept price %s after attempting %s reduction cycles": "Automatische Preisreduzierung hat Preis %s beibehalten nach dem Versuch von %s Reduktionszyklen"
-  _repost_cycle_ready:
     "Auto price reduction delayed for [%s]: waiting %s more reposts (completed %s, applied %s reductions)": "Automatische Preisreduzierung für [%s] verzögert: Warte %s weitere erneute Veröffentlichungen (abgeschlossen %s, angewendet %s Reduktionen)"
     "Auto price reduction already applied for [%s]: %s reductions match %s eligible reposts": "Automatische Preisreduzierung für [%s] bereits angewendet: %s Reduktionen entsprechen %s berechtigten erneuten Veröffentlichungen"
-  _day_delay_elapsed:
     "Auto price reduction delayed for [%s]: waiting %s days (elapsed %s)": "Automatische Preisreduzierung für [%s] verzögert: Warte %s Tage (vergangen %s)"
     "Auto price reduction delayed for [%s]: waiting %s days but publish timestamp missing": "Automatische Preisreduzierung für [%s] verzögert: Warte %s Tage, aber Zeitstempel der Veröffentlichung fehlt"
+    "Auto price reduction applied: %s -> %s after %s reduction cycles": "Automatische Preisreduzierung angewendet: %s -> %s nach %s Reduktionszyklen"
+    "Auto price reduction kept price %s after attempting %s reduction cycles": "Automatische Preisreduzierung hat Preis %s beibehalten nach dem Versuch von %s Reduktionszyklen"
 
+  _log_auto_price_reduction_preview:
+    "Auto price reduction preview for [%s] (%s): disabled": "Vorschau automatische Preisreduzierung für [%s] (%s): deaktiviert"
+    "Auto price reduction preview for [%s] (%s): missing price": "Vorschau automatische Preisreduzierung für [%s] (%s): Preis fehlt"
+    "Auto price reduction preview for [%s] (%s): disabled (on_update=false, effective_price=%s)": "Vorschau automatische Preisreduzierung für [%s] (%s): deaktiviert (on_update=false, effektiver Preis=%s)"
+    "Auto price reduction preview for [%s] (%s): %s -> %s (cycle %s)": "Vorschau automatische Preisreduzierung für [%s] (%s): %s -> %s (Zyklus %s)"
+    "Auto price reduction preview for [%s] (%s): no new reduction (effective_price=%s, reason=%s)": "Vorschau automatische Preisreduzierung für [%s] (%s): keine neue Reduktion (effektiver Preis=%s, Grund=%s)"
   publish_ad:
     "Publishing ad '%s'...": "Veröffentliche Anzeige '%s'..."
     "Updating ad '%s'...": "Aktualisiere Anzeige '%s'..."

--- a/tests/smoke/test_smoke_health.py
+++ b/tests/smoke/test_smoke_health.py
@@ -198,7 +198,6 @@ def test_cli_subcommands_create_config_fails_if_exists(tmp_path:Path) -> None:
         ("verify", "verify"),
         ("update-check", "update"),
         ("update-content-hash", "update-content-hash"),
-        ("diagnose", "diagnose"),
     ],
 )
 @pytest.mark.parametrize(
@@ -241,8 +240,6 @@ def test_cli_subcommands_with_config_formats(
         assert "no active ads found" in out, f"Expected 'no active ads found' in output for 'update-content-hash'.\n{out}"
     elif subcommand == "update-check":
         assert result.returncode == 0
-    elif subcommand == "diagnose":
-        assert "browser connection diagnostics" in out or "browser-verbindungsdiagnose" in out, f"Expected diagnostic output for 'diagnose'.\n{out}"
 
 
 @pytest.mark.smoke

--- a/tests/smoke/test_smoke_health.py
+++ b/tests/smoke/test_smoke_health.py
@@ -138,12 +138,15 @@ def test_app_starts(smoke_bot:SmokeKleinanzeigenBot) -> None:
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("subcommand", [
-    "--help",
-    "help",
-    "version",
-    "diagnose",
-])
+@pytest.mark.parametrize(
+    "subcommand",
+    [
+        "--help",
+        "help",
+        "version",
+        "diagnose",
+    ],
+)
 def test_cli_subcommands_no_config(subcommand:str, tmp_path:Path) -> None:
     """
     Smoke: CLI subcommands that do not require a config file (--help, help, version, diagnose).
@@ -185,23 +188,27 @@ def test_cli_subcommands_create_config_fails_if_exists(tmp_path:Path) -> None:
     assert result.returncode == 0
     assert config_file.exists(), "config.yaml was deleted or not present after second create-config run"
     out = (result.stdout + "\n" + result.stderr).lower()
-    assert (
-        "already exists" in out or "not overwritten" in out or "saving" in out
-    ), f"Expected message about existing config in CLI output.\n{out}"
+    assert "already exists" in out or "not overwritten" in out or "saving" in out, f"Expected message about existing config in CLI output.\n{out}"
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize(("subcommand", "output_check"), [
-    ("verify", "verify"),
-    ("update-check", "update"),
-    ("update-content-hash", "update-content-hash"),
-    ("diagnose", "diagnose"),
-])
-@pytest.mark.parametrize(("config_ext", "serializer"), [
-    ("yaml", None),
-    ("yml", None),
-    ("json", json.dumps),
-])
+@pytest.mark.parametrize(
+    ("subcommand", "output_check"),
+    [
+        ("verify", "verify"),
+        ("update-check", "update"),
+        ("update-content-hash", "update-content-hash"),
+        ("diagnose", "diagnose"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("config_ext", "serializer"),
+    [
+        ("yaml", None),
+        ("yml", None),
+        ("json", json.dumps),
+    ],
+)
 def test_cli_subcommands_with_config_formats(
     subcommand:str,
     output_check:str,
@@ -240,7 +247,7 @@ def test_cli_subcommands_with_config_formats(
 
 @pytest.mark.smoke
 def test_verify_shows_auto_price_reduction_decisions(tmp_path:Path, test_bot_config:Config) -> None:
-    """Smoke: verify command previews auto price reduction decisions for all configured ads."""
+    """Smoke: verify previews publish and update-mode price reduction decisions."""
     config_dict = test_bot_config.model_dump()
     config_dict["ad_files"] = ["./**/ad_*.yaml"]
     config_path = tmp_path / "config.yaml"
@@ -268,9 +275,33 @@ def test_verify_shows_auto_price_reduction_decisions(tmp_path:Path, test_bot_con
         encoding = "utf-8",
     )
 
+    ad_yaml_update = ad_dir / "ad_test_update_pricing.yaml"
+    ad_yaml_update.write_text(
+        "title: Test Auto Pricing Update Ad\n"
+        "description: A test ad to verify update price reduction preview\n"
+        "category: 161/gezielt\n"
+        "price: 200\n"
+        "price_type: FIXED\n"
+        "repost_count: 1\n"
+        "auto_price_reduction:\n"
+        "  enabled: true\n"
+        "  strategy: PERCENTAGE\n"
+        "  amount: 10\n"
+        "  min_price: 100\n"
+        "  delay_reposts: 3\n"
+        "  delay_days: 0\n"
+        "  on_update: true\n",
+        encoding = "utf-8",
+    )
+
     args = ["verify", "--config", str(config_path), "--workspace-mode", "portable"]
     result = invoke_cli(args, cwd = tmp_path)
     assert result.returncode == 0
     out = (result.stdout + "\n" + result.stderr).lower()
     assert "no configuration errors found" in out, f"Expected 'no configuration errors found' in output.\n{out}"
-    assert "auto price reduction applied" in out, f"Expected auto price reduction applied log in output.\n{out}"
+    assert "auto price reduction preview for" in out, f"Expected auto price reduction preview logs in output.\n{out}"
+    assert "(publish):" in out, f"Expected publish preview in output.\n{out}"
+    assert "disabled (on_update=false" in out, f"Expected update preview disabled message when on_update=false.\n{out}"
+    assert "ad_test_update_pricing.yaml" in out, f"Expected update-enabled ad preview in output.\n{out}"
+    assert "(update):" in out, f"Expected update preview in output.\n{out}"
+    assert "cycle 1" in out, f"Expected update preview with cycle progression in output.\n{out}"

--- a/tests/smoke/test_smoke_health.py
+++ b/tests/smoke/test_smoke_health.py
@@ -188,7 +188,7 @@ def test_cli_subcommands_create_config_fails_if_exists(tmp_path:Path) -> None:
     assert result.returncode == 0
     assert config_file.exists(), "config.yaml was deleted or not present after second create-config run"
     out = (result.stdout + "\n" + result.stderr).lower()
-    assert "already exists" in out or "not overwritten" in out or "saving" in out, f"Expected message about existing config in CLI output.\n{out}"
+    assert "already exists" in out or "not overwritten" in out, f"Expected message about existing config in CLI output.\n{out}"
 
 
 @pytest.mark.smoke

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2716,7 +2716,8 @@ class TestKleinanzeigenBotShippingOptions:
 
             # --- REPLACE mode: always calls apply_auto_price_reduction ---
             await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
-            assert mock_apply.call_count == 1, "Auto price reduction should be called on REPLACE"
+            mock_apply.assert_called_once()
+            assert mock_apply.call_args.kwargs["mode"] == AdUpdateStrategy.REPLACE
 
             # --- MODIFY mode with default config (on_update=false): should NOT call ---
             mock_apply.reset_mock()
@@ -2735,7 +2736,8 @@ class TestKleinanzeigenBotShippingOptions:
                 on_update = True,
             )
             await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
-            assert mock_apply.call_count == 1, "Auto price reduction SHOULD be called exactly once on MODIFY when on_update=true"
+            mock_apply.assert_called_once()
+            assert mock_apply.call_args.kwargs["mode"] == AdUpdateStrategy.MODIFY
 
     @pytest.mark.asyncio
     async def test_special_attributes_compound_name_lookup(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2735,7 +2735,7 @@ class TestKleinanzeigenBotShippingOptions:
                 on_update = True,
             )
             await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
-            assert mock_apply.call_count >= 1, "Auto price reduction SHOULD be called on MODIFY when on_update=true"
+            assert mock_apply.call_count == 1, "Auto price reduction SHOULD be called exactly once on MODIFY when on_update=true"
 
     @pytest.mark.asyncio
     async def test_special_attributes_compound_name_lookup(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -16,7 +16,7 @@ from pydantic import ValidationError
 from kleinanzeigen_bot import LOG, PUBLISH_MAX_RETRIES, AdUpdateStrategy, KleinanzeigenBot, LoginDetectionReason, LoginDetectionResult, misc
 from kleinanzeigen_bot._version import __version__
 from kleinanzeigen_bot.model.ad_model import Ad
-from kleinanzeigen_bot.model.config_model import AdDefaults, Config, DiagnosticsConfig, PublishingConfig
+from kleinanzeigen_bot.model.config_model import AdDefaults, AutoPriceReductionConfig, Config, DiagnosticsConfig, PublishingConfig
 from kleinanzeigen_bot.utils import dicts, loggers, xdg_paths
 from kleinanzeigen_bot.utils.exceptions import PublishedAdsFetchIncompleteError, PublishSubmissionUncertainError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
@@ -2613,7 +2613,14 @@ class TestKleinanzeigenBotShippingOptions:
         # Track what path argument __apply_auto_price_reduction receives
         recorded_path:list[str] = []
 
-        def mock_apply_auto_price_reduction(ad_cfg:Ad, ad_cfg_orig:dict[str, Any], ad_file_relative:str) -> None:
+        def mock_apply_auto_price_reduction(
+            ad_cfg:Ad,
+            ad_cfg_orig:dict[str, Any],
+            ad_file_relative:str,
+            *,
+            mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE,
+        ) -> None:
+            _ = mode
             recorded_path.append(ad_file_relative)
             raise _SentinelException("Abort early for test")
 
@@ -2637,9 +2644,16 @@ class TestKleinanzeigenBotShippingOptions:
         assert recorded_path[0] == ad_file, f"Expected absolute path fallback, got: {recorded_path[0]}"
 
     @pytest.mark.asyncio
-    async def test_auto_price_reduction_only_on_replace_not_update(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], tmp_path:Path) -> None:
-        """Test that auto price reduction is ONLY applied on REPLACE mode, not UPDATE."""
-        # Create ad with auto price reduction enabled
+    async def test_auto_price_reduction_conditional_on_mode_and_on_update(
+        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], tmp_path:Path
+    ) -> None:
+        """Test price reduction dispatch across REPLACE and MODIFY modes.
+
+        - REPLACE mode always calls apply_auto_price_reduction.
+        - MODIFY mode with on_update=false (default) does NOT call it.
+        - MODIFY mode with on_update=true DOES call it (conditional new behavior).
+        """
+        # Shared ad config with auto price reduction enabled
         ad_cfg = Ad.model_validate(
             base_ad_config
             | {
@@ -2655,47 +2669,57 @@ class TestKleinanzeigenBotShippingOptions:
         ad_cfg.update_content_hash()
         ad_cfg_orig = ad_cfg.model_dump()
 
-        # Mock the private __apply_auto_price_reduction method
-        with patch("kleinanzeigen_bot.apply_auto_price_reduction") as mock_apply:
-            # Mock other dependencies
-            mock_response = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}
+        mock_response = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}
 
-            async def mock_web_execute_price_reduction(script:str) -> Any:
-                if "window.location.href" in script:
-                    return "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=12345"
-                return mock_response
+        async def mock_web_execute_price_reduction(script:str) -> Any:
+            if "window.location.href" in script:
+                return "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=12345"
+            return mock_response
 
-            with (
-                patch.object(test_bot, "web_find", new_callable = AsyncMock),
-                patch.object(test_bot, "web_input", new_callable = AsyncMock),
-                patch.object(test_bot, "web_click", new_callable = AsyncMock),
-                patch.object(test_bot, "web_open", new_callable = AsyncMock),
-                patch.object(test_bot, "web_select", new_callable = AsyncMock),
-                patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
-                patch.object(test_bot, "web_await", new_callable = AsyncMock),
-                patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-                patch.object(test_bot, "web_execute", side_effect = mock_web_execute_price_reduction),
-                patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = mock_response),
-                patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-                patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
-                patch.object(test_bot, "check_and_wait_for_captcha", new_callable = AsyncMock),
-                patch("builtins.input", return_value = ""),
-                patch("kleinanzeigen_bot.utils.misc.ainput", new_callable = AsyncMock, return_value = ""),
-            ):
-                test_bot.page = MagicMock()
-                test_bot.page.url = "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=12345"
-                test_bot.config.publishing.delete_old_ads = "BEFORE_PUBLISH"
+        with (
+            patch("kleinanzeigen_bot.apply_auto_price_reduction") as mock_apply,
+            patch.object(test_bot, "web_find", new_callable = AsyncMock),
+            patch.object(test_bot, "web_input", new_callable = AsyncMock),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_open", new_callable = AsyncMock),
+            patch.object(test_bot, "web_select", new_callable = AsyncMock),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_execute", side_effect = mock_web_execute_price_reduction),
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = mock_response),
+            patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
+            patch.object(test_bot, "check_and_wait_for_captcha", new_callable = AsyncMock),
+            patch("builtins.input", return_value = ""),
+            patch("kleinanzeigen_bot.utils.misc.ainput", new_callable = AsyncMock, return_value = ""),
+        ):
+            test_bot.page = MagicMock()
+            test_bot.page.url = "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=12345"
+            test_bot.config.publishing.delete_old_ads = "BEFORE_PUBLISH"
 
-                # Test REPLACE mode - should call __apply_auto_price_reduction
-                await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
-                assert mock_apply.call_count == 1, "Auto price reduction should be called on REPLACE"
+            # --- REPLACE mode: always calls apply_auto_price_reduction ---
+            await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
+            assert mock_apply.call_count == 1, "Auto price reduction should be called on REPLACE"
 
-                # Reset mock
-                mock_apply.reset_mock()
+            # --- MODIFY mode with default config (on_update=false): should NOT call ---
+            mock_apply.reset_mock()
+            await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
+            assert mock_apply.call_count == 0, "Auto price reduction should NOT be called on MODIFY with on_update=false"
 
-                # Test MODIFY mode - should NOT call __apply_auto_price_reduction
-                await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
-                assert mock_apply.call_count == 0, "Auto price reduction should NOT be called on MODIFY"
+            # --- MODIFY mode with on_update=true: SHOULD call (new conditional behavior) ---
+            mock_apply.reset_mock()
+            ad_cfg.auto_price_reduction = AutoPriceReductionConfig(
+                enabled = True,
+                strategy = "FIXED",
+                amount = 50,
+                min_price = 50,
+                delay_reposts = 0,
+                delay_days = 0,
+                on_update = True,
+            )
+            await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
+            assert mock_apply.call_count >= 1, "Auto price reduction SHOULD be called on MODIFY when on_update=true"
 
     @pytest.mark.asyncio
     async def test_special_attributes_compound_name_lookup(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2666,8 +2666,8 @@ class TestKleinanzeigenBotShippingOptions:
         """Test price reduction dispatch across REPLACE and MODIFY modes.
 
         - REPLACE mode always calls apply_auto_price_reduction.
-        - MODIFY mode with on_update=false (default) does NOT call it.
-        - MODIFY mode with on_update=true DOES call it (conditional new behavior).
+        - MODIFY mode with on_update=false still calls it for restore-first (no cycle advance).
+        - MODIFY mode with on_update=true calls it with full evaluation and cycle advance.
         """
         # Shared ad config with auto price reduction enabled
         ad_cfg = Ad.model_validate(
@@ -2719,10 +2719,11 @@ class TestKleinanzeigenBotShippingOptions:
             mock_apply.assert_called_once()
             assert mock_apply.call_args.kwargs["mode"] == AdUpdateStrategy.REPLACE
 
-            # --- MODIFY mode with default config (on_update=false): should NOT call ---
+            # --- MODIFY mode with default config (on_update=false): still calls for restore-first ---
             mock_apply.reset_mock()
             await test_bot.publish_ad(str(tmp_path / "ad.yaml"), ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
-            assert mock_apply.call_count == 0, "Auto price reduction should NOT be called on MODIFY with on_update=false"
+            mock_apply.assert_called_once()
+            assert mock_apply.call_args.kwargs["mode"] == AdUpdateStrategy.MODIFY
 
             # --- MODIFY mode with on_update=true: SHOULD call (new conditional behavior) ---
             mock_apply.reset_mock()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1809,24 +1809,40 @@ class TestKleinanzeigenBotBasics:
         base_ad_config:dict[str, Any],
         mock_page:MagicMock,
     ) -> None:
-        """Retry branch should sleep with explicit millisecond delay."""
+        """Retry branch should sleep with explicit millisecond delay and reset price-reduction mutations."""
         test_bot.page = mock_page
         test_bot.keep_old_ads = True
 
-        ad_cfg = Ad.model_validate(base_ad_config)
+        ad_cfg = Ad.model_validate(base_ad_config | {"price": 100, "price_reduction_count": 0, "repost_count": 1})
         ad_cfg_orig = copy.deepcopy(base_ad_config)
         ad_file = "ad.yaml"
         ads_response = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})}
+        seen_prices:list[tuple[int | None, int | None]] = []
+
+        async def publish_side_effect(
+            _ad_file:str,
+            candidate_cfg:Ad,
+            _candidate_orig:dict[str, Any],
+            _published_ads:list[dict[str, Any]],
+            _mode:AdUpdateStrategy,
+        ) -> None:
+            seen_prices.append((candidate_cfg.price, candidate_cfg.price_reduction_count))
+            if len(seen_prices) == 1:
+                # Simulate in-memory mutation done by apply_auto_price_reduction before a failed attempt.
+                candidate_cfg.price = 90
+                candidate_cfg.price_reduction_count = 1
+                raise TimeoutError("transient")
 
         with (
             patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = [TimeoutError("transient"), None]) as publish_mock,
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
             await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
 
             assert publish_mock.await_count == 2
+            assert seen_prices == [(100, 0), (100, 0)]
             sleep_mock.assert_awaited_once_with(2_000)
 
     @pytest.mark.asyncio

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -437,11 +437,11 @@ class TestKleinanzeigenBotInitialization:
 
         extractor_mock.download_ad.assert_awaited_once_with(123, active = expected_active)
 
-        warning_messages = [record.getMessage() for record in caplog.records if record.levelno >= logging.WARNING]
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
         if expect_warning:
-            assert any("123" in msg for msg in warning_messages)
+            assert len(warning_records) >= 1
         else:
-            assert len(warning_messages) == 0
+            assert len(warning_records) == 0
 
     @pytest.mark.asyncio
     async def test_download_ads_numeric_selector_fails_when_published_ads_fetch_incomplete(self, test_bot:KleinanzeigenBot, tmp_path:Path) -> None:

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -443,11 +443,11 @@ def test_apply_auto_price_reduction_delayed_when_timestamp_missing(
 
 
 @pytest.mark.unit
-def test_fractional_reduction_does_not_increment_counter_when_price_unchanged(
+def test_fractional_reduction_increments_counter_when_price_unchanged(
     caplog:pytest.LogCaptureFixture, apply_auto_price_reduction:_ApplyAutoPriceReduction
 ) -> None:
-    # Small reductions that round back to the same euro value should not advance the
-    # persisted cycle counter. This avoids counter drift when no visible price change occurs.
+    # Small reductions that round back to the same euro value still advance the
+    # reduction cycle counter so fractional progress can accumulate across runs.
     ad_cfg = SimpleNamespace(
         price = 100,
         auto_price_reduction = AutoPriceReductionConfig(enabled = True, strategy = "FIXED", amount = 0.3, min_price = 50, delay_reposts = 0, delay_days = 0),
@@ -466,8 +466,33 @@ def test_fractional_reduction_does_not_increment_counter_when_price_unchanged(
     expected = _("Auto price reduction kept price %s after attempting %s reduction cycles") % (100, 1)
     assert any(expected in message for message in caplog.messages)
     assert ad_cfg.price == 100
-    assert ad_cfg.price_reduction_count == 0
+    assert ad_cfg.price_reduction_count == 1
     assert "price_reduction_count" not in ad_orig
+
+
+@pytest.mark.unit
+def test_no_visible_change_at_floor_advances_counter(apply_auto_price_reduction:_ApplyAutoPriceReduction) -> None:
+    """When price is already floor-clamped, no visible change still advances cycle counter."""
+    ad_cfg = SimpleNamespace(
+        price = 100,
+        auto_price_reduction = AutoPriceReductionConfig(
+            enabled = True,
+            strategy = "PERCENTAGE",
+            amount = 10,
+            min_price = 90,
+            delay_reposts = 0,
+            delay_days = 0,
+        ),
+        price_reduction_count = 3,
+        repost_count = 5,
+        updated_on = None,
+        created_on = None,
+    )
+
+    apply_auto_price_reduction(ad_cfg, {}, "ad_floor.yaml")
+
+    assert ad_cfg.price == 90
+    assert ad_cfg.price_reduction_count == 4
 
 
 @pytest.mark.unit

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -10,6 +10,7 @@ from typing import Any, Protocol, runtime_checkable
 import pytest
 
 import kleinanzeigen_bot
+from kleinanzeigen_bot import AdUpdateStrategy
 from kleinanzeigen_bot.model.ad_model import calculate_auto_price
 from kleinanzeigen_bot.model.config_model import AutoPriceReductionConfig
 from kleinanzeigen_bot.utils.pydantics import ContextualValidationError
@@ -17,14 +18,36 @@ from kleinanzeigen_bot.utils.pydantics import ContextualValidationError
 
 @runtime_checkable
 class _ApplyAutoPriceReduction(Protocol):
-    def __call__(self, ad_cfg:SimpleNamespace, ad_cfg_orig:dict[str, Any], ad_file_relative:str) -> None:
+    def __call__(
+        self,
+        ad_cfg:Any,
+        _ad_cfg_orig:dict[str, Any],
+        ad_file_relative:str,
+        *,
+        mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE,
+    ) -> None:
         pass
 
 
 @pytest.fixture
 def apply_auto_price_reduction() -> _ApplyAutoPriceReduction:
     # Return the module-level function directly (no more name-mangling!)
-    return kleinanzeigen_bot.apply_auto_price_reduction  # type: ignore[return-value]
+    return kleinanzeigen_bot.apply_auto_price_reduction
+
+
+def _price_cfg(*, on_update:bool = False, **overrides:Any) -> AutoPriceReductionConfig:
+    """Create an auto_price_reduction config with optional overrides."""
+    defaults:dict[str, Any] = {
+        "enabled": True,
+        "strategy": "PERCENTAGE",
+        "amount": 10,
+        "min_price": 50,
+        "delay_reposts": 0,
+        "delay_days": 0,
+        "on_update": on_update,
+    }
+    defaults.update(overrides)
+    return AutoPriceReductionConfig.model_validate(defaults)
 
 
 @pytest.mark.unit
@@ -347,7 +370,7 @@ def test_apply_auto_price_reduction_waits_when_reduction_already_applied(
         "next reduction earliest at repost >= 4 and day delay 0/0 days. repost_count=3 eligible_cycles=3 applied_cycles=3"
     )
     assert any(message.startswith(decision_message) for message in caplog.messages)
-    assert ad_cfg.price == 100
+    assert ad_cfg.price == 73
     assert ad_cfg.price_reduction_count == 3
     assert "price_reduction_count" not in ad_orig
 
@@ -435,11 +458,11 @@ def test_apply_auto_price_reduction_delayed_when_timestamp_missing(
 
 
 @pytest.mark.unit
-def test_fractional_reduction_increments_counter_even_when_price_unchanged(
+def test_fractional_reduction_does_not_increment_counter_when_price_unchanged(
     caplog:pytest.LogCaptureFixture, apply_auto_price_reduction:_ApplyAutoPriceReduction
 ) -> None:
-    # Test that small fractional reductions increment the counter even when rounded price doesn't change
-    # This allows cumulative reductions to eventually show visible effect
+    # Small reductions that round back to the same euro value should not advance the
+    # persisted cycle counter. This avoids counter drift when no visible price change occurs.
     ad_cfg = SimpleNamespace(
         price = 100,
         auto_price_reduction = AutoPriceReductionConfig(enabled = True, strategy = "FIXED", amount = 0.3, min_price = 50, delay_reposts = 0, delay_days = 0),
@@ -455,11 +478,10 @@ def test_fractional_reduction_increments_counter_even_when_price_unchanged(
         apply_auto_price_reduction(ad_cfg, ad_orig, "ad_fractional.yaml")
 
     # Price: 100 - 0.3 = 99.7, rounds to 100 (no visible change)
-    # But counter should still increment for future cumulative reductions
     expected = _("Auto price reduction kept price %s after attempting %s reduction cycles") % (100, 1)
     assert any(expected in message for message in caplog.messages)
     assert ad_cfg.price == 100
-    assert ad_cfg.price_reduction_count == 1  # Counter incremented despite no visible price change
+    assert ad_cfg.price_reduction_count == 0
     assert "price_reduction_count" not in ad_orig
 
 
@@ -558,3 +580,148 @@ def test_fractional_min_price_is_rounded_up_with_ceiling() -> None:
         target_reduction_cycle = 3,  # 60 - 5 - 5 - 5 = 45, clamped to ceil(49.1) = 50
     )
     assert result2 == 50  # Rounded up from 49.1 floor
+
+
+# ---------------------------------------------------------------------------
+# MODIFY-mode price reduction tests (on_update conditional behavior)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_modify_mode_skips_when_on_update_false(
+    apply_auto_price_reduction:_ApplyAutoPriceReduction,
+) -> None:
+    """MODIFY mode with on_update=false must not touch the price at all."""
+    ad_cfg = SimpleNamespace(
+        price = 200,
+        auto_price_reduction = _price_cfg(on_update = False, amount = 25),
+        price_reduction_count = 0,
+        repost_count = 1,
+        updated_on = None,
+        created_on = None,
+    )
+
+    apply_auto_price_reduction(ad_cfg, {}, "ad_no_update.yaml", mode = AdUpdateStrategy.MODIFY)
+
+    assert ad_cfg.price == 200
+    assert ad_cfg.price_reduction_count == 0
+
+
+@pytest.mark.unit
+def test_apply_modify_mode_applies_reduction_when_on_update_true_and_day_delay_satisfied(
+    monkeypatch:pytest.MonkeyPatch,
+    apply_auto_price_reduction:_ApplyAutoPriceReduction,
+) -> None:
+    """MODIFY mode with on_update=true reduces price when day delay is met.
+
+    delay_reposts must be ignored in MODIFY mode (repost count does not change).
+    """
+    reference = datetime(2025, 1, 1, tzinfo = timezone.utc)
+    ad_cfg = SimpleNamespace(
+        price = 200,
+        # delay_reposts=5 would normally block reduction, but MODIFY mode ignores it
+        auto_price_reduction = _price_cfg(on_update = True, amount = 25, delay_reposts = 5, delay_days = 3),
+        price_reduction_count = 0,
+        repost_count = 1,
+        updated_on = reference - timedelta(days = 5),
+        created_on = reference - timedelta(days = 10),
+    )
+
+    monkeypatch.setattr("kleinanzeigen_bot.misc.now", lambda: reference)
+
+    apply_auto_price_reduction(ad_cfg, {}, "ad_modify.yaml", mode = AdUpdateStrategy.MODIFY)
+
+    assert ad_cfg.price == 150  # 200 * 0.75
+    assert ad_cfg.price_reduction_count == 1
+
+
+@pytest.mark.unit
+def test_apply_modify_mode_skips_new_cycle_when_day_delay_not_satisfied(
+    monkeypatch:pytest.MonkeyPatch,
+    apply_auto_price_reduction:_ApplyAutoPriceReduction,
+) -> None:
+    """MODIFY mode with on_update=true does NOT apply a new cycle when day delay is not met."""
+    reference = datetime(2025, 1, 1, tzinfo = timezone.utc)
+    ad_cfg = SimpleNamespace(
+        price = 200,
+        auto_price_reduction = _price_cfg(on_update = True, amount = 25, delay_days = 3),
+        price_reduction_count = 0,
+        repost_count = 1,
+        updated_on = reference - timedelta(days = 1),  # only 1 day elapsed, need 3
+        created_on = reference - timedelta(days = 10),
+    )
+
+    monkeypatch.setattr("kleinanzeigen_bot.misc.now", lambda: reference)
+
+    apply_auto_price_reduction(ad_cfg, {}, "ad_delay_not_met.yaml", mode = AdUpdateStrategy.MODIFY)
+
+    assert ad_cfg.price == 200
+    assert ad_cfg.price_reduction_count == 0
+
+
+@pytest.mark.unit
+def test_apply_modify_mode_restores_reduced_price_with_prior_reductions(
+    apply_auto_price_reduction:_ApplyAutoPriceReduction,
+) -> None:
+    """Restore-first invariant: effective reduced price is recalculated from base price
+    and existing reduction_count even when no new cycle is eligible.
+
+    This prevents the YAML base price from overwriting an already-reduced effective price
+    during MODIFY operations.
+    """
+    ad_cfg = SimpleNamespace(
+        price = 100,  # YAML base price (original)
+        auto_price_reduction = _price_cfg(on_update = True, amount = 10, delay_days = 5),
+        price_reduction_count = 2,  # 2 prior reductions were applied
+        repost_count = 5,
+        updated_on = None,  # missing timestamp → day delay not satisfied
+        created_on = None,
+    )
+
+    apply_auto_price_reduction(ad_cfg, {}, "ad_restore.yaml", mode = AdUpdateStrategy.MODIFY)
+
+    # base=100, 2 cycles of 10%: 100*0.9=90 → 90*0.9=81
+    assert ad_cfg.price == 81  # restored to reduced price, not left at base 100
+    assert ad_cfg.price_reduction_count == 2  # no increment (no new cycle)
+
+
+@pytest.mark.unit
+def test_cross_mode_update_then_publish_preserves_reduced_price(
+    apply_auto_price_reduction:_ApplyAutoPriceReduction,
+) -> None:
+    """After a MODIFY-mode reduction, a subsequent REPLACE with no newly eligible cycle
+    must preserve the reduced price.
+
+    Simulates:
+      1. MODIFY applies one reduction cycle (100 → 90).
+      2. Price and counters are persisted (simulated by resetting price to base and
+         adjusting counters as if re-loaded from YAML).
+      3. REPLACE runs but no new repost cycle is eligible → reduced price restored.
+    """
+    cfg = _price_cfg(on_update = True, amount = 10, delay_days = 0)
+
+    # --- Step 1: MODIFY applies first reduction ---
+    ad_cfg = SimpleNamespace(
+        price = 100,
+        auto_price_reduction = cfg,
+        price_reduction_count = 0,
+        repost_count = 1,
+        updated_on = None,
+        created_on = None,
+    )
+    apply_auto_price_reduction(ad_cfg, {}, "ad_cross.yaml", mode = AdUpdateStrategy.MODIFY)
+    assert ad_cfg.price == 90
+    assert ad_cfg.price_reduction_count == 1
+
+    # --- Step 2: Simulate re-load from YAML (price resets to base) ---
+    # repost_count and price_reduction_count reflect post-persist state
+    ad_cfg.price = 100  # YAML always stores base price
+    ad_cfg.repost_count = 2
+    ad_cfg.price_reduction_count = 2  # persisted after successful publish
+
+    # --- Step 3: REPLACE mode, no new repost cycle eligible ---
+    apply_auto_price_reduction(ad_cfg, {}, "ad_cross.yaml", mode = AdUpdateStrategy.REPLACE)
+
+    # Restore-first: 2 cycles from base 100 → 81, NOT left at base 100
+    assert ad_cfg.price == 81
+    assert ad_cfg.price_reduction_count == 2

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -723,3 +723,39 @@ def test_cross_mode_update_then_publish_preserves_reduced_price(
     # Restore-first: keep the single previously applied cycle from base 100 → 90
     assert ad_cfg.price == 90
     assert ad_cfg.price_reduction_count == 1
+
+
+def test_modify_on_update_false_restores_price(
+    apply_auto_price_reduction:_ApplyAutoPriceReduction,
+) -> None:
+    """MODIFY with on_update=false must still restore previously reduced prices.
+
+    Regression test: when on_update is false, the evaluator must still compute
+    and restore the effective price from price_reduction_count.  Without this,
+    an ad that previously received reductions via REPLACE would have its base
+    YAML price submitted during an update, silently reverting the reduction.
+
+    Given:
+      - base price 200, one 10% reduction already applied (→ 180)
+      - price_reduction_count = 1, on_update = false
+    Expected:
+      - price is restored to 180 (not base 200)
+      - price_reduction_count unchanged (no new cycle)
+    """
+    cfg = _price_cfg(on_update = False, amount = 10, delay_reposts = 0, delay_days = 0)
+
+    ad_cfg = SimpleNamespace(
+        price = 200,  # YAML base price (not yet restored)
+        auto_price_reduction = cfg,
+        price_reduction_count = 1,  # one reduction already applied
+        repost_count = 1,
+        updated_on = None,
+        created_on = None,
+    )
+
+    apply_auto_price_reduction(ad_cfg, {}, "ad_restore.yaml", mode = AdUpdateStrategy.MODIFY)
+
+    # Price must be restored from base 200 with one 10% reduction → 180
+    assert ad_cfg.price == 180
+    # Counter must NOT advance (on_update is false)
+    assert ad_cfg.price_reduction_count == 1

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -693,10 +693,10 @@ def test_cross_mode_update_then_publish_preserves_reduced_price(
     Simulates:
       1. MODIFY applies one reduction cycle (100 → 90).
       2. Price and counters are persisted (simulated by resetting price to base and
-         adjusting counters as if re-loaded from YAML).
+         restoring counters as if re-loaded from YAML after one applied cycle).
       3. REPLACE runs but no new repost cycle is eligible → reduced price restored.
     """
-    cfg = _price_cfg(on_update = True, amount = 10, delay_days = 0)
+    cfg = _price_cfg(on_update = True, amount = 10, delay_reposts = 1, delay_days = 0)
 
     # --- Step 1: MODIFY applies first reduction ---
     ad_cfg = SimpleNamespace(
@@ -712,14 +712,14 @@ def test_cross_mode_update_then_publish_preserves_reduced_price(
     assert ad_cfg.price_reduction_count == 1
 
     # --- Step 2: Simulate re-load from YAML (price resets to base) ---
-    # repost_count and price_reduction_count reflect post-persist state
+    # repost_count and price_reduction_count reflect post-persist state after one cycle
     ad_cfg.price = 100  # YAML always stores base price
     ad_cfg.repost_count = 2
-    ad_cfg.price_reduction_count = 2  # persisted after successful publish
+    ad_cfg.price_reduction_count = 1
 
     # --- Step 3: REPLACE mode, no new repost cycle eligible ---
     apply_auto_price_reduction(ad_cfg, {}, "ad_cross.yaml", mode = AdUpdateStrategy.REPLACE)
 
-    # Restore-first: 2 cycles from base 100 → 81, NOT left at base 100
-    assert ad_cfg.price == 81
-    assert ad_cfg.price_reduction_count == 2
+    # Restore-first: keep the single previously applied cycle from base 100 → 90
+    assert ad_cfg.price == 90
+    assert ad_cfg.price_reduction_count == 1

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -160,7 +160,7 @@ def test_apply_auto_price_reduction_disabled_emits_no_decision_logs(
 
 
 @pytest.mark.unit
-def test_apply_auto_price_reduction_logs_drop(caplog:pytest.LogCaptureFixture, apply_auto_price_reduction:_ApplyAutoPriceReduction) -> None:
+def test_apply_auto_price_reduction_reduces_price_by_configured_percentage(apply_auto_price_reduction:_ApplyAutoPriceReduction) -> None:
     ad_cfg = SimpleNamespace(
         price = 200,
         auto_price_reduction = AutoPriceReductionConfig(
@@ -178,12 +178,8 @@ def test_apply_auto_price_reduction_logs_drop(caplog:pytest.LogCaptureFixture, a
     )
 
     ad_orig:dict[str, Any] = {}
+    apply_auto_price_reduction(ad_cfg, ad_orig, "ad_test.yaml")
 
-    with caplog.at_level(logging.INFO):
-        apply_auto_price_reduction(ad_cfg, ad_orig, "ad_test.yaml")
-
-    expected = _("Auto price reduction applied: %s -> %s after %s reduction cycles") % (200, 150, 1)
-    assert any(expected in message for message in caplog.messages)
     assert ad_cfg.price == 150
     assert ad_cfg.price_reduction_count == 1
     # Note: price_reduction_count is NOT persisted to ad_orig until after successful publish
@@ -264,7 +260,7 @@ def test_apply_auto_price_reduction_warns_and_preserves_state_on_invalid_config(
 
 
 @pytest.mark.unit
-def test_apply_auto_price_reduction_respects_repost_delay(caplog:pytest.LogCaptureFixture, apply_auto_price_reduction:_ApplyAutoPriceReduction) -> None:
+def test_apply_auto_price_reduction_respects_repost_delay(apply_auto_price_reduction:_ApplyAutoPriceReduction) -> None:
     ad_cfg = SimpleNamespace(
         price = 200,
         auto_price_reduction = AutoPriceReductionConfig(
@@ -282,18 +278,10 @@ def test_apply_auto_price_reduction_respects_repost_delay(caplog:pytest.LogCaptu
     )
 
     ad_orig:dict[str, Any] = {}
-
-    with caplog.at_level(logging.DEBUG):
-        apply_auto_price_reduction(ad_cfg, ad_orig, "ad_delay.yaml")
+    apply_auto_price_reduction(ad_cfg, ad_orig, "ad_delay.yaml")
 
     assert ad_cfg.price == 200
-    delayed_message = _("Auto price reduction delayed for [%s]: waiting %s more reposts (completed %s, applied %s reductions)") % ("ad_delay.yaml", 2, 2, 0)
-    assert any(delayed_message in message for message in caplog.messages)
-    decision_message = (
-        "Auto price reduction decision for [ad_delay.yaml]: skipped (repost delay). "
-        "next reduction earliest at repost >= 4 and day delay 0/0 days. repost_count=2 eligible_cycles=0 applied_cycles=0"
-    )
-    assert any(message.startswith(decision_message) for message in caplog.messages)
+    assert ad_cfg.price_reduction_count == 0
 
 
 @pytest.mark.unit

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -586,10 +586,10 @@ def test_fractional_min_price_is_rounded_up_with_ceiling() -> None:
 
 
 @pytest.mark.unit
-def test_apply_modify_mode_skips_when_on_update_false(
+def test_apply_modify_mode_on_update_false_leaves_base_price_when_no_prior_reductions(
     apply_auto_price_reduction:_ApplyAutoPriceReduction,
 ) -> None:
-    """MODIFY mode with on_update=false must not touch the price at all."""
+    """With no prior reductions, MODIFY + on_update=false must not start a new cycle."""
     ad_cfg = SimpleNamespace(
         price = 200,
         auto_price_reduction = _price_cfg(on_update = False, amount = 25),

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -220,49 +220,34 @@ def test_apply_auto_price_reduction_logs_unchanged_price_at_floor(
 
 
 @pytest.mark.unit
-def test_apply_auto_price_reduction_warns_when_price_missing(caplog:pytest.LogCaptureFixture, apply_auto_price_reduction:_ApplyAutoPriceReduction) -> None:
-    ad_cfg = SimpleNamespace(
-        price = None,
-        auto_price_reduction = AutoPriceReductionConfig(
-            enabled = True,
-            strategy = "PERCENTAGE",
-            amount = 25,
-            min_price = 10,
-            delay_reposts = 0,
-            delay_days = 0,
-        ),
-        price_reduction_count = 2,
-        repost_count = 2,
-        updated_on = None,
-        created_on = None,
-    )
-
-    ad_orig:dict[str, Any] = {}
-
-    with caplog.at_level(logging.WARNING):
-        apply_auto_price_reduction(ad_cfg, ad_orig, "ad_warning.yaml")
-
-    expected = _("Auto price reduction is enabled for [%s] but no price is configured.") % ("ad_warning.yaml",)
-    assert any(expected in message for message in caplog.messages)
-    assert ad_cfg.price is None
-
-
-@pytest.mark.unit
-def test_apply_auto_price_reduction_warns_when_min_price_equals_price(
-    caplog:pytest.LogCaptureFixture, apply_auto_price_reduction:_ApplyAutoPriceReduction
+@pytest.mark.parametrize(
+    ("price", "min_price", "price_reduction_count", "repost_count"),
+    [
+        (None, 10, 2, 2),
+        (100, 100, 0, 1),
+    ],
+    ids = ["price_missing", "min_price_equals_price"],
+)
+def test_apply_auto_price_reduction_warns_and_preserves_state_on_invalid_config(
+    price:int | None,
+    min_price:int,
+    price_reduction_count:int,
+    repost_count:int,
+    caplog:pytest.LogCaptureFixture,
+    apply_auto_price_reduction:_ApplyAutoPriceReduction,
 ) -> None:
     ad_cfg = SimpleNamespace(
-        price = 100,
+        price = price,
         auto_price_reduction = AutoPriceReductionConfig(
             enabled = True,
             strategy = "PERCENTAGE",
             amount = 25,
-            min_price = 100,
+            min_price = min_price,
             delay_reposts = 0,
             delay_days = 0,
         ),
-        price_reduction_count = 0,
-        repost_count = 1,
+        price_reduction_count = price_reduction_count,
+        repost_count = repost_count,
         updated_on = None,
         created_on = None,
     )
@@ -270,12 +255,12 @@ def test_apply_auto_price_reduction_warns_when_min_price_equals_price(
     ad_orig:dict[str, Any] = {}
 
     with caplog.at_level(logging.WARNING):
-        apply_auto_price_reduction(ad_cfg, ad_orig, "ad_equal_prices.yaml")
+        apply_auto_price_reduction(ad_cfg, ad_orig, "ad_invalid.yaml")
 
-    expected = _("Auto price reduction is enabled for [%s] but min_price equals price (%s) - no reductions will occur.") % ("ad_equal_prices.yaml", 100)
-    assert any(expected in message for message in caplog.messages)
-    assert ad_cfg.price == 100
-    assert ad_cfg.price_reduction_count == 0
+    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warning_records) >= 1
+    assert ad_cfg.price == price
+    assert ad_cfg.price_reduction_count == price_reduction_count
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## ℹ️ Description
Automatic price reduction now works reliably during `update` runs (MODIFY mode), not only during `publish`, while staying backward compatible for existing configurations. The verify flow also explains what will happen in both modes before any command touches live ads.

- Link to the related issue(s): Issue # N/A
- Describe the motivation and context for this change.
  - Update-mode reductions needed to be explicitly opt-in so existing setups remain unchanged by default.
  - Pricing behavior had to stay deterministic across retries and mixed publish/update workflows.
  - Preview output and documentation now mirror real runtime behavior so configuration decisions are easier to trust.

## 📋 Changes Summary
- Added `auto_price_reduction.on_update` (`bool`, default `false`) in model/schema so update-mode reductions are explicitly opt-in.
- Refactored price reduction flow into decision + apply steps:
  - `evaluate_auto_price_reduction(...)` computes mode-aware outcomes
  - `apply_auto_price_reduction(...)` applies mutations and logs from that decision
- Implemented restore-first behavior so effective reduced price is recomputed from base `price` + `price_reduction_count` before deciding a new cycle.
- Updated `verify` to preview both publish and update outcomes.
- Kept update-mode semantics explicit:
  - `delay_days` applies
  - `delay_reposts` is ignored in MODIFY mode
- Fixed retry idempotency in `publish_ads` by restoring baseline `price` and `price_reduction_count` before each retry.
- Addressed follow-up review feedback:
  - no-visible-change cycles advance counters (for fractional accumulation)
  - verify output stays non-misleading for no-visible-change cases
  - tightened a unit assertion from `>= 1` to `== 1`
  - tightened smoke behavior for `create-config` when config already exists
  - clarified README/docs and documented `price_reduction_count` as auto-managed
- Expanded/updated tests for:
  - MODIFY `on_update` behavior
  - restore-first invariant
  - cross-mode interactions
  - retry baseline reset
  - verify mode previews
  - floor-clamped no-visible-change counter advancement

Mention any dependencies, configuration changes, or additional requirements introduced.
- Configuration change: new optional field `auto_price_reduction.on_update` (default `false`, backward compatible).
- No external runtime dependency changes.
- Existing configurations continue to work unchanged unless `on_update` is enabled.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `verify` now previews automatic price-reduction outcomes for both publish and update modes.
  * New config option (auto_price_reduction.on_update, default false) to enable reductions during update runs.

* **Documentation**
  * Clarified publish vs. update reduction behavior, timing rules, restore-first semantics, logging, examples, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->