### PR TITLE
fix(delete): report actual deletion outcome and reduce log noise

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2013,47 +2013,86 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
     async def delete_ads(self, ad_cfgs:list[tuple[str, Ad, dict[str, Any]]]) -> None:
         count = 0
+        deleted_count = 0
 
         published_ads = await self._fetch_published_ads()
 
         for ad_file, ad_cfg, _ad_cfg_orig in ad_cfgs:
             count += 1
             LOG.info("Processing %s/%s: '%s' from [%s]...", count, len(ad_cfgs), ad_cfg.title, ad_file)
-            await self.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = self.config.publishing.delete_old_ads_by_title)
+            if await self.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = self.config.publishing.delete_old_ads_by_title):
+                deleted_count += 1
             await self.web_sleep()
 
         LOG.info("############################################")
-        LOG.info("DONE: Deleted %s", pluralize("ad", count))
+        LOG.info("DONE: Deleted %s of %s", deleted_count, pluralize("ad", count))
         LOG.info("############################################")
 
     async def delete_ad(self, ad_cfg:Ad, published_ads:list[dict[str, Any]], *, delete_old_ads_by_title:bool) -> bool:
+        """Delete an ad from the server.
+
+        Returns:
+            True if at least one delete request returned 200 (confirmed deleted).
+            False if no matching ads were found or all returned 404 (already gone).
+
+        Side effects:
+            Clears ``ad_cfg.id`` whenever a delete was attempted, regardless of
+            the server response (200 or 404). The old ID is stale in both cases.
+            Preserves ``ad_cfg.id`` when no deletion was attempted (early return).
+        """
         LOG.info("Deleting ad '%s' if already present...", ad_cfg.title)
 
+        # Phase A: Build set of IDs to delete, unified across both modes
+        ids_to_delete:set[int] = set()
+
+        if delete_old_ads_by_title:
+            for published_ad in published_ads:
+                raw_id = published_ad.get("id")
+                if raw_id is None:
+                    LOG.debug("Skipping published ad with missing id: %r", published_ad.get("title"))
+                    continue
+                try:
+                    published_ad_id = int(raw_id)
+                except (ValueError, TypeError):
+                    LOG.debug("Skipping published ad with invalid id: %r", raw_id)
+                    continue
+                published_ad_title = published_ad.get("title", "")
+                if ad_cfg.id == published_ad_id or ad_cfg.title == published_ad_title:
+                    LOG.info(" -> matched ad %s '%s' for deletion", published_ad_id, published_ad_title)
+                    ids_to_delete.add(published_ad_id)
+        elif ad_cfg.id is not None:
+            ids_to_delete.add(ad_cfg.id)
+
+        # Early return if nothing to delete — skip page open, CSRF fetch, and sleep
+        if not ids_to_delete:
+            return False
+
+        # Phase B: Open manage-ads page, fetch CSRF token, execute deletions
         await self.web_open(f"{self.root_url}/m-meine-anzeigen.html")
         csrf_token_elem = await self.web_find(By.CSS_SELECTOR, "meta[name=_csrf]")
         csrf_token = csrf_token_elem.attrs["content"]
         ensure(csrf_token is not None, "Expected CSRF Token not found in HTML content!")
 
