### PR TITLE
fix: streamline download selector handling

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -51,6 +51,7 @@ validate_condition_api_mapping("_CONDITION_DISPLAY_TO_API", _CONDITION_DISPLAY_T
 _LABEL_TO_KEY:Final[dict[str, str]] = {
     "zustand": "condition_s",
 }
+DOWNLOAD_CREATION_DATE_SELECTOR:Final[str] = "#viewad-extra-info > div:nth-child(1) > span:nth-child(2)"
 
 
 def _is_retryable_rmtree_error(error:BaseException) -> bool:
@@ -365,7 +366,9 @@ class AdExtractor(WebScrapingMixin):
         img_paths = []
         try:
             # download all images from box
-            image_box = await self.web_find(By.CLASS_NAME, "galleryimage-large")
+            image_box = await self.web_probe(By.CLASS_NAME, "galleryimage-large")
+            if image_box is None:
+                raise TimeoutError("No image area found.")
 
             images = await self.web_find_all(By.CSS_SELECTOR, ".galleryimage-element[data-ix] > img", parent = image_box)
             n_images = len(images)
@@ -502,14 +505,11 @@ class AdExtractor(WebScrapingMixin):
             return False
 
         # close (warning) popup, if given
-        try:
-            await self.web_find(By.ID, "vap-ovrly-secure")
+        popup = await self.web_probe(By.ID, "vap-ovrly-secure")
+        if popup is not None:
             LOG.warning("A popup appeared!")
             await self.web_click(By.CLASS_NAME, "mfp-close")
             await self.web_sleep()
-        except TimeoutError:
-            # Popup did not appear within timeout.
-            pass
         return True
 
     async def _extract_title_from_ad_page(self) -> str:
@@ -585,10 +585,7 @@ class AdExtractor(WebScrapingMixin):
         info["contact"] = await self._extract_contact_from_ad_page()
         info["id"] = ad_id
 
-        try:  # try different locations known for creation date element
-            creation_date = await self.web_text(By.XPATH, "/html/body/div[1]/div[2]/div/section[2]/section/section/article/div[3]/div[2]/div[2]/div[1]/span")
-        except TimeoutError:
-            creation_date = await self.web_text(By.CSS_SELECTOR, "#viewad-extra-info > div:nth-child(1) > span:nth-child(2)")
+        creation_date = await self.web_text(By.CSS_SELECTOR, DOWNLOAD_CREATION_DATE_SELECTOR)
 
         # convert creation date to ISO format
         created_parts = creation_date.split(".")
@@ -912,10 +909,11 @@ class AdExtractor(WebScrapingMixin):
         contact:dict[str, (str | None)] = {}
         address_text = await self.web_text(By.ID, "viewad-locality")
         # format: e.g. (Beispiel Allee 42,) 12345 Bundesland - Stadt
-        try:
-            street = (await self.web_text(By.ID, "street-address"))[:-1]  # trailing comma
+        street_element = await self.web_probe(By.ID, "street-address")
+        if street_element is not None:
+            street = (await self._extract_visible_text(street_element))[:-1]  # trailing comma
             contact["street"] = street
-        except TimeoutError:
+        else:
             LOG.info("No street given in the contact.")
 
         (zipcode, location) = address_text.split(" ", maxsplit = 1)
@@ -932,11 +930,11 @@ class AdExtractor(WebScrapingMixin):
 
         if "street" not in contact:
             contact["street"] = None
-        try:  # phone number is unusual for non-professional sellers today
-            phone_element = await self.web_find(By.ID, "viewad-contact-phone")
+        phone_element = await self.web_probe(By.ID, "viewad-contact-phone")
+        if phone_element is not None:
             phone_number = await self.web_text(By.TAG_NAME, "a", parent = phone_element)
             contact["phone"] = "".join(phone_number.replace("-", " ").split(" ")).replace("+49(0)", "0")
-        except TimeoutError:
+        else:
             contact["phone"] = None  # phone seems to be a deprecated feature (for non-professional users)
         # also see 'https://themen.kleinanzeigen.de/hilfe/deine-anzeigen/Telefon/
 

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -911,8 +911,12 @@ class AdExtractor(WebScrapingMixin):
         # format: e.g. (Beispiel Allee 42,) 12345 Bundesland - Stadt
         street_element = await self.web_probe(By.ID, "street-address")
         if street_element is not None:
-            street = (await self._extract_visible_text(street_element))[:-1]  # trailing comma
-            contact["street"] = street
+            try:
+                street = (await self._extract_visible_text(street_element))[:-1]  # trailing comma
+            except TimeoutError:
+                LOG.debug("Skipping street extraction after timeout.")
+            else:
+                contact["street"] = street
         else:
             LOG.info("No street given in the contact.")
 
@@ -932,8 +936,13 @@ class AdExtractor(WebScrapingMixin):
             contact["street"] = None
         phone_element = await self.web_probe(By.ID, "viewad-contact-phone")
         if phone_element is not None:
-            phone_number = await self.web_text(By.TAG_NAME, "a", parent = phone_element)
-            contact["phone"] = "".join(phone_number.replace("-", " ").split(" ")).replace("+49(0)", "0")
+            try:
+                phone_number = await self.web_text(By.TAG_NAME, "a", parent = phone_element)
+            except TimeoutError:
+                LOG.debug("Skipping phone extraction after timeout.")
+                contact["phone"] = None
+            else:
+                contact["phone"] = "".join(phone_number.replace("-", " ").split(" ")).replace("+49(0)", "0")
         else:
             contact["phone"] = None  # phone seems to be a deprecated feature (for non-professional users)
         # also see 'https://themen.kleinanzeigen.de/hilfe/deine-anzeigen/Telefon/

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -441,7 +441,7 @@ class TestAdExtractorNavigation:
         with (
             patch.object(test_extractor, "page", page_mock),
             patch.object(test_extractor, "web_open", new_callable = AsyncMock) as mock_web_open,
-            patch.object(test_extractor, "web_find", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_extractor, "web_probe", new_callable = AsyncMock, return_value = None),
         ):
             result = await test_extractor.navigate_to_ad_page("https://www.kleinanzeigen.de/s-anzeige/test/12345")
             assert result is True
@@ -466,6 +466,7 @@ class TestAdExtractorNavigation:
         with (
             patch.object(test_extractor, "page", page_mock),
             patch.object(test_extractor, "web_open", new_callable = AsyncMock) as mock_web_open,
+            patch.object(test_extractor, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_extractor, "web_find", new_callable = AsyncMock, side_effect = find_mock),
         ):
             result = await test_extractor.navigate_to_ad_page(ad_id)
@@ -487,6 +488,7 @@ class TestAdExtractorNavigation:
         with (
             patch.object(test_extractor, "page", page_mock),
             patch.object(test_extractor, "web_open", new_callable = AsyncMock),
+            patch.object(test_extractor, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_extractor, "web_find", new_callable = AsyncMock, return_value = input_mock),
             patch.object(test_extractor, "web_click", new_callable = AsyncMock) as mock_web_click,
             patch.object(test_extractor, "web_check", new_callable = AsyncMock, return_value = True),
@@ -888,6 +890,7 @@ class TestAdExtractorContent:
                         "03.02.2025",  # Creation date
                     ]
                 ),
