### PR TITLE
fix(publish): normalize legacy condition handling

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3332,6 +3332,13 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         normalized_special_attribute_key:str,
         special_attr_xpath:str,
     ) -> None:
+        """Set a resolved special attribute on the detected form control.
+
+        Handles ``select``, ``checkbox``, button-combobox, combobox-input, and plain text
+        inputs; ``condition`` additionally retries the mapped display candidates before
+        falling back. All failures are normalized to ``TimeoutError`` so callers can treat
+        special-attribute setting uniformly in logs and error handling.
+        """
         try:
             elem_id = cast(str | None, special_attr_elem.attrs.get("id"))
             elem_type = str(cast(Any, special_attr_elem.attrs.get("type")) or "").lower()

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -27,6 +27,7 @@ from .model.ad_model import (
     Contact,
     calculate_auto_price,
     calculate_auto_price_with_trace,
+    validate_condition_api_display_candidates,
     validate_condition_api_mapping,
 )
 from .model.config_model import DEFAULT_DOWNLOAD_DIR, Config
@@ -71,6 +72,7 @@ _CONDITION_API_TO_DISPLAY_CANDIDATES:Final[dict[str, tuple[str, ...]]] = {
     "alright": ("In Ordnung",),
     "defect": ("Defekt",),
 }
+validate_condition_api_display_candidates("_CONDITION_API_TO_DISPLAY_CANDIDATES", _CONDITION_API_TO_DISPLAY_CANDIDATES)
 _LOGIN_DETECTION_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CLASS_NAME, "mr-medium"),
     (By.ID, "user-email"),

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3316,101 +3316,152 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     )
                 raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key) from ex
 
-            try:
-                elem_id = cast(str | None, special_attr_elem.attrs.get("id"))
-                elem_type = str(cast(Any, special_attr_elem.attrs.get("type")) or "").lower()
-                elem_role = str(cast(Any, special_attr_elem.attrs.get("role")) or "").lower()
-                elem_selector_type = By.ID if elem_id else By.XPATH
-                elem_selector_value = elem_id or special_attr_xpath
-                condition_display_candidates = _CONDITION_API_TO_DISPLAY_CANDIDATES.get(special_attribute_value_str, (special_attribute_value_str,))
+            await self.__set_special_attribute_value(
+                special_attr_elem,
+                special_attribute_key,
+                special_attribute_value_str,
+                normalized_special_attribute_key,
+                special_attr_xpath,
+            )
 
-                if special_attr_elem.local_name == "select":
-                    LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)
-                    selected_values = [special_attribute_value_str]
-                    if normalized_special_attribute_key == "condition":
-                        selected_values = list(dict.fromkeys((*condition_display_candidates, special_attribute_value_str)))
+    async def __set_special_attribute_value(
+        self,
+        special_attr_elem:Element,
+        special_attribute_key:str,
+        special_attribute_value_str:str,
+        normalized_special_attribute_key:str,
+        special_attr_xpath:str,
+    ) -> None:
+        try:
+            elem_id = cast(str | None, special_attr_elem.attrs.get("id"))
+            elem_type = str(cast(Any, special_attr_elem.attrs.get("type")) or "").lower()
+            elem_role = str(cast(Any, special_attr_elem.attrs.get("role")) or "").lower()
+            elem_selector_type = By.ID if elem_id else By.XPATH
+            elem_selector_value = elem_id or special_attr_xpath
+            condition_display_candidates = _CONDITION_API_TO_DISPLAY_CANDIDATES.get(special_attribute_value_str, (special_attribute_value_str,))
 
-                    last_timeout_error:TimeoutError | None = None
-                    for selected_value in selected_values:
-                        try:
-                            await self.web_select(elem_selector_type, elem_selector_value, selected_value)
-                            break
-                        except TimeoutError as ex:
-                            last_timeout_error = ex
-                    else:
-                        if last_timeout_error is not None:
-                            raise last_timeout_error
-                elif elem_type == "checkbox":
-                    LOG.debug("Attribute field '%s' seems to be a checkbox...", special_attribute_key)
-                    truthy_values = {"1", "true", "yes", "on", "ja", "checked"}
-                    falsy_values = {"", "0", "false", "no", "off", "nein", "unchecked", "none"}
-                    normalized_checkbox_value = special_attribute_value_str.strip().lower()
-                    if normalized_checkbox_value in truthy_values:
-                        desired_checked = True
-                    elif normalized_checkbox_value in falsy_values:
-                        desired_checked = False
-                    else:
-                        LOG.debug(
-                            "Attribute field '%s' has unsupported checkbox value '%s'.",
-                            special_attribute_key,
-                            special_attribute_value_str,
-                        )
-                        raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key)
+            if special_attr_elem.local_name == "select":
+                LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)
+                selected_values = [special_attribute_value_str]
+                if normalized_special_attribute_key == "condition":
+                    selected_values = list(dict.fromkeys((*condition_display_candidates, special_attribute_value_str)))
 
-                    current_checked_attr = special_attr_elem.attrs.get("checked")
-                    if isinstance(current_checked_attr, bool):
-                        current_checked = current_checked_attr
-                    else:
-                        normalized_current_checked = str(current_checked_attr).strip().lower() if current_checked_attr is not None else ""
-                        current_checked = normalized_current_checked not in falsy_values
+                last_timeout_error:TimeoutError | None = None
+                for selected_value in selected_values:
+                    try:
+                        await self.web_select(elem_selector_type, elem_selector_value, selected_value)
+                        break
+                    except TimeoutError as ex:
+                        last_timeout_error = ex
+                else:
+                    if last_timeout_error is not None:
+                        raise last_timeout_error
+            elif elem_type == "checkbox":
+                LOG.debug("Attribute field '%s' seems to be a checkbox...", special_attribute_key)
+                truthy_values = {"1", "true", "yes", "on", "ja", "checked"}
+                falsy_values = {"", "0", "false", "no", "off", "nein", "unchecked", "none"}
+                normalized_checkbox_value = special_attribute_value_str.strip().lower()
+                if normalized_checkbox_value in truthy_values:
+                    desired_checked = True
+                elif normalized_checkbox_value in falsy_values:
+                    desired_checked = False
+                else:
+                    LOG.debug(
+                        "Attribute field '%s' has unsupported checkbox value '%s'.",
+                        special_attribute_key,
+                        special_attribute_value_str,
+                    )
+                    raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key)
 
