### PR TITLE
docs: clarify download naming examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,11 +331,13 @@ Full documentation including timeout tuning, browser settings, ad defaults, diag
 
 ### <a name="ad-config"></a>2) Ad configuration 📝
 
-Each ad is defined in a separate YAML/JSON file (default pattern: `ad_*.yaml`). These files specify the title, description, price, category, images, and other ad-specific settings.
+Each ad is defined in a separate YAML/JSON file. The `publish` workflow reads files matched by the `ad_files` glob pattern. The `download` workflow writes files into `download.dir` (default: the literal `downloaded-ads/` directory in the workspace root).
 
-The `publish` workflow reads files matched by the `ad_files` glob pattern. The `download` workflow writes files into `download.dir` (default: the literal `downloaded-ads/` directory in the workspace root).
+In XDG mode, the bare default `downloaded-ads/` stays in the workspace default download location. If you want a config-relative shared tree, set `download.dir` to `./downloaded-ads` and point `ad_files` at that tree, for example `./downloaded-ads/**/*.yaml`.
 
-In XDG mode, the bare default `downloaded-ads/` stays in the workspace default download location. If you want a config-relative shared tree, set `download.dir` to `./downloaded-ads` and ensure the `ad_files` glob pattern matches files inside that tree.
+Downloaded folder/file names are configured separately with `download.folder_name_template` and `download.ad_file_name_template`. For example: `ad_{id} {title}` or `{title} ({id})`.
+
+When an ad is published or republished and receives a new ID, the bot updates the `id` inside the existing local ad file; it does not rename local files or folders automatically.
 
 **Quick example (`ad_laptop.yaml`):**
 

--- a/docs/AD_CONFIGURATION.md
+++ b/docs/AD_CONFIGURATION.md
@@ -4,7 +4,7 @@ Complete reference for ad YAML files in kleinanzeigen-bot.
 
 ## File Format
 
-Each ad is described in a separate JSON or YAML file with the default `ad_` prefix (for example, `ad_laptop.yaml`). You can customize the prefix via the `ad_files` pattern in `config.yaml`.
+Each ad is described in a separate JSON or YAML file. The bot loads whichever files match the `ad_files` glob in `config.yaml`. Many users keep the default `ad_` prefix for downloaded files (for example, `ad_laptop.yaml`), but the filename itself is user-controlled.
 Examples below use YAML, but JSON uses the same keys and structure.
 
 Parameter values specified in the `ad_defaults` section of `config.yaml` don't need to be specified again in the ad configuration file.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -75,11 +75,23 @@ Valid file extensions: `.json`, `.yaml`, `.yml`
 
 ### ad_files
 
-Glob (wildcard) patterns to select ad configuration files. If relative paths are specified, they are relative to this configuration file.
+`ad_files` tells the bot which local ad configuration files to load.
+It is a file-selection glob only; it does not control how downloaded folders or files are named.
+If relative paths are specified, they are relative to this configuration file.
 
 ```yaml
 ad_files:
   - "./**/ad_*.{json,yml,yaml}"
+```
+
+If you want to keep downloaded ads as your working files, a common setup is:
+
+```yaml
+ad_files:
+  - "./downloaded-ads/**/*.yaml"
+
+download:
+  dir: "./downloaded-ads"
 ```
 
 ### ad_defaults