-        if delete_old_ads_by_title:
-            for published_ad in published_ads:
-                published_ad_id = int(published_ad.get("id", -1))
-                published_ad_title = published_ad.get("title", "")
-                if ad_cfg.id == published_ad_id or ad_cfg.title == published_ad_title:
-                    LOG.info(" -> deleting %s '%s'...", published_ad_id, published_ad_title)
-                    await self.web_request(
-                        url = f"{self.root_url}/m-anzeigen-loeschen.json?ids={published_ad_id}", method = "POST", headers = {"x-csrf-token": str(csrf_token)}
-                    )
-        elif ad_cfg.id:
-            await self.web_request(
-                url = f"{self.root_url}/m-anzeigen-loeschen.json?ids={ad_cfg.id}",
+        HTTP_OK:Final = 200
+        deleted = False
+        for target_id in ids_to_delete:
+            LOG.info(" -> deleting ad %s...", target_id)
+            response = await self.web_request(
+                url = f"{self.root_url}/m-anzeigen-loeschen.json?ids={target_id}",
                 method = "POST",
                 headers = {"x-csrf-token": str(csrf_token)},
                 valid_response_codes = [200, 404],
             )
+            if response["statusCode"] == HTTP_OK:
+                deleted = True
+            else:
+                LOG.warning(" -> ad %s not found (status %s), may have been removed already", target_id, response["statusCode"])
 
         await self.web_sleep()
+        # Clear ad_cfg.id whenever a delete was attempted — the old ID is stale
+        # regardless of whether the server returned 200 (deleted) or 404 (already gone).
         ad_cfg.id = None
-        return True
+        return deleted
 
     async def extend_ads(self, ad_cfgs:list[tuple[str, Ad, dict[str, Any]]]) -> None:
         """Extends ads that are close to expiry."""

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2058,7 +2058,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     continue
                 published_ad_title = published_ad.get("title", "")
                 if ad_cfg.id == published_ad_id or ad_cfg.title == published_ad_title:
-                    LOG.info(" -> matched ad %s '%s' for deletion", published_ad_id, published_ad_title)
+                    LOG.debug(" -> matched ad %s '%s' for deletion", published_ad_id, published_ad_title)
                     ids_to_delete.add(published_ad_id)
         elif ad_cfg.id is not None:
             ids_to_delete.add(ad_cfg.id)
@@ -2076,7 +2076,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         HTTP_OK:Final = 200
         deleted = False
         for target_id in ids_to_delete:
-            LOG.info(" -> deleting ad %s...", target_id)
+            LOG.debug(" -> deleting ad %s...", target_id)
             response = await self.web_request(
                 url = f"{self.root_url}/m-anzeigen-loeschen.json?ids={target_id}",
                 method = "POST",

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -129,13 +129,15 @@ kleinanzeigen_bot/__init__.py:
 
   delete_ads:
     "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' von [%s]..."
-    "DONE: Deleted %s": "FERTIG: %s gelöscht"
+    "DONE: Deleted %s of %s": "FERTIG: %s von %s gelöscht"
     "ad": "Anzeige"
 
   delete_ad:
     "Deleting ad '%s' if already present...": "Lösche Anzeige '%s', falls bereits vorhanden..."
     "Expected CSRF Token not found in HTML content!": "Erwartetes CSRF-Token wurde im HTML-Inhalt nicht gefunden!"
-    " -> deleting %s '%s'...": " -> lösche %s '%s'..."
+    " -> matched ad %s '%s' for deletion": " -> Anzeige %s '%s' zum Löschen gefunden"
+    " -> deleting ad %s...": " -> lösche Anzeige %s..."
+    " -> ad %s not found (status %s), may have been removed already": " -> Anzeige %s nicht gefunden (Status %s), möglicherweise bereits entfernt"
 
   extend_ads:
     "No ads need extension at this time.": "Keine Anzeigen müssen derzeit verlängert werden."

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -135,8 +135,6 @@ kleinanzeigen_bot/__init__.py:
   delete_ad:
     "Deleting ad '%s' if already present...": "Lösche Anzeige '%s', falls bereits vorhanden..."
     "Expected CSRF Token not found in HTML content!": "Erwartetes CSRF-Token wurde im HTML-Inhalt nicht gefunden!"
-    " -> matched ad %s '%s' for deletion": " -> Anzeige %s '%s' zum Löschen gefunden"
-    " -> deleting ad %s...": " -> lösche Anzeige %s..."
     " -> ad %s not found (status %s), may have been removed already": " -> Anzeige %s nicht gefunden (Status %s), möglicherweise bereits entfernt"
 
   extend_ads:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2901,16 +2901,13 @@ class TestKleinanzeigenBotAdDeletion:
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch.object(test_bot, "web_request", new_callable = AsyncMock,
-                         return_value = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}) as mock_request,
+                         return_value = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}),
         ):
             mock_find.return_value.attrs = {"content": "some-token"}
             result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = True)
 
         assert result is True
         assert ad_cfg.id is None
-        # Verify the unified loop uses valid_response_codes=[200, 404] for both modes
-        mock_request.assert_called_once()
-        assert mock_request.call_args[1]["valid_response_codes"] == [200, 404]
 
     @pytest.mark.asyncio
     async def test_delete_ad_by_id_succeeds(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2891,88 +2891,192 @@ class TestKleinanzeigenBotAdDeletion:
     """Tests for ad deletion functionality."""
 
     @pytest.mark.asyncio
-    async def test_delete_ad_by_title(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
-        """Test deleting an ad by title."""
-        test_bot.page = MagicMock()
-        test_bot.page.evaluate = AsyncMock(return_value = {"statusCode": 200, "statusMessage": "OK", "content": "{}"})
-        test_bot.page.sleep = AsyncMock()
-
-        # Use minimal config since we only need title for deletion by title
-        ad_cfg = Ad.model_validate(
-            minimal_ad_config
-            | {
-                "title": "Test Title",
-                "id": None,  # Explicitly set id to None for title-based deletion
-            }
-        )
-
-        published_ads = [{"title": "Test Title", "id": "67890"}, {"title": "Other Title", "id": "11111"}]
+    async def test_delete_ad_by_title_match_succeeds(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When title matches a published ad and server returns 200, should return True and clear id."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"title": "Test Title", "id": None})
+        published_ads = [{"title": "Test Title", "id": 67890}, {"title": "Other Title", "id": 11111}]
 
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = True),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_request", new_callable = AsyncMock,
+                         return_value = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}) as mock_request,
         ):
             mock_find.return_value.attrs = {"content": "some-token"}
             result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = True)
