### PR TITLE
fix: compare preview release notes against latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -488,21 +488,28 @@ jobs:
         # We reuse the moving "latest"/"preview" tags for releases. GitHub's generate-notes compares
         # tag_name -> previous_tag_name. If we pass the moving tag as tag_name before it moves, the
         # comparison is old -> old (empty notes). We avoid this by using a fake tag_name (not created)
-        # and anchoring previous_tag_name to the current moving tag. This yields old -> new notes
-        # without creating or pushing any tags (important: pushes can be blocked for workflow files).
+        # and anchoring previous_tag_name to the prior release tag. Preview releases compare against
+        # the last stable "latest" release so their changelog shows stable -> preview changes.
+        # This yields old -> new notes without creating or pushing any tags (important: pushes can
+        # be blocked for workflow files).
         if ! gh release view "$RELEASE_NAME" --json tagName --jq '.tagName' >/dev/null 2>&1; then
           echo "ERROR: Failed to query existing '$RELEASE_NAME' release; cannot generate release notes." >&2
           exit 1
         fi
 
+        PREVIOUS_TAG_NAME="$RELEASE_NAME"
+        if [[ "$RELEASE_NAME" == "preview" ]]; then
+          PREVIOUS_TAG_NAME="latest"
+        fi
+
         NOTES_TAG="${RELEASE_NAME}-notes-${GITHUB_RUN_ID}"
-        echo "Generating notes: tag_name=${NOTES_TAG}, previous_tag_name=${RELEASE_NAME}, target_commitish=${GITHUB_SHA}"
+        echo "Generating notes: tag_name=${NOTES_TAG}, previous_tag_name=${PREVIOUS_TAG_NAME}, target_commitish=${GITHUB_SHA}"
 
         # Prefer GitHub's generate-notes API so we get PR links and @mentions
         gh api -X POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
           -f tag_name="$NOTES_TAG" \
           -f target_commitish="$GITHUB_SHA" \
-          -f previous_tag_name="$RELEASE_NAME" \
+          -f previous_tag_name="$PREVIOUS_TAG_NAME" \
           --jq '.body' > release-notes.md
 
         if ! grep -q '[^[:space:]]' release-notes.md; then


### PR DESCRIPTION
## ℹ️ Description
*Ensure preview releases generate changelog notes against the last stable latest release instead of the previous preview release.*

- Link to the related issue(s): N/A
- Describe the motivation and context for this change.

## 📋 Changes Summary

- Adjust release note generation in the publish workflow.
- Preview releases now set `previous_tag_name=latest` when calling GitHub release notes generation.
- Verified with a local `gh api` dry-run that preview notes include concrete changelog entries.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

Dry-run verification:
- `gh api .../releases/generate-notes` with `previous_tag_name=latest` returned concrete preview changelog entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release notes generation to correctly reference the appropriate previous release version based on release type (latest vs. preview).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Second-Hand-Friends/kleinanzeigen-bot/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->