### PR TITLE
fix(update): harden per-ad retries and location convergence

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -43,7 +43,7 @@ from .utils.web_scraping_mixin import By, Element, Is, WebScrapingMixin
 LOG:Final[loggers.Logger] = loggers.get_logger(__name__)
 LOG.setLevel(loggers.INFO)
 
-PUBLISH_MAX_RETRIES:Final[int] = 3
+SUBMISSION_MAX_RETRIES:Final[int] = 3
 _NUMERIC_IDS_RE:Final[re.Pattern[str]] = re.compile(r"^\d+(,\d+)*$")
 _SPECIAL_ATTRIBUTE_TOKEN_RE:Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_]+$")
 # See issue #930 for migrating __select_button_combobox to web_select_button_combobox
@@ -2178,7 +2178,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
     async def publish_ads(self, ad_cfgs:list[tuple[str, Ad, dict[str, Any]]]) -> None:
         count = 0
         failed_count = 0
-        max_retries = PUBLISH_MAX_RETRIES
+        max_retries = SUBMISSION_MAX_RETRIES
 
         published_ads = await self._fetch_published_ads()
 
@@ -2531,20 +2531,178 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             f"}})({js_element_id},{js_value})"
         )
 
+    @staticmethod
+    def __location_matches_target(target:str, candidate:str | None) -> bool:
+        if not candidate:
+            return False
+
+        normalized_target = " ".join(target.split()).casefold()
+        normalized_candidate = " ".join(candidate.split()).casefold()
+        if not normalized_target or not normalized_candidate:
+            return False
+
+        if normalized_target == normalized_candidate:
+            return True
+
+        if " - " in normalized_target:
+            return False
+
+        if normalized_candidate.startswith(f"{normalized_target} - "):
+            return True
+
+        candidate_city = normalized_candidate.rsplit(" - ", maxsplit = 1)[-1]
+        return normalized_target == candidate_city
+
+    async def __city_option_text(self, option:Element) -> str:
+        text = str(getattr(option, "text", "") or "").strip()
+        if text:
+            return text
+        try:
+            return (await self._extract_visible_text(option)).strip()
+        except TimeoutError:
+            return ""
+
+    async def __read_city_selection_text(self) -> str | None:
+        city_timeout = self._timeout("default")
+        quick_dom_timeout = self._timeout("quick_dom")
+        try:
+            city_element = await self.web_find(By.ID, "ad-city", timeout = city_timeout)
+        except TimeoutError:
+            return None
+        if city_element is None:
+            return None
+
+        if city_element.local_name == "input":
+            live_value = await city_element.apply("(elem) => (elem.value || '').trim()")
+            if isinstance(live_value, str) and live_value.strip():
+                return live_value
+
+        try:
+            selected_text = await self.web_text(By.ID, "ad-city-selected-option", timeout = quick_dom_timeout)
+            if selected_text:
+                return selected_text
+        except TimeoutError:
+            pass
+
+        live_text = await city_element.apply("(elem) => (elem.textContent || '').trim()")
+        if isinstance(live_text, str) and live_text.strip():
+            return live_text
+
+        try:
+            selected_text = await self.web_text(By.ID, "ad-city", timeout = quick_dom_timeout)
+            if selected_text:
+                return selected_text
+        except TimeoutError:
+            return None
+        return None
+
+    async def __select_city_combobox_option(self, target:str) -> None:
+        quick_dom_timeout = self._timeout("quick_dom")
+        city_flow_timeout = self._timeout("default")
+
+        await self.web_click(By.ID, "ad-city", timeout = quick_dom_timeout)
+        city_element = await self.web_find(By.ID, "ad-city", timeout = quick_dom_timeout)
+        city_attrs = getattr(city_element, "attrs", None)
+        listbox_id_raw = None
+        if city_attrs is not None:
+            listbox_id_raw = city_attrs.get("aria-controls") if hasattr(city_attrs, "get") else getattr(city_attrs, "aria-controls", None)
+        listbox_id = next((candidate for candidate in str(listbox_id_raw or "").split() if candidate.strip()), "")
+        if not listbox_id:
+            listbox_id = "ad-city-menu"
+
+        listbox_id_css = listbox_id.replace("\\", "\\\\").replace('"', '\\"')
+        listbox_scope = f'[id="{listbox_id_css}"]'
+        option_selector = (
+            f"{listbox_scope} [role='option'], "
+            f"{listbox_scope} li[aria-selected='true'], {listbox_scope} li[aria-selected='false'], "
+            f"{listbox_scope} button[aria-selected='true'], {listbox_scope} button[aria-selected='false']"
+        )
+
+        candidates:list[Element] = []
+
+        async def _options_available() -> bool:
+            nonlocal candidates
+            try:
+                candidates = await self.web_find_all(By.CSS_SELECTOR, option_selector, timeout = quick_dom_timeout)
+            except TimeoutError:
+                candidates = []
+            return bool(candidates)
+
+        try:
+            await self.web_await(_options_available, timeout = city_flow_timeout)
+        except TimeoutError as ex:
+            raise TimeoutError(_("City combobox options did not load for location: %s") % target) from ex
+
+        def normalize(value:str) -> str:
+            return " ".join(value.split()).casefold()
+
+        target_norm = normalize(target)
+        option_entries = [(candidate, normalize(await self.__city_option_text(candidate))) for candidate in candidates]
+
+        exact_match = next((entry[0] for entry in option_entries if entry[1] == target_norm), None)
+        city_match:Element | None = None
+        prefix_matches:list[Element] = []
+        if " - " not in target_norm:
+            city_match = next((entry[0] for entry in option_entries if entry[1] and entry[1].rsplit(" - ", maxsplit = 1)[-1] == target_norm), None)
+            prefix_matches = [entry[0] for entry in option_entries if entry[1].startswith(f"{target_norm} - ")]
+
+        if exact_match is None and city_match is None and len(prefix_matches) > 1:
+            raise TimeoutError(_("City combobox options are ambiguous for location: %s") % target)
+
+        selected_option = exact_match or city_match or (prefix_matches[0] if len(prefix_matches) == 1 else None)
+        if selected_option is None:
+            raise TimeoutError(_("No city combobox option matched location: %s") % target)
+
+        await selected_option.click()
+
+        async def _selection_converged() -> bool:
+            selected_city = await self.__read_city_selection_text()
+            return self.__location_matches_target(target, selected_city)
+
+        try:
+            await self.web_await(_selection_converged, timeout = city_flow_timeout)
+        except TimeoutError as ex:
+            raise TimeoutError(_("City selection did not converge for location: %s") % target) from ex
+
+    async def __set_contact_location(self, location:str) -> None:
+        target = location.strip()
+        if not target:
+            return
+
+        selected_city = await self.__read_city_selection_text()
+        if self.__location_matches_target(target, selected_city):
+            return
+
+        city_timeout = self._timeout("default")
+        city_element = await self.web_find(By.ID, "ad-city", timeout = city_timeout)
+        if city_element is None:
+            raise TimeoutError(_("Unsupported city element type while setting contact location: <%s>") % "missing")
+        city_tag = city_element.local_name
+        city_role = str(city_element.attrs.get("role") or "").casefold()
+        if city_tag != "button" or city_role != "combobox":
+            raise TimeoutError(_("Unsupported city element type while setting contact location: <%s>") % city_tag)
+
+        await self.__select_city_combobox_option(target)
+
     async def __set_contact_fields(self, contact:Contact) -> None:
         #############################
         # set contact zipcode
         #############################