-            assert result is True
+
+        assert result is True
+        assert ad_cfg.id is None
+        # Verify the unified loop uses valid_response_codes=[200, 404] for both modes
+        mock_request.assert_called_once()
+        assert mock_request.call_args[1]["valid_response_codes"] == [200, 404]
 
     @pytest.mark.asyncio
-    async def test_delete_ad_by_id(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
-        """Test deleting an ad by ID."""
-        test_bot.page = MagicMock()
-        test_bot.page.evaluate = AsyncMock(return_value = {"statusCode": 200, "statusMessage": "OK", "content": "{}"})
-        test_bot.page.sleep = AsyncMock()
-
-        # Create config with ID for deletion by ID
-        ad_cfg = Ad.model_validate(
-            minimal_ad_config
-            | {
-                "id": "12345"  # Fixed: use proper dict key syntax
-            }
-        )
-
-        published_ads = [{"title": "Different Title", "id": "12345"}, {"title": "Other Title", "id": "11111"}]
+    async def test_delete_ad_by_id_succeeds(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When ad has an ID and server returns 200, should return True and clear id."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"id": 12345})
+        published_ads = [{"title": "Different Title", "id": 12345}, {"title": "Other Title", "id": 11111}]
 
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = True),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_request", new_callable = AsyncMock,
+                         return_value = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}),
         ):
             mock_find.return_value.attrs = {"content": "some-token"}
             result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = False)
-            assert result is True
+
+        assert result is True
+        assert ad_cfg.id is None
 
     @pytest.mark.asyncio
-    async def test_delete_ad_by_id_with_non_string_csrf_token(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
-        """Test deleting an ad by ID with non-string CSRF token to cover str() conversion."""
-        test_bot.page = MagicMock()
-        test_bot.page.evaluate = AsyncMock(return_value = {"statusCode": 200, "statusMessage": "OK", "content": "{}"})
-        test_bot.page.sleep = AsyncMock()
+    async def test_delete_ad_returns_false_when_no_match(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When no published ads match, should return False without opening any pages."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"title": "No Match Title", "id": 99999})
+        published_ads = [{"title": "Different Title", "id": 12345}]
 
-        # Create config with ID for deletion by ID
-        ad_cfg = Ad.model_validate(minimal_ad_config | {"id": "12345"})
+        with (
+            patch.object(test_bot, "web_open", new_callable = AsyncMock) as mock_web_open,
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_web_find,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_web_sleep,
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+        ):
+            result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = True)
 
-        published_ads = [{"title": "Different Title", "id": "12345"}, {"title": "Other Title", "id": "11111"}]
+        assert result is False
+        assert ad_cfg.id == 99999  # Preserved — no deletion attempted
+        mock_web_open.assert_not_called()
+        mock_web_find.assert_not_called()
+        mock_web_sleep.assert_not_called()
+        mock_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_ad_returns_false_on_404_clears_id(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When delete is attempted but server returns 404, should return False but still clear the id."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"id": 12345})
+        published_ads:list[dict[str, Any]] = []
 
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = True),
-            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = {"statusCode": 404, "statusMessage": "Not Found", "content": "{}"}),
         ):
-            # Mock non-string CSRF token to test str() conversion
-            mock_find.return_value.attrs = {"content": 12345}  # Non-string token
+            mock_find.return_value.attrs = {"content": "some-token"}
             result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = False)
-            assert result is True
 
