### PR TITLE
fix(publish): add confirmation redirect fallback to recover ad ID

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2480,10 +2480,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             current_url_query_params = urllib_parse.parse_qs(urllib_parse.urlparse(current_url).query)
             ad_id = int(current_url_query_params.get("adId", [])[0])
 
-        except (TimeoutError, ProtocolException) as ex:
-            # The confirmation page may have auto-redirected before we could poll it.
+        except (TimeoutError, ProtocolException, IndexError, ValueError, TypeError) as ex:
+            # The confirmation page may have auto-redirected before we could poll it,
+            # or the URL was redirected between polling and extraction (race condition).
             # Try to recover the ad ID from tracking data on the current page.
-            LOG.debug("Confirmation URL polling timed out, attempting tracking data fallback...")
+            LOG.debug("Confirmation URL polling or extraction failed (%s), attempting tracking data fallback...", type(ex).__name__)
             try:
                 ad_id = await self._try_recover_ad_id_from_redirect()
             except Exception as fallback_ex:  # noqa: BLE001

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2551,7 +2551,12 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # Note: referrer reflects the most recent navigation, so a stale ID from a
         # previous publish is not a concern — the publish flow navigates to the edit
         # page first, resetting the referrer before the confirmation redirect occurs.
-        referrer = str(await self.web_execute("document.referrer") or "")
+        try:
+            referrer = str(await self.web_execute("document.referrer") or "")
+        except (TimeoutError, ProtocolException) as ex:
+            LOG.debug("document.referrer lookup failed (%s), skipping to script scan", type(ex).__name__)
+            referrer = ""
+
         if "p-anzeige-aufgeben-bestaetigung.html?adId=" in referrer:
             try:
                 query = urllib_parse.parse_qs(urllib_parse.urlparse(referrer).query)
@@ -2572,8 +2577,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 ad_id = int(match.group(1))
                 LOG.debug("Extracted ad ID %s from inline script fallback", ad_id)
                 return ad_id
-        except (ValueError, TypeError) as ex:
-            LOG.debug("Failed to parse ad ID from script content: %s", ex)
+        except (TimeoutError, ProtocolException, ValueError, TypeError) as ex:
+            LOG.debug("Script content scan failed (%s): %s", type(ex).__name__, ex)
 
         return None
 

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2430,6 +2430,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         #############################
         # set title (right before submit to prevent React re-render clearing it)
         #############################
+        LOG.debug("Setting title '%s' (deferred to prevent React re-render clearing it)", ad_cfg.title)
         await self.__set_input_value("ad-title", ad_cfg.title)
 
         #############################
@@ -2440,6 +2441,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         await self.web_click(By.XPATH, "//button[contains(., 'Anzeige aufgeben') or contains(., 'Änderungen speichern') or contains(., 'Anzeige speichern')]")
 
         # Everything after the first click is uncertain: the ad may already have been submitted.
+        ad_id:int | None = None
         try:
             quick_dom = self._timeout("quick_dom")
 
@@ -2472,13 +2474,37 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 return "p-anzeige-aufgeben-bestaetigung.html?adId=" in url
 
             await self.web_await(_check_confirmation_url, timeout = confirmation_timeout)
-        except (TimeoutError, ProtocolException) as ex:
-            raise PublishSubmissionUncertainError("submission may have succeeded before failure") from ex
 
