### PR TITLE
fix(publish): handle category-suggestion radio picker fallback

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2984,6 +2984,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     LOG.warning("Manual recovery required for '%s'. Check 'Meine Anzeigen' to confirm whether the update was applied.", ad_cfg.title)
                     failed_count += 1
                     break
+                except CategoryResolutionError as ex:
+                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                    LOG.error("Category resolution failed for '%s': %s. Skipping ad (configuration error, no retry).", ad_cfg.title, ex)
+                    failed_count += 1
+                    break
                 except (TimeoutError, ProtocolException) as ex:
                     await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
                     if attempt >= max_retries:
@@ -3113,35 +3118,40 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         ``category`` (deepest first). The radio input is ``sr-only``, so clicks
         go on the associated ``<label for="...">``.
 
-        Raises ``TimeoutError`` with the list of offered suggestions if none of
-        the segments match — surfaces an actionable error instead of letting the
-        submit retry loop trip the duplicate-guard.
+        If the picker shell is present but radios have not rendered yet, retry
+        once after a short pause and then raise ``TimeoutError`` so the caller
+        can treat it as a retryable pre-submit failure. Raises
+        ``CategoryResolutionError`` with the list of offered suggestions if none
+        of the segments match — surfaces an actionable error instead of letting
+        the submit retry loop trip the duplicate-guard.
         """
         picker_timeout = self._timeout("quick_dom")
         picker = await self.web_probe(By.ID, "ad-category-picker", timeout = picker_timeout)
         if picker is None:
             return
 
-        try:
-            radios = await self.web_find_all(
-                By.CSS_SELECTOR,
-                "#ad-category-picker input[type='radio'][name='category-suggestions']",
-                timeout = picker_timeout,
-            )
-        except TimeoutError:
-            radios = []
-
+        radio_selector = "#ad-category-picker input[type='radio'][name='category-suggestions']"
         radio_by_value:dict[str, Element] = {}
-        for radio in radios:
-            value = str(cast(Any, radio.attrs.get("value")) or "").strip()
-            if value and value not in radio_by_value:
-                radio_by_value[value] = radio
+        for attempt in range(2):
+            try:
+                radios = await self.web_find_all(By.CSS_SELECTOR, radio_selector, timeout = picker_timeout)
+            except TimeoutError:
+                radios = []
 
-        # If the fieldset is present but radios haven't rendered yet (transient
-        # React state, or an unrelated fieldset reuse), don't block the flow.
+            radio_by_value = {}
+            for radio in radios:
+                value = str(cast(Any, radio.attrs.get("value")) or "").strip()
+                if value and value not in radio_by_value:
+                    radio_by_value[value] = radio
+
+            if radio_by_value:
+                break
+
+            if attempt == 0:
+                await self.web_sleep(200, 350)
+
         if not radio_by_value:
-            LOG.debug("Category suggestion picker element found but no radio suggestions rendered; skipping resolver.")
-            return
+            raise TimeoutError(_("Category suggestion picker element found but no radio suggestions rendered after waiting."))
 
         # Try deepest-first segments so "73/76/sachbuecher" first probes the leaf, then 76, then 73.
         for segment in (seg.strip() for seg in reversed(category.split("/")) if seg.strip()):

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -31,7 +31,7 @@ from .model.ad_model import (
 from .model.config_model import DEFAULT_DOWNLOAD_DIR, Config
 from .update_checker import UpdateChecker
 from .utils import diagnostics, dicts, error_handlers, loggers, misc, xdg_paths
-from .utils.exceptions import CaptchaEncountered, PublishedAdsFetchIncompleteError, PublishSubmissionUncertainError
+from .utils.exceptions import CaptchaEncountered, CategoryResolutionError, PublishedAdsFetchIncompleteError, PublishSubmissionUncertainError
 from .utils.files import abspath
 from .utils.i18n import Locale, get_current_locale, pluralize, set_current_locale
 from .utils.misc import ainput, ensure, is_frozen
@@ -2313,6 +2313,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     break  # Publish succeeded, exit retry loop
                 except asyncio.CancelledError:
                     raise  # Respect task cancellation
+                except CategoryResolutionError as ex:
+                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                    LOG.error("Category resolution failed for '%s': %s. Skipping ad (configuration error, no retry).", ad_cfg.title, ex)
+                    failed_count += 1
+                    break
                 except PublishSubmissionUncertainError as ex:
                     await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
                     LOG.warning(
@@ -3149,6 +3154,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     await self.web_click(
                         By.XPATH,
                         f"//fieldset[@id='ad-category-picker']//label[@for={_xpath_literal(radio_id)}]",
+                        timeout = picker_timeout,
                     )
                 else:
                     await radio.click()
@@ -3159,7 +3165,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         offered = ", ".join(sorted(radio_by_value.keys())) or "(none)"
         message = _("Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path.")  # noqa: E501
-        raise TimeoutError(message % {"category": category, "offered": offered})
+        raise CategoryResolutionError(message % {"category": category, "offered": offered})
 
     @staticmethod
     def __special_attribute_candidate_priority(elem:Element) -> tuple[int, int]:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3091,8 +3091,75 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             category_url = f"{self.root_url}/p-kategorie-aendern.html#?path={category}"
             await self.web_open(category_url)
             await self.web_click(By.XPATH, "//button[contains(., 'Weiter')]")
+
+            # When the configured path cannot be resolved (e.g. outdated or ambiguous),
+            # the site falls back to a React category-suggestion radio picker. Handle it
+            # by matching a path segment against one of the offered suggestions.
+            await self.__resolve_category_suggestions(category)
         else:
             ensure(is_category_auto_selected, f"No category specified in [{ad_file}] and automatic category detection failed")
+
+    async def __resolve_category_suggestions(self, category:str) -> None:
+        """Handle Kleinanzeigen's post-redesign category-suggestion picker.
+
+        If ``fieldset#ad-category-picker`` is rendered after the category change
+        flow (because the configured path could not be resolved), try to click
+        the suggestion whose radio ``value`` matches one of the segments of
+        ``category`` (deepest first). The radio input is ``sr-only``, so clicks
+        go on the associated ``<label for="...">``.
+
+        Raises ``TimeoutError`` with the list of offered suggestions if none of
+        the segments match — surfaces an actionable error instead of letting the
+        submit retry loop trip the duplicate-guard.
+        """
+        picker_timeout = self._timeout("quick_dom")
+        picker = await self.web_probe(By.ID, "ad-category-picker", timeout = picker_timeout)
+        if picker is None:
+            return
+
+        try:
+            radios = await self.web_find_all(
+                By.CSS_SELECTOR,
+                "#ad-category-picker input[type='radio'][name='category-suggestions']",
+                timeout = picker_timeout,
+            )
+        except TimeoutError:
+            radios = []
+
+        radio_by_value:dict[str, Element] = {}
+        for radio in radios:
+            value = str(cast(Any, radio.attrs.get("value")) or "").strip()
+            if value and value not in radio_by_value:
+                radio_by_value[value] = radio
+
+        # If the fieldset is present but radios haven't rendered yet (transient
+        # React state, or an unrelated fieldset reuse), don't block the flow.
+        if not radio_by_value:
+            LOG.debug("Category suggestion picker element found but no radio suggestions rendered; skipping resolver.")
+            return
+
+        # Try deepest-first segments so "73/76/sachbuecher" first probes the leaf, then 76, then 73.
+        for segment in (seg.strip() for seg in reversed(category.split("/")) if seg.strip()):
+            radio = radio_by_value.get(segment)
+            if radio is None:
+                continue
+            radio_id = str(cast(Any, radio.attrs.get("id")) or "")
+            try:
+                if radio_id:
+                    await self.web_click(
+                        By.XPATH,
+                        f"//fieldset[@id='ad-category-picker']//label[@for={_xpath_literal(radio_id)}]",
+                    )
+                else:
+                    await radio.click()
+            except TimeoutError:
+                await radio.click()
+            LOG.info("Category suggestion picker: selected value=%s (matched path segment).", segment)
+            return
+
+        offered = ", ".join(sorted(radio_by_value.keys())) or "(none)"
+        message = _("Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path.")  # noqa: E501
+        raise TimeoutError(message % {"category": category, "offered": offered})
 
     @staticmethod
     def __special_attribute_candidate_priority(elem:Element) -> tuple[int, int]:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -225,6 +225,7 @@ kleinanzeigen_bot/__init__.py:
     "Skipping because ad is reserved": "Überspringen, da Anzeige reserviert ist"
     " -> SKIPPED: ad '%s' (ID: %s) not found in published ads": " -> ÜBERSPRUNGEN: Anzeige '%s' (ID: %s) nicht in veröffentlichten Anzeigen gefunden"
     "Attempt %s/%s for '%s' reached submit boundary but failed: %s. Not retrying to prevent duplicate modifications.": "Versuch %s/%s für '%s' hat die Sendegrenze erreicht, ist aber fehlgeschlagen: %s. Kein weiterer Versuch, um doppelte Änderungen zu vermeiden."
+    "Category resolution failed for '%s': %s. Skipping ad (configuration error, no retry).": "Kategorieauflösung fehlgeschlagen für '%s': %s. Anzeige wird übersprungen (Konfigurationsfehler, kein erneuter Versuch)."
     "Manual recovery required for '%s'. Check 'Meine Anzeigen' to confirm whether the update was applied.": "Manuelle Nachbearbeitung für '%s' erforderlich. Bitte unter 'Meine Anzeigen' prüfen, ob die Aktualisierung übernommen wurde."
     "All %s attempts failed for '%s': %s. Skipping ad.": "Alle %s Versuche für '%s' sind fehlgeschlagen: %s. Anzeige wird übersprungen."
     "Attempt %s/%s failed for '%s': %s. Retrying...": "Versuch %s/%s für '%s' ist fehlgeschlagen: %s. Erneuter Versuch..."

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -237,6 +237,11 @@ kleinanzeigen_bot/__init__.py:
     "Unable to select condition [%s]": "Zustand [%s] konnte nicht ausgewählt werden"
     "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"
 
+  __resolve_category_suggestions:
+    "Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path.": "Kategorievorschlag-Auswahl wurde angezeigt, aber kein Segment des konfigurierten Pfades '%(category)s' passte zu den angebotenen Vorschlägen [%(offered)s]. Aktualisieren Sie 'category' auf eine angebotene ID oder einen gültigen vollständigen Pfad."
+    "Category suggestion picker: selected value=%s (matched path segment).": "Kategorievorschlag-Auswahl: Wert=%s ausgewählt (passender Pfad-Segment)."
+    "Category suggestion picker element found but no radio suggestions rendered; skipping resolver.": "Kategorievorschlag-Auswahl gefunden, aber keine Radio-Vorschläge gerendert; Resolver wird übersprungen."
+
   __set_contact_fields:
     "Could not set contact street.": "Kontaktstraße konnte nicht gesetzt werden."
     "Could not set contact name.": "Kontaktname konnte nicht gesetzt werden."

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -181,6 +181,7 @@ kleinanzeigen_bot/__init__.py:
     ? "If posted, sync local state with 'kleinanzeigen-bot download --ads=new' or 'kleinanzeigen-bot download --ads=<id>'; otherwise rerun publish for this ad."
     : "Falls veröffentlicht, lokalen Stand mit 'kleinanzeigen-bot download --ads=new' oder 'kleinanzeigen-bot download --ads=<id>' synchronisieren; andernfalls Veröffentlichung für diese Anzeige erneut starten."
     "All %s attempts failed for '%s': %s. Skipping ad.": "Alle %s Versuche fehlgeschlagen für '%s': %s. Überspringe Anzeige."
+    "Category resolution failed for '%s': %s. Skipping ad (configuration error, no retry).": "Kategorieauflösung fehlgeschlagen für '%s': %s. Anzeige wird übersprungen (Konfigurationsfehler, kein erneuter Versuch)."
     "DONE: (Re-)published %s (%s failed after retries)": "FERTIG: %s (erneut) veröffentlicht (%s fehlgeschlagen nach Wiederholungen)"
     "DONE: (Re-)published %s": "FERTIG: %s (erneut) veröffentlicht"
     "ad": "Anzeige"
@@ -239,7 +240,7 @@ kleinanzeigen_bot/__init__.py:
 
   __resolve_category_suggestions:
     "Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path.": "Kategorievorschlag-Auswahl wurde angezeigt, aber kein Segment des konfigurierten Pfades '%(category)s' passte zu den angebotenen Vorschlägen [%(offered)s]. Aktualisieren Sie 'category' auf eine angebotene ID oder einen gültigen vollständigen Pfad."
-    "Category suggestion picker: selected value=%s (matched path segment).": "Kategorievorschlag-Auswahl: Wert=%s ausgewählt (passender Pfad-Segment)."
+    "Category suggestion picker: selected value=%s (matched path segment).": "Kategorievorschlag-Auswahl: Wert=%s ausgewählt (passendes Pfad-Segment)."
     "Category suggestion picker element found but no radio suggestions rendered; skipping resolver.": "Kategorievorschlag-Auswahl gefunden, aber keine Radio-Vorschläge gerendert; Resolver wird übersprungen."
 
   __set_contact_fields:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -241,7 +241,7 @@ kleinanzeigen_bot/__init__.py:
   __resolve_category_suggestions:
     "Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path.": "Kategorievorschlag-Auswahl wurde angezeigt, aber kein Segment des konfigurierten Pfades '%(category)s' passte zu den angebotenen Vorschlägen [%(offered)s]. Aktualisieren Sie 'category' auf eine angebotene ID oder einen gültigen vollständigen Pfad."
     "Category suggestion picker: selected value=%s (matched path segment).": "Kategorievorschlag-Auswahl: Wert=%s ausgewählt (passendes Pfad-Segment)."
-    "Category suggestion picker element found but no radio suggestions rendered; skipping resolver.": "Kategorievorschlag-Auswahl gefunden, aber keine Radio-Vorschläge gerendert; Resolver wird übersprungen."
+    "Category suggestion picker element found but no radio suggestions rendered after waiting.": "Kategorievorschlag-Auswahl gefunden, aber auch nach dem Warten wurden keine Radio-Vorschläge gerendert."
 
   __set_contact_fields:
     "Could not set contact street.": "Kontaktstraße konnte nicht gesetzt werden."

--- a/src/kleinanzeigen_bot/utils/exceptions.py
+++ b/src/kleinanzeigen_bot/utils/exceptions.py
@@ -25,3 +25,16 @@ class PublishSubmissionUncertainError(KleinanzeigenBotError):
 
 class PublishedAdsFetchIncompleteError(KleinanzeigenBotError):
     """Raised when published ads cannot be fetched completely for ownership-critical operations."""
+
+
+class CategoryResolutionError(KleinanzeigenBotError):
+    """Raised when the ad's configured category cannot be resolved by the publish flow.
+
+    This is a deterministic configuration problem (no retry value): the configured
+    'category' path did not match any offered category-suggestion radio, so the
+    user must update the ad YAML. Distinct from ``TimeoutError`` so the publish
+    retry loop does not burn attempts on an error it cannot recover from.
+    """
+
+    def __init__(self, reason:str) -> None:
+        super().__init__(reason)

--- a/src/kleinanzeigen_bot/utils/exceptions.py
+++ b/src/kleinanzeigen_bot/utils/exceptions.py
@@ -28,7 +28,7 @@ class PublishedAdsFetchIncompleteError(KleinanzeigenBotError):
 
 
 class CategoryResolutionError(KleinanzeigenBotError):
-    """Raised when the ad's configured category cannot be resolved by the publish flow.
+    """Raised when the ad's configured category cannot be resolved by publish/update flows.
 
     This is a deterministic configuration problem (no retry value): the configured
     'category' path did not match any offered category-suggestion radio, so the

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2281,6 +2281,32 @@ class TestKleinanzeigenBotUpdateAdsResilience:
         sleep_mock.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_update_ads_category_resolution_error_is_not_retried(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        ad_one = self._build_update_ad(base_ad_config, 303, "Category Error Update")
+        ad_two = self._build_update_ad(base_ad_config, 304, "Second Update")
+
+        async def publish_side_effect(
+            _ad_file:str,
+            ad_cfg:Ad,
+            _ad_cfg_orig:dict[str, Any],
+            _published_ads:list[dict[str, Any]],
+            _mode:AdUpdateStrategy,
+        ) -> None:
+            if ad_cfg.id == 303:
+                raise CategoryResolutionError("no suggestion matched")
+
+        with (
+            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(303, 304)),
+            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.update_ads([ad_one, ad_two])
+
+        assert [call.args[1].id for call in publish_mock.await_args_list] == [303, 304]
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_update_ads_cancelled_error_propagates_immediately(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
         ad_one = self._build_update_ad(base_ad_config, 401, "Cancelled Ad")
         ad_two = self._build_update_ad(base_ad_config, 402, "Should Not Run")
@@ -3390,8 +3416,16 @@ class TestKleinanzeigenBotShippingOptions:
                 return "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=12345"
             return mock_response
 
+        async def mock_web_probe(selector_type:Any, selector_value:str, **_kwargs:Any) -> Any:
+            if selector_value == "ad-category-path":
+                marker = MagicMock()
+                marker.apply = AsyncMock(return_value = "")
+                return marker
+            return None
+
         with (
             patch("kleinanzeigen_bot.apply_auto_price_reduction") as mock_apply,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = mock_web_probe),
             patch.object(test_bot, "web_find", new_callable = AsyncMock),
             patch.object(test_bot, "web_input", new_callable = AsyncMock),
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
@@ -3963,16 +3997,19 @@ class TestCategorySuggestionPicker:
         mock_click.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_picker_present_without_rendered_radios_silently_skips(self, test_bot:KleinanzeigenBot) -> None:
-        """Picker shell present but radios not rendered yet (transient React state) -> silent no-op."""
+    async def test_picker_present_without_rendered_radios_retries_then_times_out(self, test_bot:KleinanzeigenBot) -> None:
+        """Picker shell present but radios not rendered yet should fail closed after a bounded retry."""
         with (
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []) as mock_find_all,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            pytest.raises(TimeoutError, match = "Category suggestion picker element found but no radio suggestions rendered after waiting."),
         ):
             await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("73/76/sachbuecher")
 
-        mock_find_all.assert_awaited_once()
+        assert mock_find_all.await_count == 2
+        mock_sleep.assert_awaited_once()
         mock_click.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -32,7 +32,7 @@ from kleinanzeigen_bot.model.config_model import (
     PublishingConfig,
 )
 from kleinanzeigen_bot.utils import dicts, loggers, xdg_paths
-from kleinanzeigen_bot.utils.exceptions import PublishedAdsFetchIncompleteError, PublishSubmissionUncertainError
+from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError, PublishedAdsFetchIncompleteError, PublishSubmissionUncertainError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
 
 
@@ -1930,6 +1930,40 @@ class TestKleinanzeigenBotBasics:
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
         ):
             await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
+
+            assert publish_mock.await_count == 1
+            sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_publish_ads_does_not_retry_on_category_resolution_error(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """CategoryResolutionError is deterministic configuration failure -> no retry, fail fast."""
+        test_bot.page = mock_page
+        test_bot.keep_old_ads = True
+
+        ad_cfg = Ad.model_validate(base_ad_config)
+        ad_cfg_orig = copy.deepcopy(base_ad_config)
+
+        with (
+            patch.object(
+                test_bot,
+                "web_request",
+                new_callable = AsyncMock,
+                return_value = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})},
+            ),
+            patch.object(
+                test_bot,
+                "publish_ad",
+                new_callable = AsyncMock,
+                side_effect = CategoryResolutionError("no suggestion matched"),
+            ) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
+        ):
+            await test_bot.publish_ads([("ad.yaml", ad_cfg, ad_cfg_orig)])
 
             assert publish_mock.await_count == 1
             sleep_mock.assert_not_awaited()
@@ -3948,14 +3982,14 @@ class TestCategorySuggestionPicker:
 
     @pytest.mark.asyncio
     async def test_picker_present_no_match_raises_with_offered_list(self, test_bot:KleinanzeigenBot) -> None:
-        """Picker present but path has no matching segment -> TimeoutError with offered IDs."""
+        """Picker present but path has no matching segment -> CategoryResolutionError with offered IDs."""
         radios = [self._radio("76", "76"), self._radio("77", "77"), self._radio("240", "240")]
 
         with (
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            pytest.raises(TimeoutError, match = r"Category suggestion picker shown.*offered"),
+            pytest.raises(CategoryResolutionError, match = r"Category suggestion picker shown.*offered"),
         ):
             await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("999/888")
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3963,9 +3963,26 @@ class TestCategorySuggestionPicker:
         mock_click.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_picker_present_without_rendered_radios_silently_skips(self, test_bot:KleinanzeigenBot) -> None:
+        """Picker shell present but radios not rendered yet (transient React state) -> silent no-op."""
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []) as mock_find_all,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("73/76/sachbuecher")
+
+        mock_find_all.assert_awaited_once()
+        mock_click.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_picker_present_matches_leaf_segment_and_clicks_label(self, test_bot:KleinanzeigenBot) -> None:
-        """Picker present with matching radio value -> label[for=ID] is clicked."""
-        radios = [self._radio("76", "76"), self._radio("77", "77"), self._radio("240", "240")]
+        """Picker present with matching radio value -> label[for=ID] is clicked (value != id to catch regressions)."""
+        radios = [
+            self._radio("76", "category-suggestion-parent"),
+            self._radio("77", "category-suggestion-leaf"),
+            self._radio("240", "category-suggestion-other"),
+        ]
 
         with (
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
@@ -3977,28 +3994,38 @@ class TestCategorySuggestionPicker:
         mock_click.assert_awaited_once()
         selector_type, selector_value = mock_click.call_args.args[:2]
         assert selector_type == By.XPATH
-        assert "label[@for='77']" in selector_value
+        assert "label[@for='category-suggestion-leaf']" in selector_value
         assert "'ad-category-picker'" in selector_value
 
     @pytest.mark.asyncio
     async def test_picker_present_no_match_raises_with_offered_list(self, test_bot:KleinanzeigenBot) -> None:
-        """Picker present but path has no matching segment -> CategoryResolutionError with offered IDs."""
-        radios = [self._radio("76", "76"), self._radio("77", "77"), self._radio("240", "240")]
+        """Picker present but path has no matching segment -> CategoryResolutionError listing offered IDs."""
+        radios = [
+            self._radio("76", "category-suggestion-parent"),
+            self._radio("77", "category-suggestion-leaf"),
+            self._radio("240", "category-suggestion-other"),
+        ]
 
         with (
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            pytest.raises(CategoryResolutionError, match = r"Category suggestion picker shown.*offered"),
+            pytest.raises(CategoryResolutionError, match = r"Category suggestion picker shown.*offered") as exc_info,
         ):
             await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("999/888")
 
         mock_click.assert_not_awaited()
+        error_message = str(exc_info.value)
+        # The error must name the configured (unmatched) path and every offered ID,
+        # otherwise the user cannot know what to correct.
+        assert "999/888" in error_message
+        for offered_id in ("76", "77", "240"):
+            assert offered_id in error_message
 
     @pytest.mark.asyncio
     async def test_picker_prefers_deepest_matching_segment(self, test_bot:KleinanzeigenBot) -> None:
         """When both parent and leaf segments match radios, the leaf (deepest) wins."""
-        radios = [self._radio("76", "76"), self._radio("77", "77")]
+        radios = [self._radio("76", "id-for-76"), self._radio("77", "id-for-77")]
 
         with (
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
@@ -4008,7 +4035,7 @@ class TestCategorySuggestionPicker:
             await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("76/77")
 
         mock_click.assert_awaited_once()
-        assert "label[@for='77']" in mock_click.call_args.args[1]
+        assert "label[@for='id-for-77']" in mock_click.call_args.args[1]
 
 
 class TestShippingDialogFlow:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3863,8 +3863,13 @@ class TestCategoryProbeBehavior:
         category_marker = MagicMock()
         category_marker.apply = AsyncMock(return_value = "Auto Category")
 
+        async def probe(selector_type:Any, selector_value:str, **_kwargs:Any) -> Any:
+            if selector_value == "ad-category-path":
+                return category_marker
+            return None  # no suggestion picker shown
+
         with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = category_marker) as mock_probe,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe) as mock_probe,
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "web_find", new_callable = AsyncMock),
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
@@ -3872,7 +3877,7 @@ class TestCategoryProbeBehavior:
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_category")("185/249", "data/my_ads/ad.yaml")
 
-        mock_probe.assert_awaited_once_with(By.ID, "ad-category-path")
+        mock_probe.assert_any_await(By.ID, "ad-category-path")
 
     @pytest.mark.asyncio
     async def test_set_category_without_explicit_category_requires_probe_match(self, test_bot:KleinanzeigenBot) -> None:
@@ -3883,6 +3888,93 @@ class TestCategoryProbeBehavior:
             pytest.raises(AssertionError, match = "No category specified"),
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_category")(None, "data/my_ads/ad.yaml")
+
+
+class TestCategorySuggestionPicker:
+    """Regression tests for the post-redesign category-suggestion radio picker fallback."""
+
+    @staticmethod
+    def _picker_probe_factory(picker_present:bool) -> Callable[..., Any]:
+        async def probe(selector_type:Any, selector_value:str, **_kwargs:Any) -> Any:
+            if selector_value == "ad-category-path":
+                marker = MagicMock()
+                marker.apply = AsyncMock(return_value = "")
+                return marker
+            if selector_value == "ad-category-picker":
+                return MagicMock() if picker_present else None
+            return None
+
+        return probe
+
+    @staticmethod
+    def _radio(value:str, radio_id:str | None = None) -> MagicMock:
+        elem = MagicMock()
+        elem.attrs = {"value": value}
+        if radio_id is not None:
+            elem.attrs["id"] = radio_id
+        elem.click = AsyncMock()
+        return elem
+
+    @pytest.mark.asyncio
+    async def test_picker_absent_leaves_flow_unchanged(self, test_bot:KleinanzeigenBot) -> None:
+        """No picker -> no-op, no find_all / label click."""
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = False)),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock) as mock_find_all,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("73/76/sachbuecher")
+
+        mock_find_all.assert_not_awaited()
+        mock_click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_picker_present_matches_leaf_segment_and_clicks_label(self, test_bot:KleinanzeigenBot) -> None:
+        """Picker present with matching radio value -> label[for=ID] is clicked."""
+        radios = [self._radio("76", "76"), self._radio("77", "77"), self._radio("240", "240")]
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("73/77")
+
+        mock_click.assert_awaited_once()
+        selector_type, selector_value = mock_click.call_args.args[:2]
+        assert selector_type == By.XPATH
+        assert "label[@for='77']" in selector_value
+        assert "'ad-category-picker'" in selector_value
+
+    @pytest.mark.asyncio
+    async def test_picker_present_no_match_raises_with_offered_list(self, test_bot:KleinanzeigenBot) -> None:
+        """Picker present but path has no matching segment -> TimeoutError with offered IDs."""
+        radios = [self._radio("76", "76"), self._radio("77", "77"), self._radio("240", "240")]
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            pytest.raises(TimeoutError, match = r"Category suggestion picker shown.*offered"),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("999/888")
+
+        mock_click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_picker_prefers_deepest_matching_segment(self, test_bot:KleinanzeigenBot) -> None:
+        """When both parent and leaf segments match radios, the leaf (deepest) wins."""
+        radios = [self._radio("76", "76"), self._radio("77", "77")]
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = self._picker_probe_factory(picker_present = True)),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("76/77")
+
+        mock_click.assert_awaited_once()
+        assert "label[@for='77']" in mock_click.call_args.args[1]
 
 
 class TestShippingDialogFlow:


### PR DESCRIPTION
## Summary

Kleinanzeigen's React redesign shows a category-suggestion radio picker (`fieldset#ad-category-picker`, radios `name="category-suggestions"`) on the posting form when the configured category path cannot be resolved by the category-change flow (outdated or ambiguous path).

Before this fix, `__set_category` did not detect the picker, so submission proceeded with an empty hidden `categoryId`, the server rejected it, and the retry loop tripped the submit-limit duplicate-guard **without publishing** — surfacing as:

```
[WARN] Versuch 1/3 für [<title>] hat die Submit-Grenze erreicht, ist aber fehlgeschlagen: submission may have succeeded before failure. Kein erneuter Versuch, um doppelte Anzeigen zu vermeiden.
[WARN] Manuelle Wiederherstellung für [<title>] erforderlich.
```

## Change

New helper `__resolve_category_suggestions(category)` runs after the category-change "Weiter" click:

- If `fieldset#ad-category-picker` is not present → no-op.
- If present: match path segments of configured `category` (deepest first) against the offered radio `value` attrs. Click the associated `<label for="...">` (the radio input itself is `sr-only` so label is the click target).
- If the picker is present but no segment matches → raise `TimeoutError` listing the offered IDs so the user can correct the ad's `category`.
- If the picker is present but no radios have rendered yet (transient / unrelated fieldset) → skip silently so we don't false-positive on DOM reuse.

## Test plan

- [x] New `TestCategorySuggestionPicker` class with 4 tests:
  - picker absent → no `web_find_all` / `web_click`
  - picker present, leaf segment matches → label click targets `#ad-category-picker`
  - picker present, no match → `TimeoutError` with offered IDs in message
  - picker present, deepest segment preferred over parent
- [x] Updated `test_set_category_uses_probe_for_auto_selected_marker` to use a selective `probe` side-effect (returns the marker for `ad-category-path`, `None` for `ad-category-picker`) so the test no longer implicitly depends on a single `web_probe` call.
- [x] `pdm run pytest tests/unit -q` — 1044 passed, 4 skipped
- [x] `pdm run ruff check src/kleinanzeigen_bot/__init__.py tests/unit/test_init.py` — clean
- [x] Translations added under `__resolve_category_suggestions` in `translations.de.yaml` for all three strings (`test_all_log_messages_have_translations[de]` passes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects Kleinanzeigen’ category-suggestion picker and matches configured category paths against offered suggestions.

* **Bug Fixes**
  * Fails fast when a category cannot be deterministically resolved (no retries), and logs/skips affected ads.
  * Improved error feedback listing available suggestion IDs when no match is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->