### PR TITLE
fix(publish): handle missing PICKUP toggle (books/comics) and map legacy German condition_s values

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -51,6 +51,17 @@ _WANTED_SHIPPING_LABELS:Final[dict[str, str]] = {
     "SHIPPING": "Versand möglich",
     "PICKUP": "Nur Abholung",
 }
+# Kleinanzeigen migrated condition dialog radio values from German tokens to English
+# API codes. Existing ad YAMLs use the legacy German tokens; map them at publish time
+# so both old and new values work against the current DOM.
+_CONDITION_GERMAN_TO_API:Final[dict[str, str]] = {
+    "neu": "new",
+    "wie_neu": "like_new",
+    "sehr_gut": "like_new",  # legacy "very good" tier collapses to like_new
+    "gut": "ok",
+    "in_ordnung": "alright",
+    "defekt": "defect",
+}
 _LOGIN_DETECTION_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CLASS_NAME, "mr-medium"),
     (By.ID, "user-email"),
@@ -2960,14 +2971,28 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             )
             return False
 
+        # Kleinanzeigen changed dialog radio values from German tokens to English API codes
+        # (e.g. "wie_neu" -> "like_new", "sehr_gut" -> "like_new"). Try the configured value
+        # first (handles already-English configs), then fall back to the mapped equivalent.
+        candidate_values = [condition_value]
+        mapped_value = _CONDITION_GERMAN_TO_API.get(condition_value)
+        if mapped_value and mapped_value != condition_value:
+            candidate_values.append(mapped_value)
+
         try:
             await condition_trigger.click()
             await self.web_find(By.XPATH, '//*[self::dialog or @role="dialog"]', timeout = short_timeout)
-            condition_radio = await self.web_find(
-                By.XPATH,
-                f"//*[self::dialog or @role='dialog']//input[@type='radio' and @value={_xpath_literal(condition_value)}]",
-                timeout = short_timeout,
-            )
+            condition_radio = None
+            for candidate in candidate_values:
+                condition_radio = await self.web_probe(
+                    By.XPATH,
+                    f"//*[self::dialog or @role='dialog']//input[@type='radio' and @value={_xpath_literal(candidate)}]",
+                    timeout = short_timeout,
+                )
+                if condition_radio is not None:
+                    break
+            if condition_radio is None:
+                raise TimeoutError(f"No condition radio matched values {candidate_values}")
             condition_radio_id = str(condition_radio.attrs.get("id") or "")
             if condition_radio_id:
                 try:
@@ -3219,6 +3244,14 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
     async def __set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
         short_timeout = self._timeout("quick_dom")
         if ad_cfg.shipping_type == "PICKUP":
