### PR TITLE
refactor(publish): rename __react_input to __set_input_value

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2350,7 +2350,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 except TimeoutError as ex:
                     raise TimeoutError(_("Failed to set price type '%s'") % price_type) from ex
             if ad_cfg.price is not None:
-                await self.__react_input("ad-price-amount", str(ad_cfg.price))
+                await self.__set_input_value("ad-price-amount", str(ad_cfg.price))
 
         #############################
         # set sell_directly
@@ -2379,7 +2379,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # set description
         #############################
         description = self.__get_description(ad_cfg, with_affixes = True)
-        await self.__react_input("ad-description", description)
+        await self.__set_input_value("ad-description", description)
 
         await self.__set_contact_fields(ad_cfg.contact)
 
@@ -2433,7 +2433,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         #############################
         # set title (right before submit to prevent React re-render clearing it)
         #############################
-        await self.__react_input("ad-title", ad_cfg.title)
+        await self.__set_input_value("ad-title", ad_cfg.title)
 
         #############################
         # submit
@@ -2513,8 +2513,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         dicts.save_dict(ad_file, ad_cfg_orig)
 
-    async def __react_input(self, element_id:str, value:str) -> None:
-        """Sets a React-controlled input value using the native setter to trigger onChange."""
+    async def __set_input_value(self, element_id:str, value:str) -> None:
+        """Sets a framework-controlled input value using the native DOM setter to trigger onChange."""
         await self.web_find(By.ID, element_id)  # raises TimeoutError if element is absent
         js_element_id = json.dumps(element_id)
         js_value = json.dumps(value)
@@ -2710,7 +2710,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 if await self.web_check(By.ID, "ad-street", Is.DISABLED):
                     await self.web_click(By.ID, "ad-address-visibility")
                     await self.web_sleep()
-                await self.__react_input("ad-street", contact.street)
+                await self.__set_input_value("ad-street", contact.street)
             except TimeoutError:
                 LOG.warning("Could not set contact street.")
 
@@ -2720,7 +2720,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if contact.name:
             try:
                 if not await self.web_check(By.ID, "ad-name", Is.READONLY):
-                    await self.__react_input("ad-name", contact.name)
+                    await self.__set_input_value("ad-name", contact.name)
             except TimeoutError:
                 LOG.warning("Could not set contact name.")
 
@@ -2738,7 +2738,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     if await self.web_check(By.ID, "ad-phone", Is.DISABLED, timeout = self._timeout("quick_dom")):
                         await self.web_click(By.ID, "ad-phone-visibility", timeout = self._timeout("quick_dom"))
                         await self.web_sleep()
-                    await self.__react_input("ad-phone", contact.phone)
+                    await self.__set_input_value("ad-phone", contact.phone)
                 except TimeoutError as ex:
                     LOG.warning("Could not set contact phone despite visible phone field: %s", ex)
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3751,7 +3751,7 @@ class TestWantedShippingSelection:
             patch.object(test_bot, "_KleinanzeigenBot__set_shipping", new_callable = AsyncMock),
             patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
             patch.object(test_bot, "_KleinanzeigenBot__upload_images", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__react_input", new_callable = AsyncMock),
+            patch.object(test_bot, "_KleinanzeigenBot__set_input_value", new_callable = AsyncMock),
             patch.object(test_bot, "check_and_wait_for_captcha", new_callable = AsyncMock),
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #930
- The method `__react_input` uses the native `HTMLInputElement`/`HTMLTextAreaElement` value setter — a standard DOM API, not a React-specific one. The rename makes the name match what the method actually does.

## 📋 Changes Summary

- Rename `__react_input` → `__set_input_value` (definition + 6 call sites + test mock)
- Update docstring: "React-controlled" → "framework-controlled"

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to input handling mechanisms with updated method naming and documentation to enhance code maintainability and clarity across form field operations. Test infrastructure has been aligned with these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->