-                    if desired_checked != current_checked:
-                        await self.web_click(elem_selector_type, elem_selector_value)
-                elif special_attr_elem.local_name == "button" and elem_role == "combobox":
-                    LOG.debug("Attribute field '%s' seems to be a button combobox (click-to-open dropdown)...", special_attribute_key)
-                    ensure(elem_id, f"No id available for button combobox special attribute [{special_attribute_key}]")
-                    button_values = [special_attribute_value_str]
-                    if normalized_special_attribute_key == "condition":
-                        button_values = list(dict.fromkeys((*condition_display_candidates, special_attribute_value_str)))
+                current_checked_attr = special_attr_elem.attrs.get("checked")
+                if isinstance(current_checked_attr, bool):
+                    current_checked = current_checked_attr
+                else:
+                    normalized_current_checked = str(current_checked_attr).strip().lower() if current_checked_attr is not None else ""
+                    current_checked = normalized_current_checked not in falsy_values
+
+                if desired_checked != current_checked:
+                    await self.web_click(elem_selector_type, elem_selector_value)
+            elif special_attr_elem.local_name == "button" and elem_role == "combobox":
+                LOG.debug("Attribute field '%s' seems to be a button combobox (click-to-open dropdown)...", special_attribute_key)
+                ensure(elem_id, f"No id available for button combobox special attribute [{special_attribute_key}]")
+                if normalized_special_attribute_key == "condition":
+                    button_id = cast(str, elem_id)
+                    await self.web_click(By.ID, button_id)
 
                     last_timeout_error_button:TimeoutError | None = None
-                    for button_combobox_value in button_values:
+                    for button_combobox_value in condition_display_candidates:
                         try:
-                            await self.__select_button_combobox(cast(str, elem_id), button_combobox_value)
+                            await self.web_select_button_combobox(button_id, button_combobox_value, click_trigger = False)
                             break
                         except TimeoutError as ex:
                             last_timeout_error_button = ex
                     else:
                         if last_timeout_error_button is not None:
                             raise last_timeout_error_button
-                elif elem_role == "combobox" and elem_type in {"text", ""} and special_attr_elem.local_name == "input":
-                    LOG.debug("Attribute field '%s' seems to be a Combobox (i.e. text input with filtering dropdown)...", special_attribute_key)
-                    selected_values = [special_attribute_value_str]
-                    if normalized_special_attribute_key == "condition":
-                        selected_values = list(dict.fromkeys((*condition_display_candidates, special_attribute_value_str)))
-
-                    last_timeout_error_input:TimeoutError | None = None
-                    for selected_value in selected_values:
-                        try:
-                            await self.web_select_combobox(elem_selector_type, elem_selector_value, selected_value)
-                            break
-                        except TimeoutError as ex:
-                            last_timeout_error_input = ex
-                    else:
-                        if last_timeout_error_input is not None:
-                            raise last_timeout_error_input
                 else:
-                    LOG.debug("Attribute field '%s' seems to be a text input...", special_attribute_key)
-                    await self.web_input(elem_selector_type, elem_selector_value, special_attribute_value_str)
-            except TimeoutError as ex:
-                LOG.debug("Failed to set attribute field '%s' via known input types.", special_attribute_key)
-                raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key) from ex
-            LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
+                    await self.__select_button_combobox(cast(str, elem_id), special_attribute_value_str)
+            elif elem_role == "combobox" and elem_type in {"text", ""} and special_attr_elem.local_name == "input":
+                LOG.debug("Attribute field '%s' seems to be a Combobox (i.e. text input with filtering dropdown)...", special_attribute_key)
+                selected_values = [special_attribute_value_str]
+                if normalized_special_attribute_key == "condition":
+                    selected_values = list(dict.fromkeys((*condition_display_candidates, special_attribute_value_str)))
 
-    # Legacy wrapper kept for compatibility; prefer web_select_button_combobox (display-text-based, no React fiber).
+                last_timeout_error_input:TimeoutError | None = None
+                for selected_value in selected_values:
+                    try:
+                        await self.web_select_combobox(elem_selector_type, elem_selector_value, selected_value)
+                        break
+                    except TimeoutError as ex:
+                        last_timeout_error_input = ex
+                else:
+                    if last_timeout_error_input is not None:
+                        raise last_timeout_error_input
+            else:
+                LOG.debug("Attribute field '%s' seems to be a text input...", special_attribute_key)
+                await self.web_input(elem_selector_type, elem_selector_value, special_attribute_value_str)
+        except TimeoutError as ex:
+            LOG.debug("Failed to set attribute field '%s' via known input types.", special_attribute_key)
+            raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key) from ex
+        LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
+
+    # TODO: Issue #930 — migrate to web_select_button_combobox (display-text-based, no React fiber)
     async def __select_button_combobox(self, elem_id:str, value:str) -> None:
-        """Select an option from a ``<button role="combobox">`` dropdown by display text."""
-        await self.web_select_button_combobox(elem_id, value)
+        """Select an option from a <button role="combobox"> dropdown by its API value.
+
+        Clicks the button to open the listbox, reads the options data from the React fiber
+        (which maps API values to display labels), and clicks the matching option.
+        """
+        await self.web_click(By.ID, elem_id)
+        listbox_id = f"{elem_id}-menu"
+        await self.web_find(By.ID, listbox_id)
+        js_btn_id = json.dumps(elem_id)
+        js_listbox_id = json.dumps(listbox_id)
+        js_value = json.dumps(value)
+        ok = await self.web_execute(f"""(function() {{
+            const listbox = document.getElementById({js_listbox_id});
+            if (!listbox) return false;
+            const liOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
+            const btnEl = document.getElementById({js_btn_id});
+            if (!btnEl) return false;
+            const fiberKey = Object.keys(btnEl).find(k => k.startsWith('__reactFiber'));
+            let fiber = fiberKey ? btnEl[fiberKey] : null;
+            for (let i = 0; i < 20 && fiber; i++, fiber = fiber.return) {{
+                if (fiber.memoizedProps && fiber.memoizedProps.options) {{
+                    const optionsData = fiber.memoizedProps.options;
+                    for (let j = 0; j < optionsData.length; j++) {{
+                        if (optionsData[j].value === {js_value} && liOptions[j]) {{
+                            liOptions[j].click();
+                            return true;
+                        }}
+                    }}
+                    return false;
+                }}
+            }}
+            return false;
+        }})()""")
+        if not ok:
+            raise TimeoutError(_("Option '%(value)s' not found in button combobox '%(id)s'") % {"value": value, "id": elem_id})
 
     async def __set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
         short_timeout = self._timeout("quick_dom")

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3323,7 +3323,6 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 elem_selector_type = By.ID if elem_id else By.XPATH
                 elem_selector_value = elem_id or special_attr_xpath
                 condition_display_candidates = _CONDITION_API_TO_DISPLAY_CANDIDATES.get(special_attribute_value_str, (special_attribute_value_str,))
-                condition_display_value = condition_display_candidates[0]
 
                 if special_attr_elem.local_name == "select":
                     LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)
@@ -3370,12 +3369,36 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 elif special_attr_elem.local_name == "button" and elem_role == "combobox":
                     LOG.debug("Attribute field '%s' seems to be a button combobox (click-to-open dropdown)...", special_attribute_key)
                     ensure(elem_id, f"No id available for button combobox special attribute [{special_attribute_key}]")