@@ -146,6 +158,10 @@ For more details on timeout configuration and troubleshooting, see [Browser Trou
 
 Download configuration for the `download` command.
 
+Use these templates to control how downloaded ads are named. Text outside `{id}` and `{title}` is copied literally.
+`{id}` is required in both templates; `{title}` is optional. The defaults are different by design: folder names default to `ad_{id}_{title}`, while file stems default to `ad_{id}`.
+So a folder/file name can be just the ID, or ID plus title.
+
 ```yaml
 download:
   dir: "downloaded-ads"  # default literal keeps workspace-mode download-folder behavior
@@ -170,14 +186,55 @@ download:
 - `download.ad_file_name_template` must include `{id}` so downloaded filenames remain stable and unique.
 - `download.folder_name_max_length` limits folder names only; downloaded file stems use a separate filename budget.
 
-Valid templates:
+Assume this sample ad:
 
-- `ad_{id}_{title}`
-- `{id}_listing`
-- `{title}_{id}`
+- ad ID: `123456789`
+- title: `My Listing`
+
+Template rules:
+
+- Allowed placeholders: `{id}`, `{title}`
+- Required placeholder: `{id}`
+- `{title}` is optional
+- Each placeholder may appear at most once
+
+How templates render:
+
+| Template | Folder name (`folder_name_template`) | File stem (`ad_file_name_template`) |
+| --- | --- | --- |
+| `ad_{id}_{title}` | `ad_123456789_My Listing/` | `ad_123456789_My Listing.yaml` |
+| `ad_{id}` | `ad_123456789/` | `ad_123456789.yaml` |
+| `ad_{id} {title}` | `ad_123456789 My Listing/` | `ad_123456789 My Listing.yaml` |
+| `{title} ({id})` | `My Listing (123456789)/` | `My Listing (123456789).yaml` |
+| `{id}` | `123456789/` | `123456789.yaml` |
+
+Full example:
+
+```yaml
+ad_files:
+  - "./downloaded-ads/**/*.yaml"
+
+download:
+  dir: "./downloaded-ads"
+  folder_name_template: "{title} ({id})"
+  ad_file_name_template: "{title} ({id})"
+```
+
+This produces a structure like:
+
+```text
+downloaded-ads/
+  My Listing (123456789)/
+    My Listing (123456789).yaml
+    My Listing (123456789)__img1.jpg
+```
+
+> **Important:** When an ad is published or republished and receives a new ID, the bot updates the `id` inside the existing local ad file. It does **not** automatically rename existing local files or folders to match the new ID.
 
 Invalid templates (rejected at startup):
 
+- `{title}` (missing required `{id}`)
+- `my-ad` (missing required `{id}`)
 - `{id}_{id}_duplicate` (repeated `{id}`)
 - `{title}_{title}_{id}` (repeated `{title}`)
 

--- a/docs/config.default.yaml
+++ b/docs/config.default.yaml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Second-Hand-Friends/kleinanzeigen-bot/main/schemas/config.schema.json
-
-# glob (wildcard) patterns to select ad configuration files
-# if relative paths are specified, then they are relative to this configuration file
+# glob (wildcard) patterns to select local ad configuration files. This only controls which files are loaded; it does not rename downloaded files. If relative paths are specified, they are relative to this configuration file
+# Example usage:
+#   ad_files:
+#     - "./downloaded-ads/**/*.yaml"
+#     - "./**/ad_*.{json,yml,yaml}"
 ad_files:
   - ./**/ad_*.{json,yml,yaml}
 
@@ -137,18 +139,20 @@ download:
   # maximum length for downloaded folder names (default: 100). does not limit downloaded file base names
   folder_name_max_length: 100
 
-  # folder naming template for downloaded ad directories. Allowed placeholders: {id}, {title}. Each placeholder may appear at most once. Template must include {id}
+  # template for downloaded ad folder names. Default: "ad_{id}_{title}". Text outside {id} and {title} is copied literally. Allowed placeholders: {id}, {title}. Each placeholder may appear at most once. Template must include {id}; {title} is optional
   # Examples (choose one):
   #   • "ad_{id}_{title}"
-  #   • "listing_{id}_{title}"
+  #   • "ad_{id} {title}"
+  #   • "{title} ({id})"
   #   • "{id}"
   folder_name_template: ad_{id}_{title}
 
-  # base name template for downloaded ad files. The bot writes the ad config as <base>.yaml and downloaded images as <base>__imgN.<ext>. Supported placeholders: {id}, {title}. Each placeholder may appear at most once. Template must include {id}. Long titles may be truncated to keep filename limits
+  # template for the downloaded ad YAML stem and image prefix. Default: "ad_{id}". The bot writes the ad config as <base>.yaml and downloaded images as <base>__imgN.<ext>. Text outside {id} and {title} is copied literally. Supported placeholders: {id}, {title}. Each placeholder may appear at most once. Template must include {id}; {title} is optional. Long titles may be truncated to keep filename limits
   # Examples (choose one):
   #   • "ad_{id}"
-  #   • "listing_{id}"
-  #   • "listing_{id}_{title}"
+  #   • "ad_{id} {title}"
+  #   • "{title} ({id})"
+  #   • "{id}"
   ad_file_name_template: ad_{id}
 
   # if true, rename existing folders without titles to include titles (default: false)

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -535,10 +535,11 @@
         },
         "folder_name_template": {
           "default": "ad_{id}_{title}",
-          "description": "folder naming template for downloaded ad directories. Allowed placeholders: {id}, {title}. Each placeholder may appear at most once. Template must include {id}",
+          "description": "template for downloaded ad folder names. Default: \"ad_{id}_{title}\". Text outside {id} and {title} is copied literally. Allowed placeholders: {id}, {title}. Each placeholder may appear at most once. Template must include {id}; {title} is optional",
           "examples": [
             "\"ad_{id}_{title}\"",
-            "\"listing_{id}_{title}\"",
+            "\"ad_{id} {title}\"",
+            "\"{title} ({id})\"",
             "\"{id}\""
           ],
           "title": "Folder Name Template",
@@ -546,11 +547,12 @@
         },
         "ad_file_name_template": {
           "default": "ad_{id}",
-          "description": "base name template for downloaded ad files. The bot writes the ad config as <base>.yaml and downloaded images as <base>__imgN.<ext>. Supported placeholders: {id}, {title}. Each placeholder may appear at most once. Template must include {id}. Long titles may be truncated to keep filename limits",
+          "description": "template for the downloaded ad YAML stem and image prefix. Default: \"ad_{id}\". The bot writes the ad config as <base>.yaml and downloaded images as <base>__imgN.<ext>. Text outside {id} and {title} is copied literally. Supported placeholders: {id}, {title}. Each placeholder may appear at most once. Template must include {id}; {title} is optional. Long titles may be truncated to keep filename limits",
           "examples": [
             "\"ad_{id}\"",
-            "\"listing_{id}\"",
-            "\"listing_{id}_{title}\""
+            "\"ad_{id} {title}\"",
+            "\"{title} ({id})\"",
+            "\"{id}\""
           ],
           "title": "Ad File Name Template",
           "type": "string"
@@ -810,7 +812,11 @@
       "default": [
         "./**/ad_*.{json,yml,yaml}"
       ],
-      "description": "\nglob (wildcard) patterns to select ad configuration files\nif relative paths are specified, then they are relative to this configuration file\n",
+      "description": "glob (wildcard) patterns to select local ad configuration files. This only controls which files are loaded; it does not rename downloaded files. If relative paths are specified, they are relative to this configuration file",
+      "examples": [
+        "\"./downloaded-ads/**/*.yaml\"",
+        "\"./**/ad_*.{json,yml,yaml}\""
+      ],
       "items": {
         "type": "string"
       },

--- a/src/kleinanzeigen_bot/model/config_model.py
+++ b/src/kleinanzeigen_bot/model/config_model.py
@@ -151,24 +151,26 @@ class DownloadConfig(ContextualModel):
     folder_name_template:str = Field(
         default = "ad_{id}_{title}",
         description=(
-            "folder naming template for downloaded ad directories. "
+            'template for downloaded ad folder names. Default: "ad_{id}_{title}". '
+            "Text outside {id} and {title} is copied literally. "
             "Allowed placeholders: {id}, {title}. "
             "Each placeholder may appear at most once. "
-            "Template must include {id}"
+            "Template must include {id}; {title} is optional"
         ),
-        examples = ['"ad_{id}_{title}"', '"listing_{id}_{title}"', '"{id}"'],
+        examples = ['"ad_{id}_{title}"', '"ad_{id} {title}"', '"{title} ({id})"', '"{id}"'],
     )
     ad_file_name_template:str = Field(
         default = "ad_{id}",
         description=(
-            "base name template for downloaded ad files. "
+            'template for the downloaded ad YAML stem and image prefix. Default: "ad_{id}". '
             "The bot writes the ad config as <base>.yaml and downloaded images as <base>__imgN.<ext>. "
+            "Text outside {id} and {title} is copied literally. "
             "Supported placeholders: {id}, {title}. "
             "Each placeholder may appear at most once. "
-            "Template must include {id}. "
+            "Template must include {id}; {title} is optional. "
             "Long titles may be truncated to keep filename limits"
         ),
-        examples = ['"ad_{id}"', '"listing_{id}"', '"listing_{id}_{title}"'],
+        examples = ['"ad_{id}"', '"ad_{id} {title}"', '"{title} ({id})"', '"{id}"'],
     )
     rename_existing_folders:bool = Field(
         default = False,
@@ -444,10 +446,12 @@ class Config(ContextualModel):
         default_factory = lambda: ["./**/ad_*.{json,yml,yaml}"],
         json_schema_extra = {"default": ["./**/ad_*.{json,yml,yaml}"]},
         min_length = 1,
-        description = """
-glob (wildcard) patterns to select ad configuration files
-if relative paths are specified, then they are relative to this configuration file
-""",
+        description = (
+            "glob (wildcard) patterns to select local ad configuration files. "
+            "This only controls which files are loaded; it does not rename downloaded files. "
+            "If relative paths are specified, they are relative to this configuration file"
+        ),
+        examples = ['"./downloaded-ads/**/*.yaml"', '"./**/ad_*.{json,yml,yaml}"'],
     )
 
     ad_defaults:AdDefaults = Field(default_factory = AdDefaults, description = "Default values for ads, can be overwritten in each ad configuration file")


### PR DESCRIPTION
## ℹ️ Description
Documentation-only update to clarify how `ad_files` differs from download naming templates and how published IDs are handled.

- Link to the related discussion: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/discussions/839
- Describe the motivation and context for this change: reduce confusion around downloaded ad naming and local file behavior.

## 📋 Changes Summary
- Clarified `ad_files` as a file-selection glob, separate from download naming.
- Added concrete sample ID/title render examples for folder and file templates.
- Documented that publish updates the YAML `id` in place and does not auto-rename local files or folders.
- Regenerated config docs and schema artifacts to keep generated output in sync.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded ad configuration and setup documentation with improved guidance on file pattern matching and download directory configuration.
  * Clarified how placeholder templates work in file naming, including required and optional parameters.
  * Added comprehensive examples demonstrating template rendering and configuration best practices.
  * Documented republish behavior and workflow guidance for managing downloaded ad files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->