+        zipcode_failed = False
         if contact.zipcode:
             try:
-                await self.__react_input("ad-zip-code", str(contact.zipcode))
+                await self.web_input(By.ID, "ad-zip-code", str(contact.zipcode))
             except TimeoutError as ex:
                 LOG.warning("Could not set contact zipcode: %s (%s)", contact.zipcode, ex)
+                zipcode_failed = True
+        else:
+            zipcode_failed = True
+
+        if zipcode_failed:
+            raise TimeoutError(_("Failed to set contact zipcode: %s") % contact.zipcode)
+
         if contact.location:
-            try:
-                await self.__react_input("ad-city", contact.location)
-            except TimeoutError as ex:
-                LOG.warning("Could not set contact location: %s (%s)", contact.location, ex)
+            await self.__set_contact_location(contact.location)
 
         #############################
         # set contact street
@@ -2599,6 +2757,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             None
         """
         count = 0
+        failed_count = 0
+        max_retries = SUBMISSION_MAX_RETRIES
 
         published_ads = await self._fetch_published_ads()
 
@@ -2615,13 +2775,53 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 continue
 
             count += 1
+            success = False
+            baseline_price = ad_cfg.price
+            baseline_price_reduction_count = ad_cfg.price_reduction_count
 
-            await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads, AdUpdateStrategy.MODIFY)
-            publish_timeout = self._timeout("publishing_result")
-            await self.web_await(self.__check_publishing_result, timeout = publish_timeout)
+            for attempt in range(1, max_retries + 1):
+                try:
+                    ad_cfg.price = baseline_price
+                    ad_cfg.price_reduction_count = baseline_price_reduction_count
+                    await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads, AdUpdateStrategy.MODIFY)
+                    success = True
+                    break
+                except asyncio.CancelledError:
+                    raise
+                except PublishSubmissionUncertainError as ex:
+                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                    LOG.warning(
+                        "Attempt %s/%s for '%s' reached submit boundary but failed: %s. Not retrying to prevent duplicate modifications.",
+                        attempt,
+                        max_retries,
+                        ad_cfg.title,
+                        ex,
+                    )
+                    LOG.warning("Manual recovery required for '%s'. Check 'Meine Anzeigen' to confirm whether the update was applied.", ad_cfg.title)
+                    failed_count += 1
+                    break
+                except (TimeoutError, ProtocolException) as ex:
+                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                    if attempt >= max_retries:
+                        LOG.error("All %s attempts failed for '%s': %s. Skipping ad.", max_retries, ad_cfg.title, ex)
+                        failed_count += 1
+                        break
+
+                    LOG.warning("Attempt %s/%s failed for '%s': %s. Retrying...", attempt, max_retries, ad_cfg.title, ex)
+                    await self.web_sleep(2_000)
+
+            if success:
+                try:
+                    publish_timeout = self._timeout("publishing_result")
+                    await self.web_await(self.__check_publishing_result, timeout = publish_timeout)
+                except TimeoutError:
+                    LOG.warning(" -> Could not confirm update for '%s', but changes may be online", ad_cfg.title)
 
         LOG.info("############################################")
-        LOG.info("DONE: updated %s", pluralize("ad", count))
+        if failed_count > 0:
+            LOG.info("DONE: updated %s (%s failed after retries)", pluralize("ad", count - failed_count), failed_count)
+        else:
+            LOG.info("DONE: updated %s", pluralize("ad", count))
         LOG.info("############################################")
 
     async def __set_condition(self, condition_value:str) -> bool:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2582,6 +2582,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             if selected_text:
                 return selected_text
         except TimeoutError:
+            # #ad-city-selected-option may not exist in all DOM states; fall through to textContent
             pass
 
         live_text = await city_element.apply("(elem) => (elem.textContent || '').trim()")
@@ -2640,16 +2641,19 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         option_entries = [(candidate, normalize(await self.__city_option_text(candidate))) for candidate in candidates]
 
         exact_match = next((entry[0] for entry in option_entries if entry[1] == target_norm), None)
-        city_match:Element | None = None
+        city_matches:list[Element] = []
         prefix_matches:list[Element] = []
         if " - " not in target_norm:
-            city_match = next((entry[0] for entry in option_entries if entry[1] and entry[1].rsplit(" - ", maxsplit = 1)[-1] == target_norm), None)
+            city_matches = [entry[0] for entry in option_entries if entry[1] and entry[1].rsplit(" - ", maxsplit = 1)[-1] == target_norm]
             prefix_matches = [entry[0] for entry in option_entries if entry[1].startswith(f"{target_norm} - ")]
 
-        if exact_match is None and city_match is None and len(prefix_matches) > 1:
+        if exact_match is None and len(city_matches) > 1:
             raise TimeoutError(_("City combobox options are ambiguous for location: %s") % target)
 
-        selected_option = exact_match or city_match or (prefix_matches[0] if len(prefix_matches) == 1 else None)
+        if exact_match is None and not city_matches and len(prefix_matches) > 1:
+            raise TimeoutError(_("City combobox options are ambiguous for location: %s") % target)
+
+        selected_option = exact_match or (city_matches[0] if city_matches else None) or (prefix_matches[0] if len(prefix_matches) == 1 else None)
         if selected_option is None:
             raise TimeoutError(_("No city combobox option matched location: %s") % target)
 
@@ -2686,23 +2690,17 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
     async def __set_contact_fields(self, contact:Contact) -> None:
         #############################
-        # set contact zipcode
+        # set contact zipcode + location
         #############################
-        zipcode_failed = False
         if contact.zipcode:
             try:
                 await self.web_input(By.ID, "ad-zip-code", str(contact.zipcode))
             except TimeoutError as ex:
                 LOG.warning("Could not set contact zipcode: %s (%s)", contact.zipcode, ex)
-                zipcode_failed = True
-        else:
-            zipcode_failed = True
+                raise TimeoutError(_("Failed to set contact zipcode: %s") % contact.zipcode) from ex
 
-        if zipcode_failed:
-            raise TimeoutError(_("Failed to set contact zipcode: %s") % contact.zipcode)
-
-        if contact.location:
-            await self.__set_contact_location(contact.location)
+            if contact.location:
+                await self.__set_contact_location(contact.location)
 
         #############################
         # set contact street

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -221,6 +221,12 @@ kleinanzeigen_bot/__init__.py:
     "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' von [%s]..."
     "Skipping because ad is reserved": "Überspringen, da Anzeige reserviert ist"
     " -> SKIPPED: ad '%s' (ID: %s) not found in published ads": " -> ÜBERSPRUNGEN: Anzeige '%s' (ID: %s) nicht in veröffentlichten Anzeigen gefunden"
+    "Attempt %s/%s for '%s' reached submit boundary but failed: %s. Not retrying to prevent duplicate modifications.": "Versuch %s/%s für '%s' hat die Sendegrenze erreicht, ist aber fehlgeschlagen: %s. Kein weiterer Versuch, um doppelte Änderungen zu vermeiden."
+    "Manual recovery required for '%s'. Check 'Meine Anzeigen' to confirm whether the update was applied.": "Manuelle Nachbearbeitung für '%s' erforderlich. Bitte unter 'Meine Anzeigen' prüfen, ob die Aktualisierung übernommen wurde."
+    "All %s attempts failed for '%s': %s. Skipping ad.": "Alle %s Versuche für '%s' sind fehlgeschlagen: %s. Anzeige wird übersprungen."
+    "Attempt %s/%s failed for '%s': %s. Retrying...": "Versuch %s/%s für '%s' ist fehlgeschlagen: %s. Erneuter Versuch..."
+    " -> Could not confirm update for '%s', but changes may be online": " -> Aktualisierung für '%s' konnte nicht bestätigt werden, aber Änderungen könnten online sein"
+    "DONE: updated %s (%s failed after retries)": "FERTIG: %s aktualisiert (%s nach Wiederholungen fehlgeschlagen)"
     "DONE: updated %s": "FERTIG: %s aktualisiert"
     "ad": "Anzeige"
 
@@ -232,11 +238,20 @@ kleinanzeigen_bot/__init__.py:
   __set_contact_fields:
     "Could not set contact street.": "Kontaktstraße konnte nicht gesetzt werden."
     "Could not set contact name.": "Kontaktname konnte nicht gesetzt werden."
-    "Could not set contact location: %s (%s)": "Kontaktort konnte nicht gesetzt werden: %s (%s)"
     "Could not set contact zipcode: %s (%s)": "Kontakt-PLZ konnte nicht gesetzt werden: %s (%s)"
+    "Failed to set contact zipcode: %s": "Kontakt-PLZ konnte nicht gesetzt werden: %s"
     "Could not set contact phone despite visible phone field: %s": "Telefonnummer konnte trotz sichtbarem Feld nicht gesetzt werden: %s"
     ? "Phone number field not present on page. This is expected for many private accounts; commercial accounts may still support phone numbers."
     : "Telefonnummernfeld auf der Seite nicht vorhanden. Dies ist bei vielen privaten Konten zu erwarten; gewerbliche Konten unterstützen Telefonnummern möglicherweise weiterhin."
+
+  __select_city_combobox_option:
+    "City combobox options did not load for location: %s": "Stadt-Combobox-Optionen für Ort nicht geladen: %s"
+    "City combobox options are ambiguous for location: %s": "Stadt-Combobox-Optionen für Ort sind mehrdeutig: %s"
+    "No city combobox option matched location: %s": "Keine Stadt-Combobox-Option passt zum Ort: %s"
+    "City selection did not converge for location: %s": "Stadtauswahl ist nicht auf den Ort konvergiert: %s"
+
+  __set_contact_location:
+    "Unsupported city element type while setting contact location: <%s>": "Nicht unterstützter Stadt-Elementtyp beim Setzen des Kontaktorts: <%s>"
 
   __upload_images:
     " -> found %s": "-> %s gefunden"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2107,6 +2107,10 @@ class TestKleinanzeigenBotContactLocationHardening:
             ("10115 - Metroville", "12623 - Metroville", False),
             ("Metroville", "12623 - Metroville", True),
             ("Berlin", "Berlin - Mitte", True),
+            ("Metroville", None, False),
+            ("Berlin", "Hamburg", False),
+            ("Berlin", "berlin", True),
+            ("Berlin", "  Berlin  ", True),
         ],
     )
     def test_location_matches_target(self, test_bot:KleinanzeigenBot, target:str, candidate:str | None, expected:bool) -> None:
@@ -2144,6 +2148,56 @@ class TestKleinanzeigenBotContactLocationHardening:
             await getattr(test_bot, "_KleinanzeigenBot__set_contact_fields")(ad_cfg.contact)
 
         set_location_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_contact_fields_skips_zipcode_and_location_when_empty(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """When no zipcode is configured, both ZIP entry and location setting are skipped without error."""
+        config = base_ad_config | {"contact": base_ad_config["contact"] | {"zipcode": ""}}
+        ad_cfg = Ad.model_validate(config)
+
+        with (
+            patch.object(test_bot, "web_input", new_callable = AsyncMock) as web_input_mock,
+            patch.object(test_bot, "_KleinanzeigenBot__set_contact_location", new_callable = AsyncMock) as set_location_mock,
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = True),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_contact_fields")(ad_cfg.contact)
+
+        web_input_mock.assert_not_awaited()
+        set_location_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_contact_location_fails_when_city_suffix_matches_multiple_zip_codes(self, test_bot:KleinanzeigenBot) -> None:
+        """When multiple ZIP codes share the same city name and no exact match, selection must fail closed."""
+        city_button = MagicMock(spec = Element)
+        city_button.local_name = "button"
+        city_button.attrs = {"role": "combobox", "aria-controls": "ad-city-menu"}
+
+        option_a = MagicMock(spec = Element)
+        option_a.text = "10115 - Metroville"
+        option_b = MagicMock(spec = Element)
+        option_b.text = "12623 - Metroville"
+
+        def _mock_city_option_text(elem:Element) -> str:
+            return str(getattr(elem, "text", "") or "")
+
+        async def _web_await_side_effect(condition:Callable[..., Awaitable[bool] | bool], **_:Any) -> Any:
+            result = condition()
+            return await result if asyncio.iscoroutine(result) else result
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = city_button),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [option_a, option_b]),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = _web_await_side_effect),
+            patch.object(test_bot, "_KleinanzeigenBot__read_city_selection_text", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "_KleinanzeigenBot__city_option_text", new_callable = AsyncMock, side_effect = _mock_city_option_text),
+            pytest.raises(TimeoutError, match = "City combobox options are ambiguous for location: Metroville"),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_contact_location")("Metroville")
 
     @pytest.mark.asyncio
     async def test_set_contact_location_raises_when_selection_does_not_converge(self, test_bot:KleinanzeigenBot) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -13,7 +13,7 @@ import pytest
 from nodriver.core.connection import ProtocolException
 from pydantic import ValidationError
 
-from kleinanzeigen_bot import LOG, PUBLISH_MAX_RETRIES, AdUpdateStrategy, KleinanzeigenBot, LoginDetectionReason, LoginDetectionResult, misc
+from kleinanzeigen_bot import LOG, SUBMISSION_MAX_RETRIES, AdUpdateStrategy, KleinanzeigenBot, LoginDetectionReason, LoginDetectionResult, misc
 from kleinanzeigen_bot._version import __version__
 from kleinanzeigen_bot.model.ad_model import Ad
 from kleinanzeigen_bot.model.config_model import AdDefaults, AutoPriceReductionConfig, Config, DiagnosticsConfig, PublishingConfig
@@ -1633,7 +1633,7 @@ class TestKleinanzeigenBotDiagnostics:
         ):
             await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
 
-        expected_retries = PUBLISH_MAX_RETRIES
+        expected_retries = SUBMISSION_MAX_RETRIES
         assert page.save_screenshot.await_count == expected_retries
         assert page.get_content.await_count == expected_retries
         entries = os.listdir(tmp_path)
@@ -1677,7 +1677,7 @@ class TestKleinanzeigenBotDiagnostics:
 
         entries = os.listdir(tmp_path)
         log_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.log")]
-        assert len(log_files) == PUBLISH_MAX_RETRIES
+        assert len(log_files) == SUBMISSION_MAX_RETRIES
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -1963,6 +1963,219 @@ class TestKleinanzeigenBotBasics:
         test_categories = {"test_cat": "test_id"}
         test_bot.categories = test_categories
         assert test_bot.categories == test_categories
+
+
+class TestKleinanzeigenBotUpdateAdsResilience:
+    @staticmethod
+    def _build_update_ad(base_ad_config:dict[str, Any], ad_id:int, title:str) -> tuple[str, Ad, dict[str, Any]]:
+        ad_payload = copy.deepcopy(base_ad_config) | {"id": ad_id, "title": title}
+        return (f"{ad_id}.yaml", Ad.model_validate(ad_payload), ad_payload)
+
+    @staticmethod
+    def _build_published_ads(*ad_ids:int) -> list[dict[str, Any]]:
+        return [{"id": ad_id, "state": "active"} for ad_id in ad_ids]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("first_failure", "first_title"),
+        [
+            (TimeoutError("transient timeout"), "Timeout Ad"),
+            (ProtocolException(MagicMock(), "connection lost", 0), "Protocol Failing"),
+            (TimeoutError("City selection did not converge for location: 10115 - Metroville"), "Location Failed"),
+        ],
+        ids = ["timeout_error", "protocol_exception", "location_non_convergence"],
+    )
+    async def test_update_ads_continues_after_retryable_first_ad_failure(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        first_failure:Exception,
+        first_title:str,
+    ) -> None:
+        ad_one = self._build_update_ad(base_ad_config, 101, first_title)
+        ad_two = self._build_update_ad(base_ad_config, 102, "Success Ad")
+
+        async def publish_side_effect(
+            _ad_file:str,
+            ad_cfg:Ad,
+            _ad_cfg_orig:dict[str, Any],
+            _published_ads:list[dict[str, Any]],
+            _mode:AdUpdateStrategy,
+        ) -> None:
+            if ad_cfg.id == 101:
+                raise first_failure
+
+        with (
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(101, 102)),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.update_ads([ad_one, ad_two])
+
+        assert publish_mock.await_count == SUBMISSION_MAX_RETRIES + 1
+        assert any(call.args[1].id == 102 for call in publish_mock.await_args_list)
+        assert all(call.args[4] == AdUpdateStrategy.MODIFY for call in publish_mock.await_args_list)
+        assert sleep_mock.await_count == SUBMISSION_MAX_RETRIES - 1
+
+    @pytest.mark.asyncio
+    async def test_update_ads_publish_submission_uncertain_is_not_retried(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        ad_one = self._build_update_ad(base_ad_config, 301, "Uncertain Update")
+        ad_two = self._build_update_ad(base_ad_config, 302, "Second Update")
+
+        async def publish_side_effect(
+            _ad_file:str,
+            ad_cfg:Ad,
+            _ad_cfg_orig:dict[str, Any],
+            _published_ads:list[dict[str, Any]],
+            _mode:AdUpdateStrategy,
+        ) -> None:
+            if ad_cfg.id == 301:
+                raise PublishSubmissionUncertainError("submission may have succeeded before failure")
+
+        with (
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(301, 302)),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.update_ads([ad_one, ad_two])
+
+        assert publish_mock.await_count == 2
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_ads_cancelled_error_propagates_immediately(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        ad_one = self._build_update_ad(base_ad_config, 401, "Cancelled Ad")
+        ad_two = self._build_update_ad(base_ad_config, 402, "Should Not Run")
+
+        with (
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(401, 402)),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = asyncio.CancelledError()) as publish_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await test_bot.update_ads([ad_one, ad_two])
+
+        assert publish_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_update_ads_publishing_result_timeout_is_non_fatal(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        ad_one = self._build_update_ad(base_ad_config, 501, "Result Timeout")
+
+        with (
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(501)),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = TimeoutError("result timeout")),
+        ):
+            await test_bot.update_ads([ad_one])
+
+        publish_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_update_ads_summary_reports_mixed_outcomes(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        ad_one = self._build_update_ad(base_ad_config, 601, "Summary Failed")
+        ad_two = self._build_update_ad(base_ad_config, 602, "Summary Success")
+
+        async def publish_side_effect(
+            _ad_file:str,
+            ad_cfg:Ad,
+            _ad_cfg_orig:dict[str, Any],
+            _published_ads:list[dict[str, Any]],
+            _mode:AdUpdateStrategy,
+        ) -> None:
+            if ad_cfg.id == 601:
+                raise TimeoutError("still failing")
+
+        with (
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(601, 602)),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+            patch.object(LOG, "info") as log_info_mock,
+        ):
+            await test_bot.update_ads([ad_one, ad_two])
+
+        assert any(call.args and call.args[0] == "DONE: updated %s (%s failed after retries)" for call in log_info_mock.call_args_list)
+
+
+class TestKleinanzeigenBotContactLocationHardening:
+    @pytest.mark.parametrize(
+        ("target", "candidate", "expected"),
+        [
+            ("10115 - Metroville", "10115 - Metroville", True),
+            ("10115 - Metroville", "12623 - Metroville", False),
+            ("Metroville", "12623 - Metroville", True),
+            ("Berlin", "Berlin - Mitte", True),
+        ],
+    )
+    def test_location_matches_target(self, test_bot:KleinanzeigenBot, target:str, candidate:str | None, expected:bool) -> None:
+        matcher = getattr(test_bot, "_KleinanzeigenBot__location_matches_target")
+        assert matcher(target, candidate) is expected
+
+    @pytest.mark.asyncio
+    async def test_read_city_selection_text_prefers_live_input_value(self, test_bot:KleinanzeigenBot) -> None:
+        city_input = MagicMock(spec = Element)
+        city_input.local_name = "input"
+        city_input.apply = AsyncMock(return_value = "Live City")
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = city_input),
+            patch.object(test_bot, "web_text", new_callable = AsyncMock) as web_text_mock,
+        ):
+            selected = await getattr(test_bot, "_KleinanzeigenBot__read_city_selection_text")()
+
+        assert selected == "Live City"
+        web_text_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_contact_fields_fails_closed_when_zipcode_cannot_be_set(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        ad_cfg = Ad.model_validate(base_ad_config)
+
+        with (
+            patch.object(test_bot, "web_input", new_callable = AsyncMock, side_effect = TimeoutError("zip timeout")),
+            patch.object(test_bot, "_KleinanzeigenBot__set_contact_location", new_callable = AsyncMock) as set_location_mock,
+            pytest.raises(TimeoutError, match = "Failed to set contact zipcode"),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_contact_fields")(ad_cfg.contact)
+
+        set_location_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_contact_location_raises_when_selection_does_not_converge(self, test_bot:KleinanzeigenBot) -> None:
+        city_button = MagicMock(spec = Element)
+        city_button.local_name = "button"
+        city_button.attrs = {"role": "combobox", "aria-controls": "ad-city-menu"}
+
+        target_option = MagicMock(spec = Element)
+        target_option.text = "10115 - Metroville"
+        target_option.click = AsyncMock()
+
+        wait_calls = 0
+
+        async def web_await_side_effect(condition:Callable[..., Awaitable[bool] | bool], **_:Any) -> Any:
+            nonlocal wait_calls
+            wait_calls += 1
+
+            result = condition()
+            condition_value = await result if asyncio.iscoroutine(result) else result
+            if wait_calls == 1:
+                return condition_value
+            raise TimeoutError("Condition not met")
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = city_button),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [target_option]),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = web_await_side_effect),
+            patch.object(test_bot, "_KleinanzeigenBot__read_city_selection_text", new_callable = AsyncMock, return_value = "20095 - Rivertown"),
+            pytest.raises(TimeoutError, match = "City selection did not converge"),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_contact_location")("10115 - Metroville")
 
 
 class TestKleinanzeigenBotArgParsing:
@@ -2519,6 +2732,7 @@ class TestKleinanzeigenBotShippingOptions:
             patch.object(test_bot, "web_request", new_callable = AsyncMock),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock),
             patch.object(test_bot, "web_await", new_callable = AsyncMock),
+            patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
             patch("builtins.input", return_value = ""),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
         ):
@@ -2678,6 +2892,7 @@ class TestKleinanzeigenBotShippingOptions:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "check_and_wait_for_captcha", new_callable = AsyncMock),
+            patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
             patch("builtins.input", return_value = ""),
             patch("kleinanzeigen_bot.utils.misc.ainput", new_callable = AsyncMock, return_value = ""),
         ):


### PR DESCRIPTION
## ℹ️ Description
This PR implements issue #940 by making the update flow resilient per ad and hardening ZIP/city selection so unresolved location states fail closed instead of silently proceeding.

- Link to the related issue(s): Issue #940
- Describe the motivation and context for this change.

## 📋 Changes Summary
- Added per-ad retry/isolation semantics to `update_ads` (re-raise cancellation, no-retry for `PublishSubmissionUncertainError`, retry-and-continue for `TimeoutError`/`ProtocolException`, non-fatal publish-result timeout, mixed success/failure summary).
- Hardened contact/location handling: ZIP set now fails closed for the ad, city combobox selection waits for option load + post-click convergence, and ambiguous city-only matches now fail closed.
- Improved city selection read-back robustness by preferring live DOM value/text (`element.apply`) over stale serialized attributes.
- Renamed `PUBLISH_MAX_RETRIES` to `SUBMISSION_MAX_RETRIES` and updated related diagnostics/tests/translations.
- Added focused unit coverage for update resilience and contact/location hardening.
- Live verification succeeded on this branch using real ads:
  - `pdm run python -m kleinanzeigen_bot -v --ads=due publish` (2 ads republished)
  - `pdm run python -m kleinanzeigen_bot -v --ads=changed update` (2 ads updated)

Mention any dependencies, configuration changes, or additional requirements introduced.
No new dependencies or config schema changes.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-ad retry behavior for submissions: retries occur only for transient failures, certain uncertain failures stop retries immediately, and confirmation timeouts no longer trigger retries.
  * Stricter contact handling: zip code and city selection are now validated more rigorously and fail fast on ambiguous or non-converging selections.
  * Enhanced diagnostics and clearer completion reporting for mixed success/failure runs.

* **Tests**
  * Added comprehensive unit tests covering retry resilience and contact-location hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->