+            # Some categories (notably books 76/77 and comics 76/77/15156) render the
+            # "Eigenschaften und Versand" fieldset without a shipping enable/disable toggle —
+            # those ads are PICKUP-only by site convention, so the absence of the radio is
+            # the expected state and matches the configured shipping_type.
+            pickup_radio = await self.web_probe(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
+            if pickup_radio is None:
+                LOG.debug("PICKUP: no shipping toggle for this category; treating as already PICKUP.")
+                return
             try:
                 if not await self.web_check(By.ID, "ad-shipping-enabled-no", Is.SELECTED, timeout = short_timeout):
                     await self.web_click(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3609,23 +3609,20 @@ class TestConditionSelector:
         radio.attrs = radio_attrs
         radio.click = AsyncMock()
 
+        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+            # trigger lookup returns the dialog trigger button
+            if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
+                return trigger
+            # radio lookup returns the matching radio
+            if selector_type == By.XPATH and "@type='radio'" in selector_value and "@value='ok'" in selector_value:
+                return radio
+            return None
+
         with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = trigger),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-
-            async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element:
-                if selector_type != By.XPATH:
-                    raise TimeoutError("unexpected selector")
-                if "@type='radio'" in selector_value and "@value='ok'" in selector_value:
-                    return radio
-                if "dialog" in selector_value:
-                    return dialog
-                raise TimeoutError("selector not found")
-
-            mock_find.side_effect = find_side_effect
-
             handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("ok")
 
             assert handled is True
@@ -3634,6 +3631,68 @@ class TestConditionSelector:
             trigger.click.assert_awaited_once()
             assert any("label[@for=" in selector and "radio-condition-ok" in selector for selector in clicked_xpath_selectors)
             assert any("Bestätigen" in selector for selector in clicked_xpath_selectors)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("configured", "expected_api_value"),
+        [
+            ("wie_neu", "like_new"),
+            ("sehr_gut", "like_new"),
+            ("neu", "new"),
+            ("gut", "ok"),
+            ("in_ordnung", "alright"),
+            ("defekt", "defect"),
+        ],
+    )
+    async def test_condition_falls_back_to_english_api_value(
+        self,
+        test_bot:KleinanzeigenBot,
+        configured:str,
+        expected_api_value:str,
+    ) -> None:
+        """Legacy German condition tokens should resolve to the current English API codes
+        when the German token no longer matches any radio in the dialog."""
+        dialog = MagicMock()
+        trigger = MagicMock()
+        trigger.attrs = {"id": "condition-trigger", "aria-controls": "condition-dialog"}
+        trigger.click = AsyncMock()
+        radio = MagicMock()
+        radio_attrs = MagicMock()
+        radio_attrs.get.side_effect = lambda key, default = None: f"radio-condition-{expected_api_value}" if key == "id" else default
+        radio.attrs = radio_attrs
+        radio.click = AsyncMock()
+
+        probed_values:list[str] = []
+
+        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+            if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
+                return trigger
+            if selector_type == By.XPATH and "@type='radio'" in selector_value:
+                if f"@value='{configured}'" in selector_value:
+                    probed_values.append(configured)
+                    # German token is no longer a valid DOM value — mimic that by returning None
+                    return None if configured != expected_api_value else radio
+                if f"@value='{expected_api_value}'" in selector_value:
+                    probed_values.append(expected_api_value)
+                    return radio
+            return None
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")(configured)
+
+        assert handled is True
+        # If the configured value already matches (e.g. user wrote the English code),
+        # the fallback should not be probed. Otherwise both values should have been tried.
+        if configured == expected_api_value:
+            assert probed_values == [configured]
+        else:
+            assert probed_values == [configured, expected_api_value]
+        clicked_xpath_selectors = [str(call.args[1]) for call in mock_click.await_args_list if len(call.args) > 1]
+        assert any(f"radio-condition-{expected_api_value}" in selector for selector in clicked_xpath_selectors)
 
     @pytest.mark.asyncio
     async def test_condition_missing_selector_returns_not_handled(self, test_bot:KleinanzeigenBot) -> None:
@@ -3660,24 +3719,19 @@ class TestConditionSelector:
         trigger.attrs = {"id": "condition-trigger", "aria-controls": "condition-dialog"}
         trigger.click = AsyncMock()
 
-        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element:
-            if selector_type != By.XPATH:
-                raise TimeoutError("unexpected selector")
-            if "@type='radio'" in selector_value:
-                raise TimeoutError("value not found")
-            if "dialog" in selector_value:
-                return dialog
-            raise TimeoutError("selector not found")
+        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+            if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
+                return trigger
+            # Radio lookups for unknown values return None (no matching radio in the dialog).
+            return None
 
         with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = trigger),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
+            pytest.raises(TimeoutError, match = "Failed to set attribute 'condition_s'"),
         ):
-            mock_find.side_effect = find_side_effect
-
-            with pytest.raises(TimeoutError, match = "Failed to set attribute 'condition_s'"):
-                await getattr(test_bot, "_KleinanzeigenBot__set_condition")("defect")
+            await getattr(test_bot, "_KleinanzeigenBot__set_condition")("totally_unknown_value")
 
     @pytest.mark.asyncio
     async def test_condition_rejects_shipping_trigger(self, test_bot:KleinanzeigenBot) -> None:
