### PR TITLE
feat(publish): warn on legacy German condition values

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3026,6 +3026,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         Returns True when dialog handling succeeded, otherwise False to indicate
         that caller should use generic special-attribute handling.
         """
+        mapped_value = _CONDITION_GERMAN_TO_API.get(condition_value)
+        if mapped_value and mapped_value != condition_value:
+            LOG.warning("Condition value [%s] is deprecated; update your config to [%s].", condition_value, mapped_value)
+
         short_timeout = self._timeout("quick_dom")
         condition_trigger_xpath = "//label[contains(@for, '.condition')]/following::button[@aria-haspopup='dialog' or @aria-haspopup='true'][1]"
 
@@ -3053,7 +3057,6 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # (e.g. "wie_neu" -> "like_new", "sehr_gut" -> "like_new"). Try the configured value
         # first (handles already-English configs), then fall back to the mapped equivalent.
         candidate_values = [condition_value]
-        mapped_value = _CONDITION_GERMAN_TO_API.get(condition_value)
         if mapped_value and mapped_value != condition_value:
             candidate_values.append(mapped_value)
 

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -237,6 +237,7 @@ kleinanzeigen_bot/__init__.py:
     "ad": "Anzeige"
 
   __set_condition:
+    "Condition value [%s] is deprecated; update your config to [%s].": "Zustandswert [%s] ist veraltet; aktualisieren Sie die Konfiguration auf [%s]."
     "Unable to close condition dialog!": "Kann den Dialog für Artikelzustand nicht schließen!"
     "Unable to select condition [%s]": "Zustand [%s] konnte nicht ausgewählt werden"
     "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3718,25 +3718,26 @@ class TestConditionSelector:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("configured", "expected_api_value"),
+        ("configured", "expected_api_value", "expect_warning"),
         [
-            ("wie_neu", "like_new"),
-            ("sehr_gut", "like_new"),
-            ("neu", "new"),
-            ("gut", "ok"),
-            ("in_ordnung", "alright"),
-            ("defekt", "defect"),
+            ("wie_neu", "like_new", True),
+            ("sehr_gut", "like_new", True),
+            ("new", "new", False),
+            ("like_new", "like_new", False),
+            ("ok", "ok", False),
+            ("alright", "alright", False),
+            ("defect", "defect", False),
         ],
     )
-    async def test_condition_falls_back_to_english_api_value(
+    async def test_condition_tokens_warn_only_for_legacy_values(
         self,
         test_bot:KleinanzeigenBot,
         configured:str,
         expected_api_value:str,
+        expect_warning:bool,
         caplog:pytest.LogCaptureFixture,
     ) -> None:
-        """Legacy German condition tokens should resolve to the current English API codes
-        when the German token no longer matches any radio in the dialog."""
+        """Condition tokens should resolve to the current API codes and warn only for legacy German values."""
         caplog.set_level(logging.WARNING, logger = LOG.name)
         dialog = MagicMock()
         trigger = MagicMock()
@@ -3772,48 +3773,17 @@ class TestConditionSelector:
 
         assert handled is True
         warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
-        assert warning_messages == [f"Condition value [{configured}] is deprecated; update your config to [{expected_api_value}]."]
-        # Legacy German values should probe the configured token first, then the mapped API code.
-        assert probed_values == [configured, expected_api_value]
+        if expect_warning:
+            assert len(warning_messages) == 1
+            assert configured in warning_messages[0]
+            assert expected_api_value in warning_messages[0]
+            # Legacy German values should probe the configured token first, then the mapped API code.
+            assert probed_values == [configured, expected_api_value]
+        else:
+            assert warning_messages == []
+            assert probed_values == [configured]
         clicked_xpath_selectors = [str(call.args[1]) for call in mock_click.await_args_list if len(call.args) > 1]
         assert any(f"radio-condition-{expected_api_value}" in selector for selector in clicked_xpath_selectors)
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("configured", ["new", "like_new", "ok", "alright", "defect"])
-    async def test_condition_english_api_value_does_not_warn(
-        self,
-        test_bot:KleinanzeigenBot,
-        configured:str,
-        caplog:pytest.LogCaptureFixture,
-    ) -> None:
-        """Already-English condition values should not emit a deprecation warning."""
-        caplog.set_level(logging.WARNING, logger = LOG.name)
-        dialog = MagicMock()
-        trigger = MagicMock()
-        trigger.attrs = {"id": "condition-trigger", "aria-controls": "condition-dialog"}
-        trigger.click = AsyncMock()
-        radio = MagicMock()
-        radio_attrs = MagicMock()
-        radio_attrs.get.side_effect = lambda key, default = None: f"radio-condition-{configured}" if key == "id" else default
-        radio.attrs = radio_attrs
-        radio.click = AsyncMock()
-
-        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
-            if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
-                return trigger
-            if selector_type == By.XPATH and "@type='radio'" in selector_value:
-                return radio if f"@value='{configured}'" in selector_value else None
-            return None
-
-        with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-        ):
-            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")(configured)
-
-        assert handled is True
-        assert [record.message for record in caplog.records if record.levelno == logging.WARNING] == []
 
     @pytest.mark.asyncio
     async def test_condition_missing_selector_returns_not_handled(self, test_bot:KleinanzeigenBot) -> None:
@@ -3845,9 +3815,10 @@ class TestConditionSelector:
             handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("wie_neu")
 
         assert handled is False
-        assert [record.message for record in caplog.records if record.levelno == logging.WARNING] == [
-            "Condition value [wie_neu] is deprecated; update your config to [like_new]."
-        ]
+        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+        assert len(warning_messages) == 1
+        assert "wie_neu" in warning_messages[0]
+        assert "like_new" in warning_messages[0]
 
     @pytest.mark.asyncio
     async def test_condition_unknown_value_raises(self, test_bot:KleinanzeigenBot) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3733,9 +3733,11 @@ class TestConditionSelector:
         test_bot:KleinanzeigenBot,
         configured:str,
         expected_api_value:str,
+        caplog:pytest.LogCaptureFixture,
     ) -> None:
         """Legacy German condition tokens should resolve to the current English API codes
         when the German token no longer matches any radio in the dialog."""
+        caplog.set_level(logging.WARNING, logger = LOG.name)
         dialog = MagicMock()
         trigger = MagicMock()
         trigger.attrs = {"id": "condition-trigger", "aria-controls": "condition-dialog"}
@@ -3769,14 +3771,49 @@ class TestConditionSelector:
             handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")(configured)
 
         assert handled is True
-        # If the configured value already matches (e.g. user wrote the English code),
-        # the fallback should not be probed. Otherwise both values should have been tried.
-        if configured == expected_api_value:
-            assert probed_values == [configured]
-        else:
-            assert probed_values == [configured, expected_api_value]
+        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+        assert warning_messages == [f"Condition value [{configured}] is deprecated; update your config to [{expected_api_value}]."]
+        # Legacy German values should probe the configured token first, then the mapped API code.
+        assert probed_values == [configured, expected_api_value]
         clicked_xpath_selectors = [str(call.args[1]) for call in mock_click.await_args_list if len(call.args) > 1]
         assert any(f"radio-condition-{expected_api_value}" in selector for selector in clicked_xpath_selectors)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("configured", ["new", "like_new", "ok", "alright", "defect"])
+    async def test_condition_english_api_value_does_not_warn(
+        self,
+        test_bot:KleinanzeigenBot,
+        configured:str,
+        caplog:pytest.LogCaptureFixture,
+    ) -> None:
+        """Already-English condition values should not emit a deprecation warning."""
+        caplog.set_level(logging.WARNING, logger = LOG.name)
+        dialog = MagicMock()
+        trigger = MagicMock()
+        trigger.attrs = {"id": "condition-trigger", "aria-controls": "condition-dialog"}
+        trigger.click = AsyncMock()
+        radio = MagicMock()
+        radio_attrs = MagicMock()
+        radio_attrs.get.side_effect = lambda key, default = None: f"radio-condition-{configured}" if key == "id" else default
+        radio.attrs = radio_attrs
+        radio.click = AsyncMock()
+
+        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+            if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
+                return trigger
+            if selector_type == By.XPATH and "@type='radio'" in selector_value:
+                return radio if f"@value='{configured}'" in selector_value else None
+            return None
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+        ):
+            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")(configured)
+
+        assert handled is True
+        assert [record.message for record in caplog.records if record.levelno == logging.WARNING] == []
 
     @pytest.mark.asyncio
     async def test_condition_missing_selector_returns_not_handled(self, test_bot:KleinanzeigenBot) -> None:
@@ -3794,6 +3831,23 @@ class TestConditionSelector:
             handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("ok")
 
         assert handled is False
+
+    @pytest.mark.asyncio
+    async def test_condition_legacy_value_warns_even_when_not_handled(
+        self,
+        test_bot:KleinanzeigenBot,
+        caplog:pytest.LogCaptureFixture,
+    ) -> None:
+        """Legacy German values should warn even when the condition dialog path is unavailable."""
+        caplog.set_level(logging.WARNING, logger = LOG.name)
+
+        with patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None):
+            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("wie_neu")
+
+        assert handled is False
+        assert [record.message for record in caplog.records if record.levelno == logging.WARNING] == [
+            "Condition value [wie_neu] is deprecated; update your config to [like_new]."
+        ]
 
     @pytest.mark.asyncio
     async def test_condition_unknown_value_raises(self, test_bot:KleinanzeigenBot) -> None:


### PR DESCRIPTION
## ℹ️ Description
*Provide a concise summary of the changes introduced in this pull request.*

- Link to the related issue(s): Issue #1001
- Describe the motivation and context for this change: surface a warning when legacy German condition tokens are still used so users can migrate to the current English API values.

## 📋 Changes Summary

- Logs a warning in `KleinanzeigenBot.__set_condition()` when a legacy German condition value is mapped to a newer API value.
- Preserves the existing fallback behavior so legacy configs continue to work.
- Adds unit coverage for legacy warning behavior, English values, and the dialog-unavailable path.
- Adds a German translation for the warning message.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deprecation warning when using legacy condition configuration values, guiding users to update their settings.

* **Tests**
  * Enhanced test coverage for condition value handling and deprecation messaging to ensure proper system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->