+                web_probe = AsyncMock(return_value = None),
                 web_execute = AsyncMock(return_value = {"universalAnalyticsOpts": {"dimensions": {"l3_category_id": "", "ad_attributes": ""}}}),
                 _extract_category_from_ad_page = AsyncMock(return_value = "160"),
                 _extract_special_attributes_from_ad_page = AsyncMock(return_value = {}),
@@ -922,6 +925,7 @@ class TestAdExtractorContent:
                         "03.02.2025",  # Date succeeds (not reached)
                     ]
                 ),
+                web_probe = AsyncMock(return_value = None),
                 web_execute = AsyncMock(return_value = {"universalAnalyticsOpts": {"dimensions": {"l3_category_id": "", "ad_attributes": ""}}}),
                 _extract_category_from_ad_page = AsyncMock(return_value = "160"),
                 _extract_special_attributes_from_ad_page = AsyncMock(return_value = {}),
@@ -957,6 +961,7 @@ class TestAdExtractorContent:
                     "03.02.2025",  # Creation date
                 ]
             ),
+            web_probe = AsyncMock(return_value = None),
             web_execute = AsyncMock(return_value = {"universalAnalyticsOpts": {"dimensions": {"l3_category_id": "", "ad_attributes": ""}}}),
             _extract_category_from_ad_page = AsyncMock(return_value = "160"),
             _extract_special_attributes_from_ad_page = AsyncMock(return_value = {}),