-        # extract the ad id from the URL's query parameter (use JS for fresh URL, not stale self.page.url)
-        current_url = str(await self.web_execute("window.location.href"))
-        current_url_query_params = urllib_parse.parse_qs(urllib_parse.urlparse(current_url).query)
-        ad_id = int(current_url_query_params.get("adId", [])[0])
+            # extract the ad id from the URL's query parameter (use JS for fresh URL, not stale self.page.url)
+            current_url = str(await self.web_execute("window.location.href"))
+            current_url_query_params = urllib_parse.parse_qs(urllib_parse.urlparse(current_url).query)
+            ad_id = int(current_url_query_params.get("adId", [])[0])
+
+        except (TimeoutError, ProtocolException) as ex:
+            # The confirmation page may have auto-redirected before we could poll it.
+            # Try to recover the ad ID from tracking data on the current page.
+            LOG.debug("Confirmation URL polling timed out, attempting tracking data fallback...")
+            try:
+                ad_id = await self._try_recover_ad_id_from_redirect()
+            except Exception as fallback_ex:  # noqa: BLE001
+                LOG.debug("Tracking data fallback failed: %s", fallback_ex)
+
+            if ad_id is None:
+                raise PublishSubmissionUncertainError("submission may have succeeded before failure") from ex
+
+            LOG.warning(
+                "Confirmation page redirected too fast; extracted ad ID %s from page tracking data",
+                ad_id,
+            )
+
+        # Defensive guard: ad_id must be set by now — either from the confirmation URL
+        # (try block) or the tracking fallback (except block). The except block always
+        # either sets ad_id or raises PublishSubmissionUncertainError, making this
+        # unreachable in the current code. Guards against future regressions.
+        if ad_id is None:
+            msg = _("ad_id is unexpectedly None after confirmation flow for %s") % ad_file
+            raise RuntimeError(msg)
+
         ad_cfg_orig["id"] = ad_id
 
         # Update content hash after successful publication
@@ -2509,6 +2535,46 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             LOG.info(" -> SUCCESS: ad updated with ID %s", ad_id)
 
         dicts.save_dict(ad_file, ad_cfg_orig)
+
+    async def _try_recover_ad_id_from_redirect(self) -> int | None:
+        """Try to extract the published ad ID from page tracking data.
+
+        Used as a fallback when the confirmation page auto-redirects before
+        the URL can be polled. Checks document.referrer first, then scans
+        inline script content for the confirmation URL containing adId.
+
+        Returns:
+            The extracted ad ID, or None if no ad ID could be found.
+        """
+        # Layer 1: check document.referrer for the confirmation URL.
+        # Note: referrer reflects the most recent navigation, so a stale ID from a
+        # previous publish is not a concern — the publish flow navigates to the edit
+        # page first, resetting the referrer before the confirmation redirect occurs.
+        referrer = str(await self.web_execute("document.referrer") or "")
+        if "p-anzeige-aufgeben-bestaetigung.html?adId=" in referrer:
+            try:
+                query = urllib_parse.parse_qs(urllib_parse.urlparse(referrer).query)
+                ad_id_str = query.get("adId", [])[0]
+                ad_id = int(ad_id_str)
+                LOG.debug("Extracted ad ID %s from document.referrer fallback", ad_id)
+                return ad_id
+            except (IndexError, ValueError, TypeError):
+                LOG.debug("Failed to parse ad ID from document.referrer: %s", referrer)
+
+        # Layer 2: scan inline <script> tags for confirmation URL with adId
+        try:
+            script_content = str(await self.web_execute(
+                "[...document.querySelectorAll('script')].map(s => s.textContent).join('\\n')"
+            ) or "")
+            match = re.search(r"p-anzeige-aufgeben-bestaetigung\.html\?adId=(\d+)", script_content)
+            if match:
+                ad_id = int(match.group(1))
+                LOG.debug("Extracted ad ID %s from inline script fallback", ad_id)
+                return ad_id
+        except (ValueError, TypeError) as ex:
+            LOG.debug("Failed to parse ad ID from script content: %s", ex)
+
+        return None
 
     async def __set_input_value(self, element_id:str, value:str) -> None:
         """Sets a framework-controlled input value using the native DOM setter to trigger onChange."""

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -216,6 +216,8 @@ kleinanzeigen_bot/__init__.py:
     " -> effective ad meta:": " -> effektive Anzeigen-Metadaten:"
     "Press a key to continue...": "Eine Taste drücken, um fortzufahren..."
     " -> removed %d existing image(s) before upload": " -> %d vorhandene Bilder vor dem Hochladen entfernt"
+    "Confirmation page redirected too fast; extracted ad ID %s from page tracking data": "Bestätigungsseite wurde zu schnell weitergeleitet; Anzeigen-ID %s aus Seiten-Trackingdaten extrahiert"
+    "ad_id is unexpectedly None after confirmation flow for %s": "ad_id ist unerwartet None nach dem Bestätigungsablauf für %s"
 
   update_ads:
     "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' von [%s]..."

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2055,6 +2055,28 @@ class TestKleinanzeigenBotBasics:
         assert ad_cfg_orig["id"] == 99887766
 
     @pytest.mark.asyncio