@@ -3832,6 +3886,7 @@ class TestShippingDialogFlow:
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
 
         with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = selected),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
@@ -3849,10 +3904,34 @@ class TestShippingDialogFlow:
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
 
         with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = TimeoutError("pickup lookup timed out")),
             pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'PICKUP'!"),
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+
+    @pytest.mark.asyncio
+    async def test_pickup_shipping_skips_when_toggle_not_rendered(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Categories without a shipping toggle (e.g. books 76/77, comics 76/77/15156) are
+        PICKUP-only by site convention — the absence of ``ad-shipping-enabled-no`` should
+        short-circuit without calling ``web_check``/``web_click``."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None) as mock_probe,
+            patch.object(test_bot, "web_check", new_callable = AsyncMock) as mock_check,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+
+        mock_probe.assert_awaited_once()
+        assert mock_probe.call_args.args[:2] == (By.ID, "ad-shipping-enabled-no")
+        mock_check.assert_not_awaited()
+        mock_click.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_shipping_without_options_uses_radio_and_dialog(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:


### PR DESCRIPTION
## ℹ️ Description

Two small publish-time failures observed against the current Kleinanzeigen DOM for ads in specific categories.

### 1. PICKUP skip for categories without a shipping toggle

Books (`76/77`) and comics (`76/77/15156`) render the "Eigenschaften und Versand" fieldset with only price/description/images — there is no `ad-shipping-enabled-yes/no` radio because the site treats these categories as pickup-only. Today `__set_shipping` raises `Failed to set shipping attribute for type 'PICKUP'!` because the radio is absent.

Fix: probe for the radio first; if absent, treat that as "already PICKUP" (which matches the configured `shipping_type: PICKUP`) and return without an error.

Live DOM diagnostic captured during the failure:
```
{"url":"…/p-anzeige-aufgeben-schritt2.html",
 "ids":[],
 "headings":[{"tag":"LEGEND","text":"Eigenschaften und Versand"}]}
```
No `[id*=shipping]` / `[id*=versand]` elements exist for these categories.

### 2. German → English condition value mapping

The condition dialog radios now use English API codes:

```
{value:"new"}, {value:"like_new"}, {value:"ok"}, {value:"alright"}
```

Ad YAMLs written against the previous DOM use German tokens (`neu`, `wie_neu`, `sehr_gut`, `gut`, `in_ordnung`, `defekt`), which no longer match any radio and produce `Failed to set attribute 'condition_s'`.

Fix: try the configured value first (preserves behaviour for English configs), then fall back to the mapped equivalent. `wie_neu` and the legacy `sehr_gut` both collapse to `like_new` because the site now exposes a single "like new" tier.

Mapping:

| Legacy German   | Current English |
|-----------------|-----------------|
| `neu`           | `new`           |
| `wie_neu`       | `like_new`      |
| `sehr_gut`      | `like_new`      |
| `gut`           | `ok`            |
| `in_ordnung`    | `alright`       |
| `defekt`        | `defect`        |

## 📋 Changes Summary

- `__set_shipping`: probe `ad-shipping-enabled-no` before the state check; return on absence with a debug log.
- `__set_condition`: switch to `web_probe` with a candidate-value list (configured value → mapped API code); preserves the existing label-click-then-radio-click flow.
- New constant `_CONDITION_GERMAN_TO_API` mapping legacy tokens to current API codes.

No behavioural change for ads in categories that do render the shipping toggle, or for ad YAMLs already using English condition codes.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass (`pdm run test`) — verified manually against the live site; unit tests for the new branches not yet added.
- [ ] I have formatted the code (`pdm run format`).
- [ ] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary (no user-facing docs change needed; the YAML token format is unchanged because the old tokens continue to work via the fallback map).

Happy to add focused unit tests for both branches and run `pdm run format`/`lint` if the direction looks right.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with German condition values for item listings.
  * Enhanced robustness when setting item conditions by probing multiple candidate values instead of failing immediately.
  * Fixed pickup-only shipping type handling to gracefully manage missing toggle controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->