@@ -968,6 +973,42 @@ class TestAdExtractorContent:
         ):
             ad_cfg, _staging_dir, _final_dir, _ad_file_stem = await test_extractor._extract_ad_page_info_with_directory_handling(base_dir, 12345)
             assert ad_cfg.description == raw_description
+
+    @pytest.mark.asyncio
+    async def test_extract_ad_page_info_uses_css_selector_for_creation_date(
+        self,
+        test_extractor:extract_module.AdExtractor,
+        tmp_path:Path,
+    ) -> None:
+        """Test creation-date extraction uses the CSS selector directly."""
+        base_dir = tmp_path / "downloaded-ads"
+        base_dir.mkdir()
+
+        page_mock = MagicMock()
+        page_mock.url = "https://www.kleinanzeigen.de/s-anzeige/test/12345"
+        test_extractor.page = page_mock
+
+        with (
+            patch.object(test_extractor, "web_text", new_callable = AsyncMock) as mock_web_text,
+            patch.multiple(
+                test_extractor,
+                web_execute = AsyncMock(return_value = {"universalAnalyticsOpts": {"dimensions": {"l3_category_id": "", "ad_attributes": ""}}}),
+                _extract_category_from_ad_page = AsyncMock(return_value = "160"),
+                _extract_special_attributes_from_ad_page = AsyncMock(return_value = {}),
+                _extract_pricing_info_from_ad_page = AsyncMock(return_value = (None, "NOT_APPLICABLE")),
+                _extract_shipping_info_from_ad_page = AsyncMock(return_value = ("NOT_APPLICABLE", None, None)),
+                _extract_sell_directly_from_ad_page = AsyncMock(return_value = False),
+                _download_images_from_ad_page = AsyncMock(return_value = []),
+                _extract_contact_from_ad_page = AsyncMock(return_value = ContactPartial()),
+            ),
+            patch.object(test_extractor, "web_probe", new_callable = AsyncMock, return_value = None),
+        ):
+            mock_web_text.side_effect = ["Test Title", "Test Title", "Description text", "03.02.2025"]
+            ad_cfg, _staging_dir, _final_dir, _ad_file_stem = await test_extractor._extract_ad_page_info_with_directory_handling(base_dir, 12345)
+
+        mock_web_text.assert_any_await(By.CSS_SELECTOR, extract_module.DOWNLOAD_CREATION_DATE_SELECTOR)
+        assert ad_cfg.created_on is not None
+        assert ad_cfg.created_on.isoformat().startswith("2025-02-03")
 
     @pytest.mark.asyncio
     async def test_extract_sell_directly_data_hit_true(self, test_extractor:extract_module.AdExtractor) -> None:
@@ -1342,21 +1383,30 @@ class TestAdExtractorContact:
     # pylint: disable=protected-access
     async def test_extract_contact_info(self, extractor:extract_module.AdExtractor) -> None:
         """Test extraction of contact information."""
+        street_element = MagicMock()
+        contact_person_element = MagicMock()
+        name_element = MagicMock()
+
+        async def visible_text_side_effect(element:Any) -> str:
+            if element is street_element:
+                return "Example Street 123,"
+            return ""
+
         with (
             patch.object(extractor, "page", MagicMock()),
             patch.object(extractor, "web_text", new_callable = AsyncMock) as mock_web_text,
             patch.object(extractor, "web_find", new_callable = AsyncMock) as mock_web_find,
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, side_effect = [street_element, None]),
+            patch.object(extractor, "_extract_visible_text", new_callable = AsyncMock, side_effect = visible_text_side_effect),
         ):
             mock_web_text.side_effect = [
                 "12345 Berlin - Mitte",
-                "Example Street 123,",
                 "Test User",
             ]
 
             mock_web_find.side_effect = [
-                MagicMock(),  # contact person element
-                MagicMock(),  # name element
-                TimeoutError(),  # phone element (simulating no phone)
+                contact_person_element,
+                name_element,
             ]
 
             contact_info = await extractor._extract_contact_from_ad_page()