-                    button_combobox_value = condition_display_value if normalized_special_attribute_key == "condition" else special_attribute_value_str
-                    await self.__select_button_combobox(cast(str, elem_id), button_combobox_value)
+                    button_values = [special_attribute_value_str]
+                    if normalized_special_attribute_key == "condition":
+                        button_values = list(dict.fromkeys((*condition_display_candidates, special_attribute_value_str)))
+
+                    last_timeout_error_button:TimeoutError | None = None
+                    for button_combobox_value in button_values:
+                        try:
+                            await self.__select_button_combobox(cast(str, elem_id), button_combobox_value)
+                            break
+                        except TimeoutError as ex:
+                            last_timeout_error_button = ex
+                    else:
+                        if last_timeout_error_button is not None:
+                            raise last_timeout_error_button
                 elif elem_role == "combobox" and elem_type in {"text", ""} and special_attr_elem.local_name == "input":
                     LOG.debug("Attribute field '%s' seems to be a Combobox (i.e. text input with filtering dropdown)...", special_attribute_key)
-                    selected_value = condition_display_value if normalized_special_attribute_key == "condition" else special_attribute_value_str
-                    await self.web_select_combobox(elem_selector_type, elem_selector_value, selected_value)
+                    selected_values = [special_attribute_value_str]
+                    if normalized_special_attribute_key == "condition":
+                        selected_values = list(dict.fromkeys((*condition_display_candidates, special_attribute_value_str)))
+
+                    last_timeout_error_input:TimeoutError | None = None
+                    for selected_value in selected_values:
+                        try:
+                            await self.web_select_combobox(elem_selector_type, elem_selector_value, selected_value)
+                            break
+                        except TimeoutError as ex:
+                            last_timeout_error_input = ex
+                    else:
+                        if last_timeout_error_input is not None:
+                            raise last_timeout_error_input
                 else:
                     LOG.debug("Attribute field '%s' seems to be a text input...", special_attribute_key)
                     await self.web_input(elem_selector_type, elem_selector_value, special_attribute_value_str)

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3054,11 +3054,13 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             return False
 
         # Kleinanzeigen changed dialog radio values from German tokens to English API codes
-        # (e.g. "wie_neu" -> "like_new", "sehr_gut" -> "like_new"). Try the configured value
-        # first (handles already-English configs), then fall back to the mapped equivalent.
-        candidate_values = [condition_value]
+        # (e.g. "wie_neu" -> "like_new", "sehr_gut" -> "like_new"). Prefer the mapped
+        # API value first for legacy configs, then fall back to the configured value if needed.
+        candidate_values:list[str] = []
         if mapped_value and mapped_value != condition_value:
             candidate_values.append(mapped_value)
+        if condition_value not in candidate_values:
+            candidate_values.append(condition_value)
 
         try:
             await condition_trigger.click()
@@ -3260,6 +3262,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     continue
 
                 LOG.info("Condition dialog not available, falling back to generic attribute handler for [%s]...", special_attribute_key)
+                special_attribute_value_str = _CONDITION_GERMAN_TO_API.get(special_attribute_value_str, special_attribute_value_str)
 
             LOG.debug("Setting special attribute [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
             id_suffix_literal = _xpath_literal(f".{normalized_special_attribute_key}")

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -64,6 +64,13 @@ _CONDITION_GERMAN_TO_API:Final[dict[str, str]] = {
     "defekt": "defect",
 }
 validate_condition_api_mapping("_CONDITION_GERMAN_TO_API", _CONDITION_GERMAN_TO_API)
+_CONDITION_API_TO_DISPLAY_CANDIDATES:Final[dict[str, tuple[str, ...]]] = {
+    "new": ("Neu",),
+    "like_new": ("Sehr Gut", "Wie neu"),
+    "ok": ("Gut",),
+    "alright": ("In Ordnung",),
+    "defect": ("Defekt",),
+}
 _LOGIN_DETECTION_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CLASS_NAME, "mr-medium"),
     (By.ID, "user-email"),
@@ -3315,10 +3322,25 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 elem_role = str(cast(Any, special_attr_elem.attrs.get("role")) or "").lower()
                 elem_selector_type = By.ID if elem_id else By.XPATH
                 elem_selector_value = elem_id or special_attr_xpath
+                condition_display_candidates = _CONDITION_API_TO_DISPLAY_CANDIDATES.get(special_attribute_value_str, (special_attribute_value_str,))
+                condition_display_value = condition_display_candidates[0]
 
                 if special_attr_elem.local_name == "select":
                     LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)
-                    await self.web_select(elem_selector_type, elem_selector_value, special_attribute_value_str)
+                    selected_values = [special_attribute_value_str]
+                    if normalized_special_attribute_key == "condition":
+                        selected_values = list(dict.fromkeys((*condition_display_candidates, special_attribute_value_str)))
+
+                    last_timeout_error:TimeoutError | None = None
+                    for selected_value in selected_values:
+                        try:
+                            await self.web_select(elem_selector_type, elem_selector_value, selected_value)
+                            break
+                        except TimeoutError as ex:
+                            last_timeout_error = ex
+                    else:
+                        if last_timeout_error is not None:
+                            raise last_timeout_error
                 elif elem_type == "checkbox":
                     LOG.debug("Attribute field '%s' seems to be a checkbox...", special_attribute_key)
                     truthy_values = {"1", "true", "yes", "on", "ja", "checked"}
@@ -3348,10 +3370,12 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 elif special_attr_elem.local_name == "button" and elem_role == "combobox":
                     LOG.debug("Attribute field '%s' seems to be a button combobox (click-to-open dropdown)...", special_attribute_key)
                     ensure(elem_id, f"No id available for button combobox special attribute [{special_attribute_key}]")
-                    await self.__select_button_combobox(cast(str, elem_id), special_attribute_value_str)
+                    button_combobox_value = condition_display_value if normalized_special_attribute_key == "condition" else special_attribute_value_str
+                    await self.__select_button_combobox(cast(str, elem_id), button_combobox_value)
                 elif elem_role == "combobox" and elem_type in {"text", ""} and special_attr_elem.local_name == "input":
                     LOG.debug("Attribute field '%s' seems to be a Combobox (i.e. text input with filtering dropdown)...", special_attribute_key)
-                    await self.web_select_combobox(elem_selector_type, elem_selector_value, special_attribute_value_str)
+                    selected_value = condition_display_value if normalized_special_attribute_key == "condition" else special_attribute_value_str
+                    await self.web_select_combobox(elem_selector_type, elem_selector_value, selected_value)
                 else:
                     LOG.debug("Attribute field '%s' seems to be a text input...", special_attribute_key)
                     await self.web_input(elem_selector_type, elem_selector_value, special_attribute_value_str)
@@ -3360,43 +3384,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key) from ex
             LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
 