-            # Verify that str() was called on the CSRF token
-            mock_request.assert_called_once()
-            call_args = mock_request.call_args
-            assert call_args[1]["headers"]["x-csrf-token"] == "12345"  # Should be converted to string
+        assert result is False
+        assert ad_cfg.id is None  # Cleared because delete was attempted
+
+    @pytest.mark.asyncio
+    async def test_delete_ad_skips_invalid_published_ad_id(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When a title-matched published ad has an invalid id (None), it should be skipped."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"title": "Test Title", "id": None})
+        published_ads:list[dict[str, Any]] = [
+            {"title": "Test Title", "id": None},  # Invalid — should be skipped
+            {"title": "Test Title", "id": "not-a-number"},  # Invalid — should be skipped
+        ]
+
+        with (
+            patch.object(test_bot, "web_open", new_callable = AsyncMock) as mock_web_open,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_request", new_callable = AsyncMock),
+        ):
+            result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = True)
+
+        assert result is False
+        mock_web_open.assert_not_called()  # No valid IDs → no page open
+
+    @pytest.mark.asyncio
+    async def test_delete_ad_with_zero_id(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When ad_cfg.id is 0 (falsy but valid), should still enter the ID-based deletion path."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"id": 0})
+        published_ads:list[dict[str, Any]] = []
+
+        with (
+            patch.object(test_bot, "web_open", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_request", new_callable = AsyncMock,
+                         return_value = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}) as mock_request,
+        ):
+            mock_find.return_value.attrs = {"content": "some-token"}
+            result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = False)
+
+        assert result is True
+        assert ad_cfg.id is None
+        mock_request.assert_called_once()
+        assert "ids=0" in mock_request.call_args[1]["url"]
+
+    @pytest.mark.asyncio
+    async def test_delete_ad_multiple_title_matches(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When multiple published ads match by title with mixed 200/404, should return True."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"title": "Test Title", "id": None})
+        published_ads = [
+            {"title": "Test Title", "id": 100},
+            {"title": "Test Title", "id": 200},
+            {"title": "Test Title", "id": 300},
+        ]
+
+        response_sequence = [
+            {"statusCode": 200, "statusMessage": "OK", "content": "{}"},
+            {"statusCode": 404, "statusMessage": "Not Found", "content": "{}"},
+            {"statusCode": 200, "statusMessage": "OK", "content": "{}"},
+        ]
+
+        with (
+            patch.object(test_bot, "web_open", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, side_effect = response_sequence) as mock_request,
+        ):
+            mock_find.return_value.attrs = {"content": "some-token"}
+            result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = True)
+
+        assert result is True
+        assert ad_cfg.id is None
+        assert mock_request.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_delete_ad_title_and_id_match_deduplicated(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When the same ad matches by both title and ID, it should be deleted only once."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"title": "Test Title", "id": 100})
+        published_ads = [{"title": "Test Title", "id": 100}]
+        ok_response = {"statusCode": 200, "statusMessage": "OK", "content": "{}"}
+
+        with (
+            patch.object(test_bot, "web_open", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ok_response) as mock_request,
+        ):
+            mock_find.return_value.attrs = {"content": "some-token"}
+            result = await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = True)
+
+        assert result is True
+        assert ad_cfg.id is None
+        mock_request.assert_called_once()  # Deduplicated — only one request
+
+    @pytest.mark.asyncio
+    async def test_delete_ad_exception_preserves_id(self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any]) -> None:
+        """When web_request raises an exception mid-loop, ad_cfg.id should be preserved and web_sleep not called."""
+        ad_cfg = Ad.model_validate(minimal_ad_config | {"id": 12345})
+        published_ads:list[dict[str, Any]] = []
+
+        with (
+            patch.object(test_bot, "web_open", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_web_sleep,
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, side_effect = TimeoutError("request timed out")),
+        ):
+            mock_find.return_value.attrs = {"content": "some-token"}
+            with pytest.raises(TimeoutError, match = "request timed out"):
+                await test_bot.delete_ad(ad_cfg, published_ads, delete_old_ads_by_title = False)
+
+        assert ad_cfg.id == 12345  # Preserved — exception prevented clearing
+        mock_web_sleep.assert_not_called()
 
 
 class TestKleinanzeigenBotAdRepublication:


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #991
- `delete_ad` previously always returned `True` and always cleared `ad_cfg.id`, regardless of whether the ad was actually found or deleted. The title-based and ID-based matching paths behaved differently, and 404 responses were treated inconsistently. This made it impossible to distinguish "ad confirmed deleted" from "ad already gone" from "no matching ad found" — causing misleading log output and preventing accurate deletion tracking.

## 📋 Changes Summary

- Restructure `delete_ad` into two clear phases: **Phase A** (unified target selection via `ids_to_delete: set[int]`) and **Phase B** (shared delete execution loop)
- Return `True` only when at least one delete request returned HTTP 200 (confirmed deleted); return `False` for no matches or all 404s
- Clear `ad_cfg.id = None` whenever a delete was **attempted** (both 200 and 404), but preserve it on early return (no targets found)
- Fix falsy-zero bug: `elif ad_cfg.id:` → `elif ad_cfg.id is not None:` to correctly handle `id == 0`
- Replace `published_ad.get("id", -1)` with explicit None check + `try/except` around `int()` to avoid silent invalid delete attempts
- Update `delete_ads` orchestrator to track `deleted_count` accurately
- Replace 3 old tests with 9 behavior-focused tests covering: ID-only match, title match, multiple title matches, title+ID deduplication, zero ID, invalid published ad ID, 404 handling, no-match early return, exception preserves ID

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Summary now reports the actual number of ads deleted (not processed attempts).
  * Skips invalid/missing IDs and avoids unnecessary page loads when nothing to delete.
  * Treats HTTP 404 as missing ad (warn) while counting only successful deletions.
  * Ensures ad configuration is cleared after deletion attempts; preserves config if deletion errors occur.

* **Tests**
  * Expanded scenario tests covering title/ID deletion, deduplication, mixed responses, invalid IDs, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->