+    async def test_publish_ad_confirmation_fallback_when_redirect_happens_after_url_poll(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """When the confirmation URL was observed by polling but the page redirected before extraction, the fallback should recover the ad ID."""
+        ad_cfg, ad_cfg_orig = self._build_publish_ad_cfg(base_ad_config)
+
+        # web_await succeeds (confirmation URL was seen during polling), but the page
+        # redirects before line 2479 can extract the URL, causing IndexError in the
+        # extraction which falls into the except block and triggers the fallback.
+        with self._mock_post_submit_dependencies(
+            test_bot, mock_page,
+            redirect_recovery_return = 55667788,
+            include_success_mocks = True,
+        ):
+            await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
+
+        assert ad_cfg_orig["id"] == 55667788
+
+    @pytest.mark.asyncio
     async def test_publish_ad_confirmation_fallback_from_tracking_raises_uncertain_when_not_found(
         self,
         test_bot:KleinanzeigenBot,

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3,7 +3,7 @@
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 import asyncio, copy, fnmatch, gc, io, json, logging, os, tempfile  # isort: skip
 from collections.abc import Callable, Generator
-from contextlib import contextmanager, redirect_stdout
+from contextlib import ExitStack, contextmanager, redirect_stdout
 from datetime import timedelta
 from pathlib import Path, PureWindowsPath
 from typing import Any, Awaitable, Iterator, cast
@@ -1952,25 +1952,36 @@ class TestKleinanzeigenBotBasics:
 
         web_open_mock.assert_awaited_once_with(expected_url, reload_if_already_open = True)
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "web_await_error",
-        [TimeoutError("confirmation timeout"), ProtocolException(MagicMock(), "connection lost", 0)],
-        ids = ["timeout", "protocol-exception"],
-    )
-    async def test_publish_ad_marks_post_submit_errors_as_uncertain(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-        web_await_error:Exception,
-    ) -> None:
-        """Post-submit exceptions (TimeoutError, ProtocolException) should be converted to non-retryable uncertainty."""
-        test_bot.page = mock_page
+    @staticmethod
+    def _build_publish_ad_cfg(base_ad_config:dict[str, Any]) -> tuple[Ad, dict[str, Any]]:
+        """Build ad config and original dict for publish_ad tests."""
         ad_cfg = Ad.model_validate(base_ad_config | {"id": 12345, "shipping_type": "NOT_APPLICABLE", "price_type": "NOT_APPLICABLE"})
         ad_cfg_orig = copy.deepcopy(base_ad_config)
+        return ad_cfg, ad_cfg_orig
 
-        with (
+    @contextmanager
+    def _mock_post_submit_dependencies(
+        self,
+        test_bot:KleinanzeigenBot,
+        mock_page:MagicMock,
+        *,
+        web_await_side_effect:BaseException | None = None,
+        redirect_recovery_return:int | None = None,
+        redirect_recovery_side_effect:BaseException | None = None,
+        include_success_mocks:bool = False,
+    ) -> Iterator[None]:
+        """Mock all post-submit publish_ad dependencies for confirmation fallback tests.
+
+        Parameters
+        ----------
+            web_await_side_effect: Exception to raise from web_await (simulates confirmation timeout).
+            redirect_recovery_return: Return value for _try_recover_ad_id_from_redirect.
+            redirect_recovery_side_effect: Exception to raise from _try_recover_ad_id_from_redirect.
+            include_success_mocks: If True, also mock dicts.save_dict (for success-path tests).
+        """
+        test_bot.page = mock_page
+
+        common_patches:list[Any] = [
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
             patch.object(test_bot, "_KleinanzeigenBot__set_category", new_callable = AsyncMock),
@@ -1985,7 +1996,96 @@ class TestKleinanzeigenBotBasics:
             patch.object(test_bot, "web_find", new_callable = AsyncMock),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
-            patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = web_await_error),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = web_await_side_effect),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "_try_recover_ad_id_from_redirect", new_callable = AsyncMock,
+                         return_value = redirect_recovery_return, side_effect = redirect_recovery_side_effect),
+        ]
+
+        if include_success_mocks:
+            common_patches.append(patch("kleinanzeigen_bot.dicts.save_dict"))
+
+        with ExitStack() as stack:
+            for p in common_patches:
+                stack.enter_context(p)
+            yield
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "web_await_error",
+        [TimeoutError("confirmation timeout"), ProtocolException(MagicMock(), "connection lost", 0)],
+        ids = ["timeout", "protocol-exception"],
+    )
+    async def test_publish_ad_marks_post_submit_errors_as_uncertain(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+        web_await_error:Exception,
+    ) -> None:
+        """Post-submit exceptions (TimeoutError, ProtocolException) should be converted to non-retryable uncertainty."""
+        ad_cfg, ad_cfg_orig = self._build_publish_ad_cfg(base_ad_config)
+
+        with (
+            self._mock_post_submit_dependencies(test_bot, mock_page,
+                                                web_await_side_effect = web_await_error,
+                                                redirect_recovery_return = None),
+            pytest.raises(PublishSubmissionUncertainError, match = "submission may have succeeded before failure"),
+        ):
+            await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
+
+    @pytest.mark.asyncio
+    async def test_publish_ad_confirmation_fallback_from_referrer(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """When confirmation URL polling times out, ad ID should be recovered from document.referrer."""
+        ad_cfg, ad_cfg_orig = self._build_publish_ad_cfg(base_ad_config)
+
+        with self._mock_post_submit_dependencies(
+            test_bot, mock_page,
+            web_await_side_effect = TimeoutError("confirmation timeout"),
+            redirect_recovery_return = 99887766,
+            include_success_mocks = True,
+        ):
+            await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
+
+        assert ad_cfg_orig["id"] == 99887766
+
+    @pytest.mark.asyncio
+    async def test_publish_ad_confirmation_fallback_from_tracking_raises_uncertain_when_not_found(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """When both confirmation URL polling and tracking fallback fail, PublishSubmissionUncertainError should be raised."""
+        ad_cfg, ad_cfg_orig = self._build_publish_ad_cfg(base_ad_config)
+
+        with (
+            self._mock_post_submit_dependencies(test_bot, mock_page,
+                                                web_await_side_effect = TimeoutError("confirmation timeout"),
+                                                redirect_recovery_return = None),
+            pytest.raises(PublishSubmissionUncertainError, match = "submission may have succeeded before failure"),
+        ):
+            await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
+
+    @pytest.mark.asyncio
+    async def test_publish_ad_confirmation_fallback_helper_failure_still_raises_uncertain(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """When the tracking fallback helper itself raises, it should not change retry behavior — PublishSubmissionUncertainError must still be raised."""
+        ad_cfg, ad_cfg_orig = self._build_publish_ad_cfg(base_ad_config)
+
+        with (
+            self._mock_post_submit_dependencies(test_bot, mock_page,
+                                                web_await_side_effect = TimeoutError("confirmation timeout"),
+                                                redirect_recovery_side_effect = RuntimeError("browser disconnected")),
             pytest.raises(PublishSubmissionUncertainError, match = "submission may have succeeded before failure"),
         ):
             await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
@@ -4905,3 +5005,57 @@ class TestImageCleanupInPublishAd:
         assert sum(button.click.await_count for button in remove_buttons) == 3
         mock_upload.assert_awaited_once()
         assert event_log == ["remove-1", "remove-2", "remove-3", "upload"]
+
+
+class TestTrackingFallback:
+    """Tests for _try_recover_ad_id_from_redirect helper method."""
+
+    @pytest.mark.asyncio
+    async def test_extract_ad_id_from_referrer(self, test_bot:KleinanzeigenBot) -> None:
+        """Ad ID should be extracted from document.referrer containing the confirmation URL."""
+        referrer_url = "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=3382410263"
+        with patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = referrer_url):
+            result = await test_bot._try_recover_ad_id_from_redirect()
+
+        assert result == 3382410263
+
+    @pytest.mark.asyncio
+    async def test_extract_ad_id_from_script_content(self, test_bot:KleinanzeigenBot) -> None:
+        """When referrer has no confirmation URL, ad ID should be extracted from inline script content."""
+        referrer = "https://www.kleinanzeigen.de/m-meine-anzeigen.html"
+        script_content = (
+            'Belen.Tracking.initTrackingData({"page":"p-anzeige-aufgeben-bestaetigung.html?adId=44556677"});'
+        )
+        execute_returns = [referrer, script_content]
+
+        with patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = execute_returns):
+            result = await test_bot._try_recover_ad_id_from_redirect()
+
+        assert result == 44556677
+
+    @pytest.mark.asyncio
+    async def test_extract_ad_id_returns_none_when_not_found(self, test_bot:KleinanzeigenBot) -> None:
+        """When neither referrer nor scripts contain a confirmation URL, None should be returned."""
+        execute_returns = [
+            "https://www.kleinanzeigen.de/m-meine-anzeigen.html",  # referrer
+            "var x = 42;",  # script content — no confirmation URL
+        ]
+
+        with patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = execute_returns):
+            result = await test_bot._try_recover_ad_id_from_redirect()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("referrer_value", ["", None], ids = ["empty-referrer", "none-referrer"])
+    async def test_extract_ad_id_falls_back_to_script_when_referrer_lacks_confirmation_url(
+        self, test_bot:KleinanzeigenBot, referrer_value:str | None,
+    ) -> None:
+        """When document.referrer is empty or None, the script scan fallback should extract the ad ID."""
+        script_content = 'initTrackingData("p-anzeige-aufgeben-bestaetigung.html?adId=11223344")'
+        execute_returns = [referrer_value, script_content]
+
+        with patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = execute_returns):
+            result = await test_bot._try_recover_ad_id_from_redirect()
+
+        assert result == 11223344


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #991 (related delete bug), Issue #992 (diagnostics follow-up)
- During a publish run, the Kleinanzeigen confirmation page auto-redirected to the user's ad management page (`m-meine-anzeigen.html`) before the bot's URL polling could observe the confirmation URL containing the new ad ID. This caused `PublishSubmissionUncertainError` even though the ad was actually published successfully (verified via diagnostics HTML showing ad ID 3382410263 in Belen tracking data). The fix adds a two-layer fallback to recover the ad ID from page tracking data when URL polling times out.

