### PR TITLE
fix: guard condition mappings against API drift

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -27,6 +27,7 @@ from .model.ad_model import (
     Contact,
     calculate_auto_price,
     calculate_auto_price_with_trace,
+    validate_condition_api_mapping,
 )
 from .model.config_model import DEFAULT_DOWNLOAD_DIR, Config
 from .update_checker import UpdateChecker
@@ -62,6 +63,7 @@ _CONDITION_GERMAN_TO_API:Final[dict[str, str]] = {
     "in_ordnung": "alright",
     "defekt": "defect",
 }
+validate_condition_api_mapping("_CONDITION_GERMAN_TO_API", _CONDITION_GERMAN_TO_API)
 _LOGIN_DETECTION_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CLASS_NAME, "mr-medium"),
     (By.ID, "user-email"),

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -18,7 +18,7 @@ from typing import Any, Final
 
 from kleinanzeigen_bot.model.ad_model import ContactPartial
 
-from .model.ad_model import OPTION_NAME_BY_CARRIER_CODE, AdPartial
+from .model.ad_model import OPTION_NAME_BY_CARRIER_CODE, AdPartial, validate_condition_api_mapping
 from .model.config_model import Config
 from .utils import dicts, files, i18n, loggers, misc, reflect
 from .utils.web_scraping_mixin import Browser, By, Element, WebScrapingMixin
@@ -47,6 +47,7 @@ _CONDITION_DISPLAY_TO_API:Final[dict[str, str]] = {
     "in ordnung": "alright",
     "defekt": "defect",
 }
+validate_condition_api_mapping("_CONDITION_DISPLAY_TO_API", _CONDITION_DISPLAY_TO_API)
 _LABEL_TO_KEY:Final[dict[str, str]] = {
     "zustand": "condition_s",
 }

--- a/src/kleinanzeigen_bot/model/ad_model.py
+++ b/src/kleinanzeigen_bot/model/ad_model.py
@@ -117,6 +117,14 @@ CARRIER_CODES_BY_SIZE:Final[dict[str, list[str]]] = {
     "Groß": ["HERMES_004", "DHL_003", "DHL_004", "DHL_005"],
 }
 
+CONDITION_API_VALUES:Final[frozenset[str]] = frozenset({"new", "like_new", "ok", "alright", "defect"})
+
+
+def validate_condition_api_mapping(mapping_name:str, mapping:Mapping[str, str]) -> None:
+    unknown_values = set(mapping.values()) - CONDITION_API_VALUES
+    if unknown_values:
+        raise ValueError(f"{mapping_name} contains unsupported condition API values: {', '.join(sorted(unknown_values))}")
+
 
 def _validate_auto_price_reduction_constraints(price:int | None, auto_price_reduction:AutoPriceReductionConfig | dict[str, Any] | None) -> None:
     """

--- a/tests/unit/test_ad_model.py
+++ b/tests/unit/test_ad_model.py
@@ -7,7 +7,14 @@ import math
 
 import pytest
 
-from kleinanzeigen_bot.model.ad_model import MAX_DESCRIPTION_LENGTH, MAX_TITLE_LENGTH, MIN_TITLE_LENGTH, AdPartial, ShippingOption
+from kleinanzeigen_bot.model.ad_model import (
+    MAX_DESCRIPTION_LENGTH,
+    MAX_TITLE_LENGTH,
+    MIN_TITLE_LENGTH,
+    AdPartial,
+    ShippingOption,
+    validate_condition_api_mapping,
+)
 from kleinanzeigen_bot.model.config_model import AdDefaults, AutoPriceReductionConfig
 from kleinanzeigen_bot.utils.pydantics import ContextualModel, ContextualValidationError
 
@@ -146,6 +153,12 @@ class ShippingOptionWrapper(ContextualModel):
 def test_shipping_option_must_not_be_blank() -> None:
     with pytest.raises(ContextualValidationError, match = "must be non-empty and non-blank"):
         ShippingOptionWrapper.model_validate({"option": " "})
+
+
+@pytest.mark.unit
+def test_validate_condition_api_mapping_rejects_unknown_values() -> None:
+    with pytest.raises(ValueError, match = "contains unsupported condition API values: broken"):
+        validate_condition_api_mapping("mapping_name", {"known": "new", "bad": "broken"})
 
 
 @pytest.mark.unit

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2771,13 +2771,19 @@ class TestRenderDownloadNameWithBudgetWarnings:
         assert "12345678901234567890" not in rendered
         assert len(rendered) <= 5
 
-    def test_truncates_title_when_budget_exhausted(self, test_extractor:extract_module.AdExtractor) -> None:
+    def test_truncates_title_when_budget_exhausted(
+        self,
+        test_extractor:extract_module.AdExtractor,
+        caplog:pytest.LogCaptureFixture,
+    ) -> None:
         """{title} is truncated to fit within budget while {id} is preserved."""
-        rendered = test_extractor._render_download_name_with_budget("{id}_{title}", 12345, "Very Long Title Here", 12)
+        with caplog.at_level("WARNING"):
+            rendered = test_extractor._render_download_name_with_budget("{id}_{title}", 12345, "Very Long Title Here", 12)
 
         assert "12345" in rendered
         assert "Very Long Title Here" not in rendered
         assert len(rendered) <= 12
+        assert any(record.levelname == "WARNING" for record in caplog.records)
 
     def test_id_protected_over_literals(self, test_extractor:extract_module.AdExtractor) -> None:
         """{id} is protected over literal text with tight budget."""

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2474,12 +2474,11 @@ class TestAdExtractorDownload:
 
         with (
             patch("kleinanzeigen_bot.extract.os.name", "posix"),
-            patch("kleinanzeigen_bot.extract.os.stat") as mock_stat,
+            patch("kleinanzeigen_bot.extract.os.stat"),
             patch("kleinanzeigen_bot.extract.os.chmod") as mock_chmod,
         ):
             extract_module._handle_rmtree_onerror(retry_func, path, (PermissionError, PermissionError("busy"), None))
 
-        mock_stat.assert_not_called()
         mock_chmod.assert_not_called()
         retry_func.assert_called_once_with(path)
 
@@ -2783,7 +2782,7 @@ class TestRenderDownloadNameWithBudgetWarnings:
         assert "12345" in rendered
         assert "Very Long Title Here" not in rendered
         assert len(rendered) <= 12
-        assert any(record.levelname == "WARNING" for record in caplog.records)
+        assert any("Download name truncated {title} placeholder" in record.getMessage() for record in caplog.records)
 
     def test_id_protected_over_literals(self, test_extractor:extract_module.AdExtractor) -> None:
         """{id} is protected over literal text with tight budget."""


### PR DESCRIPTION
## ℹ️ Description
*Provide a concise summary of the changes introduced in this pull request.*

- Link to the related issue(s): Issue #1004
- Add import-time validation to catch condition API drift early.

## 📋 Changes Summary

- Introduce a shared canonical set of allowed condition API values in `src/kleinanzeigen_bot/model/ad_model.py`.
- Validate the publish and extract condition mapping tables at import time.
- Keep the two mapping tables independent while failing fast on unknown API codes.
- Clean up a few low-value tests in the touched area to focus on behavior instead of constant snapshots.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [ ] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test to ensure invalid condition mappings are rejected with a clear error.
  * Enhanced a test to assert that a truncation warning is logged when title length limits are hit.

* **Chores**
  * Added upfront validation of condition mappings at initialization to surface invalid configurations early with detailed error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->