-    # TODO: Issue #930 — migrate to web_select_button_combobox (display-text-based, no React fiber)
+    # Legacy wrapper kept for compatibility; prefer web_select_button_combobox (display-text-based, no React fiber).
     async def __select_button_combobox(self, elem_id:str, value:str) -> None:
-        """Select an option from a <button role="combobox"> dropdown by its API value.
-
-        Clicks the button to open the listbox, reads the options data from the React fiber
-        (which maps API values to display labels), and clicks the matching option.
-        """
-        await self.web_click(By.ID, elem_id)
-        listbox_id = f"{elem_id}-menu"
-        await self.web_find(By.ID, listbox_id)
-        js_btn_id = json.dumps(elem_id)
-        js_listbox_id = json.dumps(listbox_id)
-        js_value = json.dumps(value)
-        ok = await self.web_execute(f"""(function() {{
-            const listbox = document.getElementById({js_listbox_id});
-            if (!listbox) return false;
-            const liOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
-            const btnEl = document.getElementById({js_btn_id});
-            if (!btnEl) return false;
-            const fiberKey = Object.keys(btnEl).find(k => k.startsWith('__reactFiber'));
-            let fiber = fiberKey ? btnEl[fiberKey] : null;
-            for (let i = 0; i < 20 && fiber; i++, fiber = fiber.return) {{
-                if (fiber.memoizedProps && fiber.memoizedProps.options) {{
-                    const optionsData = fiber.memoizedProps.options;
-                    for (let j = 0; j < optionsData.length; j++) {{
-                        if (optionsData[j].value === {js_value} && liOptions[j]) {{
-                            liOptions[j].click();
-                            return true;
-                        }}
-                    }}
-                    return false;
-                }}
-            }}
-            return false;
-        }})()""")
-        if not ok:
-            raise TimeoutError(_("Option '%(value)s' not found in button combobox '%(id)s'") % {"value": value, "id": elem_id})
+        """Select an option from a ``<button role="combobox">`` dropdown by display text."""
+        await self.web_select_button_combobox(elem_id, value)
 
     async def __set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
         short_timeout = self._timeout("quick_dom")

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -42,6 +42,7 @@ _ELLIPSIS:Final[str] = "..."
 _ELLIPSIS_LEN:Final[int] = len(_ELLIPSIS)
 _CONDITION_DISPLAY_TO_API:Final[dict[str, str]] = {
     "neu": "new",
+    "wie neu": "like_new",
     "sehr gut": "like_new",
     "gut": "ok",
     "in ordnung": "alright",

--- a/src/kleinanzeigen_bot/model/ad_model.py
+++ b/src/kleinanzeigen_bot/model/ad_model.py
@@ -126,6 +126,18 @@ def validate_condition_api_mapping(mapping_name:str, mapping:Mapping[str, str]) 
         raise ValueError(f"{mapping_name} contains unsupported condition API values: {', '.join(sorted(unknown_values))}")
 
 
+def validate_condition_api_display_candidates(mapping_name:str, mapping:Mapping[str, tuple[str, ...]]) -> None:
+    unknown_keys = set(mapping) - CONDITION_API_VALUES
+    missing_keys = CONDITION_API_VALUES - set(mapping)
+    if unknown_keys or missing_keys:
+        problems:list[str] = []
+        if unknown_keys:
+            problems.append(f"unexpected condition API keys: {', '.join(sorted(unknown_keys))}")
+        if missing_keys:
+            problems.append(f"missing condition API keys: {', '.join(sorted(missing_keys))}")
+        raise ValueError(f"{mapping_name} has invalid condition API key set: {'; '.join(problems)}")
+
+
 def _validate_auto_price_reduction_constraints(price:int | None, auto_price_reduction:AutoPriceReductionConfig | dict[str, Any] | None) -> None:
     """
     Validate auto_price_reduction configuration constraints.

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -281,9 +281,6 @@ kleinanzeigen_bot/__init__.py:
   __check_ad_republication:
     " -> SKIPPED: ad [%s] was last published %d days ago. republication is only required every %s days": " -> ÜBERSPRUNGEN: Anzeige [%s] wurde zuletzt vor %d Tagen veröffentlicht. Erneute Veröffentlichung ist erst nach %s Tagen erforderlich"
 
-  __select_button_combobox:
-    "Option '%(value)s' not found in button combobox '%(id)s'": "Option '%(value)s' nicht in Button-Combobox '%(id)s' gefunden"
-
   __set_special_attributes:
     "Found %i special attributes": "%i spezielle Attribute gefunden"
     "Setting special attribute [%s] to [%s]...": "Setze spezielles Attribut [%s] auf [%s]..."

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -284,6 +284,10 @@ kleinanzeigen_bot/__init__.py:
   __set_special_attributes:
     "Found %i special attributes": "%i spezielle Attribute gefunden"
     "Setting special attribute [%s] to [%s]...": "Setze spezielles Attribut [%s] auf [%s]..."
+    "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"
+    "Condition dialog not available, falling back to generic attribute handler for [%s]...": "Zustandsdialog nicht verfügbar, falle auf generischen Attribut-Handler für [%s] zurück..."
+
+  __set_special_attribute_value:
     "Successfully set attribute field [%s] to [%s]...": "Attributfeld [%s] erfolgreich auf [%s] gesetzt..."
     "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"
     "Attribute field '%s' seems to be a select...": "Attributfeld '%s' scheint ein Auswahlfeld zu sein..."
@@ -291,7 +295,9 @@ kleinanzeigen_bot/__init__.py:
     "Attribute field '%s' seems to be a checkbox...": "Attributfeld '%s' scheint eine Checkbox zu sein..."
     "Attribute field '%s' seems to be a text input...": "Attributfeld '%s' scheint ein Texteingabefeld zu sein..."
     "Attribute field '%s' seems to be a Combobox (i.e. text input with filtering dropdown)...": "Attributfeld '%s' scheint eine Combobox zu sein (d.h. Texteingabefeld mit Dropdown-Filter)..."
-    "Condition dialog not available, falling back to generic attribute handler for [%s]...": "Zustandsdialog nicht verfügbar, falle auf generischen Attribut-Handler für [%s] zurück..."
+
+  __select_button_combobox:
+    "Option '%(value)s' not found in button combobox '%(id)s'": "Option '%(value)s' nicht in Button-Combobox '%(id)s' gefunden"
 
   download_ads:
     "Ads download directory: %s": "Anzeigen-Download-Verzeichnis: %s"

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1554,12 +1554,13 @@ class WebScrapingMixin:
         elem_id:str,
         selected_value:str,
         *,
+        click_trigger:bool = True,
         timeout:int | float | None = None,
     ) -> Element:
         """Select an option from a ``<button role="combobox">`` dropdown by display text.
 
-        Opens the dropdown by clicking the button, waits for the listbox
-        (``{elem_id}-menu``), and clicks the ``<li role="option">`` whose
+        Optionally clicks the button first, then waits for the listbox
+        (``{elem_id}-menu``) and clicks the ``<li role="option">`` whose
         normalized visible text matches *selected_value*.
 
         Matching is case-insensitive and collapses consecutive whitespace,
@@ -1581,7 +1582,8 @@ class WebScrapingMixin:
         if timeout is None:
             timeout = self._timeout("default")
 
-        await self.web_click(By.ID, elem_id, timeout = timeout)
+        if click_trigger:
+            await self.web_click(By.ID, elem_id, timeout = timeout)
         listbox_id = f"{elem_id}-menu"
         listbox = await self.web_find(By.ID, listbox_id, timeout = timeout)
 

--- a/tests/unit/test_ad_model.py
+++ b/tests/unit/test_ad_model.py
@@ -8,11 +8,13 @@ import math
 import pytest
 
 from kleinanzeigen_bot.model.ad_model import (
+    CONDITION_API_VALUES,
     MAX_DESCRIPTION_LENGTH,
     MAX_TITLE_LENGTH,
     MIN_TITLE_LENGTH,
     AdPartial,
     ShippingOption,
+    validate_condition_api_display_candidates,
     validate_condition_api_mapping,
 )
 from kleinanzeigen_bot.model.config_model import AdDefaults, AutoPriceReductionConfig
@@ -159,6 +161,27 @@ def test_shipping_option_must_not_be_blank() -> None:
 def test_validate_condition_api_mapping_rejects_unknown_values() -> None:
     with pytest.raises(ValueError, match = "contains unsupported condition API values: broken"):
         validate_condition_api_mapping("mapping_name", {"known": "new", "bad": "broken"})
+
+
+@pytest.mark.unit
+def test_validate_condition_api_display_candidates_rejects_unknown_or_missing_keys() -> None:
+    with pytest.raises(ValueError, match = "unexpected condition API keys: typo"):
+        validate_condition_api_display_candidates(
+            "display_candidates",
+            {"new": ("Neu",), "like_new": ("Sehr Gut",), "ok": ("Gut",), "alright": ("In Ordnung",), "defect": ("Defekt",), "typo": ("X",)},
+        )
+
+    with pytest.raises(ValueError, match = "missing condition API keys: like_new"):
+        validate_condition_api_display_candidates(
+            "display_candidates",
+            {"new": ("Neu",), "ok": ("Gut",), "alright": ("In Ordnung",), "defect": ("Defekt",)},
+        )
+
+
+@pytest.mark.unit
+def test_validate_condition_api_display_candidates_accepts_exact_key_set() -> None:
+    mapping = {key: (key,) for key in CONDITION_API_VALUES}
+    validate_condition_api_display_candidates("display_candidates", mapping)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -1207,19 +1207,33 @@ class TestAdExtractorCategory:
 
     @pytest.mark.asyncio
     # pylint: disable=protected-access
-    async def test_extract_special_attributes_from_dom_extracts_condition(self, extractor:extract_module.AdExtractor) -> None:
+    @pytest.mark.parametrize(
+        ("row_text", "value_text", "expected_api_value"),
+        [
+            ("Zustand Neu", "Neu", "new"),
+            ("Zustand Sehr gut", "Sehr gut", "like_new"),
+            ("Zustand Wie neu", "Wie neu", "like_new"),
+        ],
+    )
+    async def test_extract_special_attributes_from_dom_extracts_condition(
+        self,
+        extractor:extract_module.AdExtractor,
+        row_text:str,
+        value_text:str,
+        expected_api_value:str,
+    ) -> None:
         """DOM fallback should extract condition_s from #viewad-details section."""
         detail_item = MagicMock()
-        detail_item.text = "Zustand Neu"
+        detail_item.text = row_text
 
         async def text_side_effect(by:Any, selector:str, *, parent:Any = None, **__:Any) -> str:
             if parent is detail_item:
-                return "Neu"
+                return value_text
             return ""
 
         async def visible_text_side_effect(element:Any) -> str:
             if element is detail_item:
-                return "Zustand Neu"
+                return row_text
             return ""
 
         with (
@@ -1229,7 +1243,7 @@ class TestAdExtractorCategory:
         ):
             result = await extractor._extract_special_attributes_from_dom()
 
-        assert result == {"condition_s": "new"}
+        assert result == {"condition_s": expected_api_value}
 
     @pytest.mark.asyncio
     # pylint: disable=protected-access

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -1213,6 +1213,9 @@ class TestAdExtractorCategory:
             ("Zustand Neu", "Neu", "new"),
             ("Zustand Sehr gut", "Sehr gut", "like_new"),
             ("Zustand Wie neu", "Wie neu", "like_new"),
+            ("Zustand Gut", "Gut", "ok"),
+            ("Zustand In Ordnung", "In Ordnung", "alright"),
+            ("Zustand Defekt", "Defekt", "defect"),
         ],
     )
     async def test_extract_special_attributes_from_dom_extracts_condition(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3918,32 +3918,33 @@ class TestConditionFallbackToGenericHandler:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("condition_s", "expected_generic_value"),
+        ("condition_s", "expected_api_value"),
         [
             ("new", "new"),
             ("wie_neu", "like_new"),
         ],
     )
