### PR TITLE
fix(core): correct progress counter in publish/update ad loops

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2182,8 +2182,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         published_ads = await self._fetch_published_ads()
 
-        for ad_file, ad_cfg, ad_cfg_orig in ad_cfgs:
-            LOG.info("Processing %s/%s: '%s' from [%s]...", count + 1, len(ad_cfgs), ad_cfg.title, ad_file)
+        for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ad_cfgs, start = 1):
+            LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ad_cfgs), ad_cfg.title, ad_file)
 
             if [x for x in published_ads if x["id"] == ad_cfg.id and x["state"] == "paused"]:
                 LOG.info("Skipping because ad is reserved")
@@ -2760,14 +2760,15 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         published_ads = await self._fetch_published_ads()
 
-        for ad_file, ad_cfg, ad_cfg_orig in ad_cfgs:
+        for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ad_cfgs, start = 1):
+            LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ad_cfgs), ad_cfg.title, ad_file)
+
             ad = next((ad for ad in published_ads if ad["id"] == ad_cfg.id), None)
 
             if not ad:
                 LOG.warning(" -> SKIPPED: ad '%s' (ID: %s) not found in published ads", ad_cfg.title, ad_cfg.id)
                 continue
 
-            LOG.info("Processing %s/%s: '%s' from [%s]...", count + 1, len(ad_cfgs), ad_cfg.title, ad_file)
             if ad["state"] == "paused":
                 LOG.info("Skipping because ad is reserved")
                 continue
@@ -3478,18 +3479,18 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         return final_description
 
     def update_content_hashes(self, ads:list[tuple[str, Ad, dict[str, Any]]]) -> None:
-        count = 0
+        changed = 0
 
-        for ad_file, ad_cfg, ad_cfg_orig in ads:
-            LOG.info("Processing %s/%s: '%s' from [%s]...", count + 1, len(ads), ad_cfg.title, ad_file)
+        for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ads, start = 1):
+            LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ads), ad_cfg.title, ad_file)
             ad_cfg.update_content_hash()
             if ad_cfg.content_hash != ad_cfg_orig["content_hash"]:
-                count += 1
+                changed += 1
                 ad_cfg_orig["content_hash"] = ad_cfg.content_hash
                 dicts.save_dict(ad_file, ad_cfg_orig)
 
         LOG.info("############################################")
-        LOG.info("DONE: Updated [content_hash] in %s", pluralize("ad", count))
+        LOG.info("DONE: Updated [content_hash] in %s", pluralize("ad", changed))
         LOG.info("############################################")
 
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1981,9 +1981,8 @@ class TestKleinanzeigenBotUpdateAdsResilience:
         [
             (TimeoutError("transient timeout"), "Timeout Ad"),
             (ProtocolException(MagicMock(), "connection lost", 0), "Protocol Failing"),
-            (TimeoutError("City selection did not converge for location: 10115 - Metroville"), "Location Failed"),
         ],