@@ -1382,18 +1432,21 @@ class TestAdExtractorContact:
     # pylint: disable=protected-access
     async def test_extract_contact_info_with_phone(self, extractor:extract_module.AdExtractor) -> None:
         """Test extraction of contact information including phone number."""
+        contact_person_element = MagicMock()
+        name_element = MagicMock()
+        phone_element = MagicMock()
+
         with (
             patch.object(extractor, "page", MagicMock()),
             patch.object(extractor, "web_text", new_callable = AsyncMock) as mock_web_text,
             patch.object(extractor, "web_find", new_callable = AsyncMock) as mock_web_find,
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, side_effect = [None, phone_element]),
         ):
-            mock_web_text.side_effect = ["12345 Berlin - Mitte", "Example Street 123,", "Test User", "+49(0)1234 567890"]
+            mock_web_text.side_effect = ["12345 Berlin - Mitte", "Test User", "+49(0)1234 567890"]
 
-            phone_element = MagicMock()
             mock_web_find.side_effect = [
-                MagicMock(),  # contact person element
-                MagicMock(),  # name element
-                phone_element,  # phone element
+                contact_person_element,
+                name_element,
             ]
 
             contact_info = await extractor._extract_contact_from_ad_page()
@@ -1500,7 +1553,7 @@ class TestAdExtractorDownload:
     # pylint: disable=protected-access
     async def test_download_images_no_images(self, extractor:extract_module.AdExtractor) -> None:
         """Test image download when no images are found."""
-        with patch.object(extractor, "web_find", new_callable = AsyncMock, side_effect = TimeoutError):
+        with patch.object(extractor, "web_probe", new_callable = AsyncMock, return_value = None):
             image_paths = await extractor._download_images_from_ad_page("/some/dir", "ad_12345")
             assert len(image_paths) == 0
 
@@ -1518,7 +1571,7 @@ class TestAdExtractorDownload:
         img_without_url.attrs = {"src": None}
 
         with (
-            patch.object(extractor, "web_find", new_callable = AsyncMock, return_value = image_box_mock),
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, return_value = image_box_mock),
             patch.object(extractor, "web_find_all", new_callable = AsyncMock, return_value = [img_with_url, img_without_url]),
             patch.object(extract_module.AdExtractor, "_download_and_save_image_sync", return_value = "/some/dir/ad_12345__img1.jpg"),
         ):
@@ -1558,6 +1611,7 @@ class TestAdExtractorDownload:
                     "03.02.2025",  # Creation date
                 ],
             ),
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(
                 extractor,
                 "web_execute",
@@ -1622,6 +1676,7 @@ class TestAdExtractorDownload:
                     "03.02.2025",  # Creation date
                 ],
             ),
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(
                 extractor,
                 "web_execute",
@@ -1689,6 +1744,7 @@ class TestAdExtractorDownload:
                     "03.02.2025",  # Creation date
                 ],
             ),
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(
                 extractor,
                 "web_execute",
@@ -1753,6 +1809,7 @@ class TestAdExtractorDownload:
                     "03.02.2025",  # Creation date
                 ],
             ),
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(
                 extractor,
                 "web_execute",
@@ -2651,7 +2708,7 @@ class TestAdExtractorDownload:
         img_with_url.attrs = {"src": "http://example.com/valid_image.jpg"}
 
         with (
-            patch.object(extractor, "web_find", new_callable = AsyncMock, return_value = image_box_mock),
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, return_value = image_box_mock),
             patch.object(extractor, "web_find_all", new_callable = AsyncMock, return_value = [img_with_url]),
             patch.object(extract_module.AdExtractor, "_download_and_save_image_sync", return_value = "/some/dir/listing_12345__img1.jpg"),
         ):

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -454,25 +454,16 @@ class TestAdExtractorNavigation:
         page_mock = AsyncMock()
         page_mock.url = "https://www.kleinanzeigen.de/s-anzeige/test/{0}".format(ad_id)
 