-    async def test_condition_falls_back_to_generic_handler_with_canonical_value(
+    async def test_condition_falls_back_to_generic_hidden_input_with_canonical_value(
         self,
         test_bot:KleinanzeigenBot,
         base_ad_config:dict[str, Any],
         condition_s:str,
-        expected_generic_value:str,
+        expected_api_value:str,
     ) -> None:
-        """Fallback should pass the canonical condition value to the generic combobox handler."""
+        """Fallback should normalize legacy condition values before setting the hidden input."""
         ad_cfg = Ad.model_validate(base_ad_config | {"category": "185/249", "special_attributes": {"condition_s": condition_s}, "shipping_type": "PICKUP"})
 
-        button_elem = MagicMock()
-        button_attrs = MagicMock()
-        button_attrs.get.side_effect = lambda key, default = None: {
-            "id": "modellbau.condition",
-            "type": "button",
-            "role": "combobox",
-            "name": None,
+        hidden_elem = MagicMock()
+        hidden_attrs = MagicMock()
+        hidden_attrs.id = None
+        hidden_attrs.get.side_effect = lambda key, default = None: {
+            "id": None,
+            "type": "hidden",
+            "role": None,
+            "name": "attributeMap[modellbau.condition]",
         }.get(key, default)
-        button_elem.attrs = button_attrs
-        button_elem.local_name = "button"
+        hidden_elem.attrs = hidden_attrs
+        hidden_elem.local_name = "input"
 
         with (
             patch.object(
@@ -3952,17 +3953,104 @@ class TestConditionFallbackToGenericHandler:
                 new_callable = AsyncMock,
                 return_value = False,
             ) as mock_set_condition,
-            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [button_elem]),
-            patch.object(
-                test_bot,
-                "_KleinanzeigenBot__select_button_combobox",
-                new_callable = AsyncMock,
-            ) as mock_select_combobox,
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [hidden_elem]),
+            patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 
         mock_set_condition.assert_awaited_once_with(condition_s)
-        mock_select_combobox.assert_awaited_once_with("modellbau.condition", expected_generic_value)
+        assert mock_input.await_args is not None
+        assert mock_input.await_args.args[0] == By.XPATH
+        assert "condition" in str(mock_input.await_args.args[1])
+        assert mock_input.await_args.args[2] == expected_api_value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "case",
+        [
+            ("web_select_combobox", "input", "text", "combobox", (By.ID, "modellbau.condition", "Sehr Gut")),
+            ("web_select_button_combobox", "button", "button", "combobox", ("modellbau.condition", "Sehr Gut")),
+        ],
+    )
+    async def test_condition_legacy_value_uses_display_label_for_visible_generic_controls(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        case:tuple[str, str, str, str | None, tuple[Any, ...]],
+    ) -> None:
+        """Visible condition controls should receive the canonical display label."""
+        helper_name, local_name, elem_type, elem_role, expected_args = case
+        ad_cfg = Ad.model_validate(base_ad_config | {"category": "185/249", "special_attributes": {"condition_s": "wie_neu"}, "shipping_type": "PICKUP"})
+
+        control_elem = MagicMock()
+        control_attrs = MagicMock()
+        control_attrs.id = "modellbau.condition"
+        control_attrs.get.side_effect = lambda key, default = None: {
+            "id": "modellbau.condition",
+            "name": None,
+            "type": elem_type,
+            "role": elem_role,
+        }.get(key, default)
+        control_elem.attrs = control_attrs
+        control_elem.local_name = local_name
+
+        with (
+            patch.object(
+                test_bot,
+                "_KleinanzeigenBot__set_condition",
+                new_callable = AsyncMock,
+                return_value = False,
+            ) as mock_set_condition,
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [control_elem]),
+            patch.object(test_bot, helper_name, new_callable = AsyncMock) as mock_helper,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+
+        mock_set_condition.assert_awaited_once_with("wie_neu")
+        mock_helper.assert_awaited_once_with(*expected_args)
+
+    @pytest.mark.asyncio
+    async def test_condition_legacy_value_retries_select_with_api_value_when_display_label_misses(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Select controls should fall back from the visible condition label to the API value."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"category": "185/249", "special_attributes": {"condition_s": "wie_neu"}, "shipping_type": "PICKUP"})
+
+        control_elem = MagicMock()
+        control_attrs = MagicMock()
+        control_attrs.id = "modellbau.condition"
+        control_attrs.get.side_effect = lambda key, default = None: {
+            "id": "modellbau.condition",
+            "name": None,
+            "type": "select",
+            "role": None,
+        }.get(key, default)
+        control_elem.attrs = control_attrs
+        control_elem.local_name = "select"
+
+        selected_values:list[str] = []
+
+        async def web_select_side_effect(selector_type:By, selector_value:str, selected_value:str | int, **__:Any) -> None:
+            selected_values.append(str(selected_value))
+            if selected_value == "Sehr Gut":
+                raise TimeoutError("visible label missing")
+
+        with (
+            patch.object(
+                test_bot,
+                "_KleinanzeigenBot__set_condition",
+                new_callable = AsyncMock,
+                return_value = False,
+            ) as mock_set_condition,
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [control_elem]),
+            patch.object(test_bot, "web_select", new_callable = AsyncMock, side_effect = web_select_side_effect),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+
+        mock_set_condition.assert_awaited_once_with("wie_neu")
+        assert selected_values == ["Sehr Gut", "Wie neu"]
 
     @pytest.mark.asyncio
     async def test_condition_timeout_propagates_instead_of_falling_back(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -296,6 +296,7 @@ class TestKleinanzeigenBotInitialization:
         config_file = tmp_path / "config.yaml"
         test_bot.workspace = xdg_paths.Workspace.for_config(config_file, "kleinanzeigen-bot")
         test_bot.config_file_path = str(config_file)
+        test_bot.config.download.dir = "./ads"
         test_bot.ads_selector = "all"
         test_bot.browser = MagicMock()
 
@@ -314,7 +315,7 @@ class TestKleinanzeigenBotInitialization:
         mock_extractor.assert_called_once_with(
             test_bot.browser,
             test_bot.config,
-            test_bot.workspace.download_dir,
+            (tmp_path / "ads").resolve(),
             published_ads_by_id = {123: mock_published_ads[0], 456: mock_published_ads[1]},
         )
 
@@ -343,27 +344,6 @@ class TestKleinanzeigenBotInitialization:
         test_bot.config.download.dir = str((tmp_path / "absolute-target").resolve())
 
         assert test_bot._resolve_download_dir() == (tmp_path / "absolute-target").resolve()
-
-    @pytest.mark.asyncio
-    async def test_download_ads_uses_configured_relative_download_dir(self, test_bot:KleinanzeigenBot, tmp_path:Path) -> None:
-        config_file = tmp_path / "config.yaml"
-        test_bot.workspace = xdg_paths.Workspace.for_config(config_file, "kleinanzeigen-bot")
-        test_bot.config_file_path = str(config_file)
-        test_bot.config.download.dir = "./ads"
-        test_bot.ads_selector = "all"
-        test_bot.browser = MagicMock()
-
-        extractor_mock = MagicMock()
-        extractor_mock.extract_own_ads_urls = AsyncMock(return_value = [])
-
-        with (
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = []),
-            patch("kleinanzeigen_bot.extract.AdExtractor", return_value = extractor_mock) as mock_extractor,
-        ):
-            await test_bot.download_ads()
-
-        mock_extractor.assert_called_once()
-        assert mock_extractor.call_args.args[2] == (tmp_path / "ads").resolve()
 
     @pytest.mark.parametrize(
         ("published_ads_by_id", "ad_id", "expected_active", "expected_owned"),
@@ -3922,6 +3902,10 @@ class TestConditionFallbackToGenericHandler:
         [
             ("new", "new"),
             ("wie_neu", "like_new"),
+            ("sehr_gut", "like_new"),
+            ("gut", "ok"),
+            ("in_ordnung", "alright"),
+            ("defekt", "defect"),
         ],
     )
     async def test_condition_falls_back_to_generic_hidden_input_with_canonical_value(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -4010,6 +4010,60 @@ class TestConditionFallbackToGenericHandler:
         mock_helper.assert_awaited_once_with(*expected_args)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("helper_name", "local_name", "elem_type", "elem_role"),
+        [
+            ("web_select_combobox", "input", "text", "combobox"),
+            ("web_select_button_combobox", "button", "button", "combobox"),
+        ],
+    )
+    async def test_condition_legacy_value_retries_visible_generic_controls_with_second_label(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        helper_name:str,
+        local_name:str,
+        elem_type:str,
+        elem_role:str | None,
+    ) -> None:
+        """Visible condition controls should retry the second live label when the first one is missing."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"category": "185/249", "special_attributes": {"condition_s": "wie_neu"}, "shipping_type": "PICKUP"})
+
+        control_elem = MagicMock()
+        control_attrs = MagicMock()
+        control_attrs.id = "modellbau.condition"
+        control_attrs.get.side_effect = lambda key, default = None: {
+            "id": "modellbau.condition",
+            "name": None,
+            "type": elem_type,
+            "role": elem_role,
+        }.get(key, default)
+        control_elem.attrs = control_attrs
+        control_elem.local_name = local_name
+
+        selected_values:list[str] = []
+
+        async def helper_side_effect(*args:Any, **__:Any) -> None:
+            selected_values.append(str(args[-1]))
+            if args[-1] == "Sehr Gut":
+                raise TimeoutError("first label missing")
+
+        with (
+            patch.object(
+                test_bot,
+                "_KleinanzeigenBot__set_condition",
+                new_callable = AsyncMock,
+                return_value = False,
+            ) as mock_set_condition,
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [control_elem]),
+            patch.object(test_bot, helper_name, new_callable = AsyncMock, side_effect = helper_side_effect),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+
+        mock_set_condition.assert_awaited_once_with("wie_neu")
+        assert selected_values == ["Sehr Gut", "Wie neu"]
+
+    @pytest.mark.asyncio
     async def test_condition_legacy_value_retries_select_with_api_value_when_display_label_misses(
         self,
         test_bot:KleinanzeigenBot,
@@ -4034,7 +4088,7 @@ class TestConditionFallbackToGenericHandler:
 
         async def web_select_side_effect(selector_type:By, selector_value:str, selected_value:str | int, **__:Any) -> None:
             selected_values.append(str(selected_value))
-            if selected_value == "Sehr Gut":
+            if selected_value in {"Sehr Gut", "Wie neu"}:
                 raise TimeoutError("visible label missing")
 
         with (
@@ -4050,7 +4104,7 @@ class TestConditionFallbackToGenericHandler:
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 
         mock_set_condition.assert_awaited_once_with("wie_neu")
-        assert selected_values == ["Sehr Gut", "Wie neu"]
+        assert selected_values == ["Sehr Gut", "Wie neu", "like_new"]
 
     @pytest.mark.asyncio
     async def test_condition_timeout_propagates_instead_of_falling_back(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3543,6 +3543,23 @@ class TestKleinanzeigenBotShippingOptions:
         mock_input.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_button_combobox_helper_matches_api_value_for_generic_attributes(self, test_bot:KleinanzeigenBot) -> None:
+        """Generic button comboboxes should still resolve by API value."""
+        listbox = MagicMock()
+        listbox.apply = AsyncMock(return_value = True)
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = listbox),
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = True) as mock_execute,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__select_button_combobox")("kleidung_herren.color", "beige")
+
+        assert mock_execute.await_args is not None
+        assert "beige" in str(mock_execute.await_args.args[0])
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("combobox_type", ["text", None], ids = ["type-text", "type-absent"])
     async def test_special_attributes_combobox_routed_over_hidden_input(
         self,
@@ -3953,7 +3970,6 @@ class TestConditionFallbackToGenericHandler:
         "case",
         [
             ("web_select_combobox", "input", "text", "combobox", (By.ID, "modellbau.condition", "Sehr Gut")),
-            ("web_select_button_combobox", "button", "button", "combobox", ("modellbau.condition", "Sehr Gut")),
         ],
     )
     async def test_condition_legacy_value_uses_display_label_for_visible_generic_controls(
@@ -4040,12 +4056,17 @@ class TestConditionFallbackToGenericHandler:
                 return_value = False,
             ) as mock_set_condition,
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [control_elem]),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, helper_name, new_callable = AsyncMock, side_effect = helper_side_effect),
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 
         mock_set_condition.assert_awaited_once_with("wie_neu")
         assert selected_values == ["Sehr Gut", "Wie neu"]
+        if helper_name == "web_select_button_combobox":
+            mock_click.assert_awaited_once_with(By.ID, "modellbau.condition")
+        else:
+            mock_click.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_condition_legacy_value_retries_select_with_api_value_when_display_label_misses(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -151,15 +151,15 @@ def _login_detection_result(is_logged_in:bool, reason:LoginDetectionReason) -> L
 class TestKleinanzeigenBotInitialization:
     """Tests for KleinanzeigenBot initialization and basic functionality."""
 
-    def test_constructor_initializes_default_values(self, test_bot:KleinanzeigenBot) -> None:
+    def test_constructor_initializes_default_values(self) -> None:
         """Verify that constructor sets all default values correctly."""
-        assert test_bot.root_url == "https://www.kleinanzeigen.de"
-        assert isinstance(test_bot.config, Config)
-        assert test_bot.command == "help"
-        assert test_bot.ads_selector == "due"
-        assert test_bot.keep_old_ads is False
-        assert test_bot.log_file_path is not None
-        assert test_bot.file_log is None
+        bot = KleinanzeigenBot()
+        assert bot.root_url == "https://www.kleinanzeigen.de"
+        assert bot.command == "help"
+        assert bot.ads_selector == "due"
+        assert bot.keep_old_ads is False
+        assert bot.log_file_path is not None
+        assert bot.file_log is None
 
     @pytest.mark.parametrize("command", ["help", "create-config", "version"])
     def test_resolve_workspace_skips_non_workspace_commands(self, test_bot:KleinanzeigenBot, command:str) -> None:
@@ -2148,17 +2148,6 @@ class TestKleinanzeigenBotBasics:
         ):
             await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
 
-    def test_get_root_url(self, test_bot:KleinanzeigenBot) -> None:
-        """Test root URL retrieval."""
-        assert test_bot.root_url == "https://www.kleinanzeigen.de"
-
-    def test_get_config_defaults(self, test_bot:KleinanzeigenBot) -> None:
-        """Test default configuration values."""
-        assert isinstance(test_bot.config, Config)
-        assert test_bot.command == "help"
-        assert test_bot.ads_selector == "due"
-        assert test_bot.keep_old_ads is False
-
     def test_get_log_level(self, test_bot:KleinanzeigenBot) -> None:
         """Test log level configuration."""
         # Reset log level to default
@@ -3755,12 +3744,11 @@ class TestConditionSelector:
             if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
                 return trigger
             if selector_type == By.XPATH and "@type='radio'" in selector_value:
-                if f"@value='{configured}'" in selector_value:
-                    probed_values.append(configured)
-                    # German token is no longer a valid DOM value — mimic that by returning None
-                    return None if configured != expected_api_value else radio
                 if f"@value='{expected_api_value}'" in selector_value:
                     probed_values.append(expected_api_value)
+                    return radio
+                if f"@value='{configured}'" in selector_value:
+                    probed_values.append(configured)
                     return radio
             return None
 
@@ -3777,13 +3765,62 @@ class TestConditionSelector:
             assert len(warning_messages) == 1
             assert configured in warning_messages[0]
             assert expected_api_value in warning_messages[0]
-            # Legacy German values should probe the configured token first, then the mapped API code.
-            assert probed_values == [configured, expected_api_value]
+            # Legacy German values should prefer the mapped API code and stop once it is found.
+            assert probed_values == [expected_api_value]
         else:
             assert warning_messages == []
             assert probed_values == [configured]
         clicked_xpath_selectors = [str(call.args[1]) for call in mock_click.await_args_list if len(call.args) > 1]
         assert any(f"radio-condition-{expected_api_value}" in selector for selector in clicked_xpath_selectors)
+
+    @pytest.mark.asyncio
+    async def test_condition_legacy_value_falls_back_when_mapped_value_is_missing(
+        self,
+        test_bot:KleinanzeigenBot,
+        caplog:pytest.LogCaptureFixture,
+    ) -> None:
+        """Legacy values should still work if the mapped API radio is unavailable."""
+        caplog.set_level(logging.WARNING, logger = LOG.name)
+        dialog = MagicMock()
+        trigger = MagicMock()
+        trigger.attrs = {"id": "condition-trigger", "aria-controls": "condition-dialog"}
+        trigger.click = AsyncMock()
+        radio = MagicMock()
+        radio_attrs = MagicMock()
+        radio_attrs.id = "radio-condition-wie_neu"
+        radio_attrs.get.side_effect = lambda key, default = None: "radio-condition-wie_neu" if key == "id" else default
+        radio.attrs = radio_attrs
+        radio.click = AsyncMock()
+
+        probed_values:list[str] = []
+
+        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+            if selector_type == By.XPATH and "contains(@for, '.condition')" in selector_value:
+                return trigger
+            if selector_type == By.XPATH and "@type='radio'" in selector_value:
+                if "@value='like_new'" in selector_value:
+                    probed_values.append("like_new")
+                    return None
+                if "@value='wie_neu'" in selector_value:
+                    probed_values.append("wie_neu")
+                    return radio
+            return None
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("wie_neu")
+
+        assert handled is True
+        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+        assert len(warning_messages) == 1
+        assert "wie_neu" in warning_messages[0]
+        assert "like_new" in warning_messages[0]
+        assert probed_values == ["like_new", "wie_neu"]
+        clicked_xpath_selectors = [str(call.args[1]) for call in mock_click.await_args_list if len(call.args) > 1]
+        assert any("radio-condition-wie_neu" in selector for selector in clicked_xpath_selectors)
 
     @pytest.mark.asyncio
     async def test_condition_missing_selector_returns_not_handled(self, test_bot:KleinanzeigenBot) -> None:
@@ -3880,9 +3917,22 @@ class TestConditionFallbackToGenericHandler:
     """
 
     @pytest.mark.asyncio
-    async def test_condition_falls_back_to_generic_handler_when_dialog_not_handled(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
-        """When condition dialog is not handled, generic handler should be used as fallback."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"category": "185/249", "special_attributes": {"condition_s": "new"}, "shipping_type": "PICKUP"})
+    @pytest.mark.parametrize(
+        ("condition_s", "expected_generic_value"),
+        [
+            ("new", "new"),
+            ("wie_neu", "like_new"),
+        ],
+    )
+    async def test_condition_falls_back_to_generic_handler_with_canonical_value(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        condition_s:str,
+        expected_generic_value:str,
+    ) -> None:
+        """Fallback should pass the canonical condition value to the generic combobox handler."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"category": "185/249", "special_attributes": {"condition_s": condition_s}, "shipping_type": "PICKUP"})
 
         button_elem = MagicMock()
         button_attrs = MagicMock()
@@ -3911,8 +3961,8 @@ class TestConditionFallbackToGenericHandler:
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 
-        mock_set_condition.assert_awaited_once_with("new")
-        mock_select_combobox.assert_awaited_once_with("modellbau.condition", "new")
+        mock_set_condition.assert_awaited_once_with(condition_s)
+        mock_select_combobox.assert_awaited_once_with("modellbau.condition", expected_generic_value)
 
     @pytest.mark.asyncio
     async def test_condition_timeout_propagates_instead_of_falling_back(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -2795,6 +2795,23 @@ class TestWebSelectButtonCombobox:
         assert json.dumps("Nur Abholung") in js_arg
 
     @pytest.mark.asyncio
+    async def test_web_select_button_combobox_can_skip_clicking_open_button(self, web_scraper:WebScrapingMixin) -> None:
+        """When the combobox is already open, the helper should not click the trigger again."""
+        listbox = AsyncMock(spec = Element)
+        listbox.apply = AsyncMock(return_value = True)
+
+        web_scraper.web_click = AsyncMock()  # type: ignore[method-assign]
+        web_scraper.web_find = AsyncMock(return_value = listbox)  # type: ignore[method-assign]
+        web_scraper.web_sleep = AsyncMock()  # type: ignore[method-assign]
+
+        result = await web_scraper.web_select_button_combobox("test-combo", "Nur Abholung", click_trigger = False)
+
+        assert result is listbox
+        web_scraper.web_click.assert_not_awaited()
+        web_scraper.web_find.assert_awaited_once_with(By.ID, "test-combo-menu", timeout = ANY)
+        web_scraper.web_sleep.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_web_select_button_combobox_raises_when_no_matching_option(self, web_scraper:WebScrapingMixin) -> None:
         """Error path: raises TimeoutError when no matching option is found."""
         listbox = AsyncMock(spec = Element)


### PR DESCRIPTION
## ℹ️ Description
*Fix legacy `condition_s` handling so mapped API values are preferred without changing fallback compatibility.*

- Link to the related issue(s): Issue #1002, Issue #1023
- Description: legacy German condition values were still incurring unnecessary probe latency; this change normalizes the publish flow and keeps the generic fallback path aligned.

## 📋 Changes Summary
- Prefer mapped API condition values first for legacy dialog probes.
- Normalize legacy `condition_s` values before generic combobox fallback handling.
- Consolidate duplicate constructor-default and condition fallback tests into tighter regression coverage.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Condition selection now prefers canonical API codes, probes ordered display-label candidates (then raw value), retries on transient failures, and falls back to legacy tokens when needed
  * German condition labels (e.g., "wie neu") are normalized so extracted and selectable values align with API conventions
  * Checkbox inputs preserve state with normalized truthy/falsy handling to avoid unnecessary toggles

* **Behavior**
  * Unified handling for various input types so condition-specific retry and fallback apply consistently
  * Button-combobox selection can skip the trigger click when not required

* **Tests**
  * Expanded, parameterized tests covering condition variants, probe order, retry behavior, missing-mapped-control regression, and download-directory wiring adjustments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->