-        ids = ["timeout_error", "protocol_exception", "location_non_convergence"],
+        ids = ["timeout_error", "protocol_exception"],
     )
     async def test_update_ads_continues_after_retryable_first_ad_failure(
         self,
@@ -2072,31 +2071,154 @@ class TestKleinanzeigenBotUpdateAdsResilience:
 
         publish_mock.assert_awaited_once()
 
-    @pytest.mark.asyncio
-    async def test_update_ads_summary_reports_mixed_outcomes(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
-        ad_one = self._build_update_ad(base_ad_config, 601, "Summary Failed")
-        ad_two = self._build_update_ad(base_ad_config, 602, "Summary Success")
 
-        async def publish_side_effect(
-            _ad_file:str,
-            ad_cfg:Ad,
-            _ad_cfg_orig:dict[str, Any],
-            _published_ads:list[dict[str, Any]],
-            _mode:AdUpdateStrategy,
-        ) -> None:
-            if ad_cfg.id == 601:
-                raise TimeoutError("still failing")
+class TestDisplayCounterProgression:
+    """Regression tests for issue #977: progress counter must increment for every ad, including skipped ones."""
+
+    @staticmethod
+    def _build_ad(base_ad_config:dict[str, Any], ad_id:int | None, title:str) -> tuple[str, Ad, dict[str, Any]]:
+        ad_payload = copy.deepcopy(base_ad_config) | {"id": ad_id, "title": title}
+        return (f"{ad_id}.yaml", Ad.model_validate(ad_payload), ad_payload)
+
+    @staticmethod
+    def _build_published_ads(*ad_specs:tuple[int, str]) -> list[dict[str, Any]]:
+        return [{"id": ad_id, "state": state} for ad_id, state in ad_specs]
+
+    def test_update_content_hashes_counter_progression(
+        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """Display counter must advance for every ad, even when hash is unchanged."""
+        ads = [
+            self._build_ad(base_ad_config, None, "Unchanged Ad 1"),
+            self._build_ad(base_ad_config, None, "Changed Ad"),
+            self._build_ad(base_ad_config, None, "Unchanged Ad 2"),
+        ]
+
+        # Pre-compute hashes so two match and one differs
+        for _ad_file, ad_cfg, ad_cfg_orig in ads:
+            ad_cfg.update_content_hash()
+            ad_cfg_orig["content_hash"] = ad_cfg.content_hash
+
+        # Make the middle ad's original hash differ
+        ads[1][2]["content_hash"] = "deliberately_wrong_hash"
 
         with (
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(601, 602)),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect),
+            caplog.at_level(logging.INFO),
+            patch.object(dicts, "save_dict"),
+        ):
+            test_bot.update_content_hashes(ads)
+
+        processing = [r for r in caplog.records if r.message.startswith("Processing")]
+        assert len(processing) == 3
+        assert "1/3" in processing[0].message
+        assert "2/3" in processing[1].message
+        assert "3/3" in processing[2].message
+
+        summary = [r for r in caplog.records if "DONE:" in r.message and "content_hash" in r.message]
+        assert any("1 ad" in r.message for r in summary)
+
+    @pytest.mark.asyncio
+    async def test_publish_ads_counter_progression_with_paused_ads(
+        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """Display counter must advance for paused ads, and only non-paused ads are published."""
+        ad_cfgs = [
+            self._build_ad(base_ad_config, 101, "Paused Ad 1"),
+            self._build_ad(base_ad_config, 102, "Active Ad 102"),
+            self._build_ad(base_ad_config, 103, "Paused Ad 2"),
+        ]
+        published_ads = self._build_published_ads((101, "paused"), (102, "active"), (103, "paused"))
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.publish_ads(ad_cfgs)
+
+        processing = [r for r in caplog.records if r.message.startswith("Processing")]
+        assert len(processing) == 3
+        assert "1/3" in processing[0].message
+        assert "2/3" in processing[1].message
+        assert "3/3" in processing[2].message
+
+        skip_msgs = [r for r in caplog.records if "Skipping because ad is reserved" in r.message]
+        assert len(skip_msgs) == 2
+
+        publish_mock.assert_awaited_once()
+        assert publish_mock.call_args.args[1].id == 102
+
+        summary = [r for r in caplog.records if "DONE:" in r.message]
+        assert any("1 ad" in r.message for r in summary)
+
+    @pytest.mark.asyncio
+    async def test_update_ads_counter_progression_with_paused_ads(
+        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """Display counter must advance for paused ads, and only non-paused ads are updated."""
+        ad_cfgs = [
+            self._build_ad(base_ad_config, 201, "Paused Ad 1"),
+            self._build_ad(base_ad_config, 202, "Active Ad 202"),
+            self._build_ad(base_ad_config, 203, "Paused Ad 2"),
+        ]
+        published_ads = self._build_published_ads((201, "paused"), (202, "active"), (203, "paused"))
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
-            patch.object(LOG, "info") as log_info_mock,
         ):
-            await test_bot.update_ads([ad_one, ad_two])
+            await test_bot.update_ads(ad_cfgs)
 
-        assert any(call.args and call.args[0] == "DONE: updated %s (%s failed after retries)" for call in log_info_mock.call_args_list)
+        processing = [r for r in caplog.records if r.message.startswith("Processing")]
+        assert len(processing) == 3
+        assert "1/3" in processing[0].message
+        assert "2/3" in processing[1].message
+        assert "3/3" in processing[2].message
+
+        skip_msgs = [r for r in caplog.records if "Skipping because ad is reserved" in r.message]
+        assert len(skip_msgs) == 2
+
+        publish_mock.assert_awaited_once()
+        assert publish_mock.call_args.args[1].id == 202
+
+        summary = [r for r in caplog.records if "DONE:" in r.message]
+        assert any("1 ad" in r.message for r in summary)
+
+    @pytest.mark.asyncio
+    async def test_update_ads_counter_includes_not_found_ads(
+        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """Display counter must advance even for ads not found in published ads."""
+        ad_cfgs = [
+            self._build_ad(base_ad_config, 301, "Not Found Ad"),
+            self._build_ad(base_ad_config, 302, "Active Ad 302"),
+        ]
+        published_ads = self._build_published_ads((302, "active"))
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.update_ads(ad_cfgs)
+
+        processing = [r for r in caplog.records if r.message.startswith("Processing")]
+        assert len(processing) == 2
+        assert "1/2" in processing[0].message
+        assert "2/2" in processing[1].message
+        assert "Not Found Ad" in processing[0].message
+
+        skip_msgs = [r for r in caplog.records if "SKIPPED" in r.message and "not found" in r.message]
+        assert len(skip_msgs) == 1
+
+        publish_mock.assert_awaited_once()
+        assert publish_mock.call_args.args[1].id == 302
 
 
 class TestKleinanzeigenBotContactLocationHardening:


### PR DESCRIPTION
## ℹ️ Description
- Link to the related issue(s): Issue #977
- The "Processing N/M" progress counter in `publish_ads()`, `update_ads()`, and `update_content_hashes()` used the same `count` variable for both display and tally. Since `count` only incremented for ads that passed skip checks, paused/skipped ads caused the counter to stall or repeat (e.g. `1/5, 1/5, 2/5`). This decouples the display counter from the processing tally using `enumerate()`.

## 📋 Changes Summary

- **`publish_ads()`**: Use `enumerate(ad_cfgs, start=1)` with `idx` for the display counter instead of `count + 1`.
- **`update_ads()`**: Same enumerate swap; moved the "Processing" log before both skip checks (not-found and paused) so the counter is always sequential even for skipped ads.
- **`update_content_hashes()`**: Same enumerate swap; renamed `count` → `changed` for clarity since `idx` is now the display counter.
- **`delete_ads()`**: Left untouched (already correct — no skip paths, counter increments before log).
- Added `TestDisplayCounterProgression` class with 4 regression tests covering counter progression with paused, active, and not-found ads.
- Removed duplicate `test_update_ads_summary_reports_mixed_outcomes` (same scenario as continuation test, only unique assertion was a log format-string template check).
- Removed duplicate `location_non_convergence` parametrize case (second TimeoutError hitting the same branch).

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress counter now accurately reports only changed items instead of all processed items during content updates.

* **Tests**
  * Added comprehensive regression tests for progress counter display across ad processing workflows, including edge cases with paused and not-found ads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->