-        popup_close_mock = AsyncMock()
-        popup_close_mock.click = AsyncMock()
-        popup_close_mock.apply = AsyncMock(return_value = True)
-
-        def find_mock(selector_type:By, selector_value:str, **_:Any) -> Element | None:
-            if selector_type == By.CLASS_NAME and selector_value == "mfp-close":
-                return popup_close_mock
-            return None
-
         with (
             patch.object(test_extractor, "page", page_mock),
             patch.object(test_extractor, "web_open", new_callable = AsyncMock) as mock_web_open,
             patch.object(test_extractor, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_extractor, "web_find", new_callable = AsyncMock, side_effect = find_mock),
+            patch.object(test_extractor, "web_click", new_callable = AsyncMock) as mock_web_click,
         ):
             result = await test_extractor.navigate_to_ad_page(ad_id)
             assert result is True
             mock_web_open.assert_called_with("https://www.kleinanzeigen.de/s-suchanfrage.html?keywords={0}".format(ad_id))
-            popup_close_mock.click.assert_awaited_once()
+            mock_web_click.assert_awaited_once_with(By.CLASS_NAME, "mfp-close")
 
     @pytest.mark.asyncio
     async def test_navigate_to_ad_page_with_popup(self, test_extractor:extract_module.AdExtractor) -> None:
@@ -1427,6 +1418,55 @@ class TestAdExtractorContact:
             pytest.raises(TimeoutError),
         ):
             await extractor._extract_contact_from_ad_page()
+
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    async def test_extract_contact_info_with_street_timeout(self, extractor:extract_module.AdExtractor) -> None:
+        """Test street extraction timeout does not abort contact extraction."""
+        contact_person_element = MagicMock()
+        name_element = MagicMock()
+        street_element = MagicMock()
+
+        with (
+            patch.object(extractor, "page", MagicMock()),
+            patch.object(extractor, "web_text", new_callable = AsyncMock) as mock_web_text,
+            patch.object(extractor, "web_find", new_callable = AsyncMock) as mock_web_find,
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, side_effect = [street_element, None]),
+            patch.object(extractor, "_extract_visible_text", new_callable = AsyncMock, side_effect = TimeoutError()),
+        ):
+            mock_web_text.side_effect = ["12345 Berlin - Mitte", "Test User"]
+            mock_web_find.side_effect = [contact_person_element, name_element]
+
+            contact_info = await extractor._extract_contact_from_ad_page()
+            assert contact_info.street is None
+            assert contact_info.zipcode == "12345"
+            assert contact_info.location == "Berlin - Mitte"
+            assert contact_info.name == "Test User"
+            assert contact_info.phone is None
+
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    async def test_extract_contact_info_with_phone_timeout(self, extractor:extract_module.AdExtractor) -> None:
+        """Test phone extraction timeout does not abort contact extraction."""
+        contact_person_element = MagicMock()
+        name_element = MagicMock()
+        phone_element = MagicMock()
+
+        with (
+            patch.object(extractor, "page", MagicMock()),
+            patch.object(extractor, "web_text", new_callable = AsyncMock) as mock_web_text,
+            patch.object(extractor, "web_find", new_callable = AsyncMock) as mock_web_find,
+            patch.object(extractor, "web_probe", new_callable = AsyncMock, side_effect = [None, phone_element]),
+        ):
+            mock_web_text.side_effect = ["12345 Berlin - Mitte", "Test User", TimeoutError()]
+            mock_web_find.side_effect = [contact_person_element, name_element]
+
+            contact_info = await extractor._extract_contact_from_ad_page()
+            assert contact_info.street is None
+            assert contact_info.zipcode == "12345"
+            assert contact_info.location == "Berlin - Mitte"
+            assert contact_info.name == "Test User"
+            assert contact_info.phone is None
 
     @pytest.mark.asyncio
     # pylint: disable=protected-access


### PR DESCRIPTION
## ℹ️ Description
- Link to the related issue(s): N/A
- Reduce long-wait DOM lookups in the download flow while keeping optional selectors handled safely.

## 📋 Changes Summary
- Use probe-style lookups for optional download-flow elements and keep the gallery selector on the probe path.
- Centralize the creation-date selector constant and update the corresponding extraction test.
- Refresh unit coverage for the updated download extraction behavior.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Increased reliability of ad metadata extraction, including creation dates and contact details.
  * Enhanced error handling and messaging when ad images are unavailable.
  * Streamlined ad navigation popup handling.

* **Tests**
  * Added test coverage for creation date extraction validation.
  * Updated tests to verify improved ad data extraction robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Second-Hand-Friends/kleinanzeigen-bot/pull/1042)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->