## 📋 Changes Summary

- Add `_try_recover_ad_id_from_redirect()` helper with two-layer fallback: Layer 1 checks `document.referrer` for the confirmation URL; Layer 2 scans inline `<script>` tags for the confirmation URL pattern containing `adId`.
- Restructure the confirmation block in `publish_ad` to attempt recovery before raising `PublishSubmissionUncertainError`. On successful recovery, logs a WARNING about the fast redirect and continues normally.
- Add defensive `RuntimeError` guard (unreachable in current code) with i18n-translated message including `ad_file` context.
- Add DEBUG log for the deferred title set (explaining why title appears empty before submit).
- Add stale-ID assumption comment documenting why `document.referrer` cannot contain a previous ad's ID.
- Add German translations for new WARNING log message and RuntimeError guard message.
- DRY test setup: extract `_mock_post_submit_dependencies()` (ExitStack-based context manager) and `_build_publish_ad_cfg()` helpers, eliminating ~80 lines of duplicated mock boilerplate across 4 integration tests.
- Test scout cleanup: merge duplicate `test_extract_ad_id_handles_empty_referrer` + `test_extract_ad_id_handles_none_referrer` into one parametrized test (both hit identical code path via `str(... or "")`).
- Move `web_sleep` mock to unconditional patch list, eliminating real `asyncio.sleep` delays in error-path tests.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ad publication reliability with a new fallback for retrieving confirmation details when initial extraction fails.
  * Expanded error handling to mark uncertain submissions appropriately and prevent silent failures.
  * Added targeted debug logging to aid troubleshooting of the publish flow.

* **Tests**
  * Added comprehensive unit tests covering fallback recovery, confirmation timing scenarios, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->