### PR TITLE
refactor: centralize condition normalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,7 @@ select = [
   "PYI",   # flake8-pyi
   "Q",     # flake8-quotes
   "RET",   # flake8-return
+  "PLW0717",  # Try clause contains too many statements
   "RSE",   # flake8-raise
   "S",     # flake8-bandit
   "SIM",   # flake8-simplify
@@ -246,6 +247,7 @@ ignore = [
   "FIX002",  # Line contains TODO, consider resolving the issue
   "PERF203",  # `try`-`except` within a loop incurs performance overhead
   "RET504",  # Unnecessary assignment to `...` before `return` statement
+  "PLW0717",  # Try clause contains too many statements
   "PLR6301",  # Method `...` could be a function, class method, or static method
   "PLR0913",  # Too many arguments in function definition (needed to match parent signature)
   "PYI041",  # Use `float` instead of `int | float`

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -67,6 +67,14 @@ validate_condition_api_mapping("_CONDITION_GERMAN_TO_API", _CONDITION_GERMAN_TO_
 
 
 def _normalize_condition(condition_value:str) -> tuple[str, str | None]:
+    """Return the normalized condition value and legacy input.
+
+    Returns ``(canonical_value, legacy_value)`` where ``canonical_value`` is the
+    API form from ``_CONDITION_GERMAN_TO_API`` and ``legacy_value`` is the original
+    input only when a mapping was applied, otherwise ``None``. Unmapped inputs are
+    returned unchanged. Example: ``neu`` -> ``("new", "neu")``; ``new`` ->
+    ``("new", None)``.
+    """
     canonical_value = _CONDITION_GERMAN_TO_API.get(condition_value, condition_value)
     if canonical_value != condition_value:
         return canonical_value, condition_value

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -64,6 +64,15 @@ _CONDITION_GERMAN_TO_API:Final[dict[str, str]] = {
     "defekt": "defect",
 }
 validate_condition_api_mapping("_CONDITION_GERMAN_TO_API", _CONDITION_GERMAN_TO_API)
+
+
+def _normalize_condition(condition_value:str) -> tuple[str, str | None]:
+    canonical_value = _CONDITION_GERMAN_TO_API.get(condition_value, condition_value)
+    if canonical_value != condition_value:
+        return canonical_value, condition_value
+    return condition_value, None
+
+
 _LOGIN_DETECTION_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CLASS_NAME, "mr-medium"),
     (By.ID, "user-email"),
@@ -3026,9 +3035,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         Returns True when dialog handling succeeded, otherwise False to indicate
         that caller should use generic special-attribute handling.
         """
-        mapped_value = _CONDITION_GERMAN_TO_API.get(condition_value)
-        if mapped_value and mapped_value != condition_value:
-            LOG.warning("Condition value [%s] is deprecated; update your config to [%s].", condition_value, mapped_value)
+        canonical_value, legacy_value = _normalize_condition(condition_value)
+        if legacy_value is not None:
+            LOG.warning("Condition value [%s] is deprecated; update your config to [%s].", legacy_value, canonical_value)
 
         short_timeout = self._timeout("quick_dom")
         condition_trigger_xpath = "//label[contains(@for, '.condition')]/following::button[@aria-haspopup='dialog' or @aria-haspopup='true'][1]"
@@ -3056,11 +3065,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # Kleinanzeigen changed dialog radio values from German tokens to English API codes
         # (e.g. "wie_neu" -> "like_new", "sehr_gut" -> "like_new"). Prefer the mapped
         # API value first for legacy configs, then fall back to the configured value if needed.
-        candidate_values:list[str] = []
-        if mapped_value and mapped_value != condition_value:
-            candidate_values.append(mapped_value)
-        if condition_value not in candidate_values:
-            candidate_values.append(condition_value)
+        candidate_values:list[str] = [canonical_value]
+        if legacy_value is not None:
+            candidate_values.append(legacy_value)
 
         try:
             await condition_trigger.click()
@@ -3262,7 +3269,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     continue
 
                 LOG.info("Condition dialog not available, falling back to generic attribute handler for [%s]...", special_attribute_key)
-                special_attribute_value_str = _CONDITION_GERMAN_TO_API.get(special_attribute_value_str, special_attribute_value_str)
+                special_attribute_value_str = _normalize_condition(special_attribute_value_str)[0]
 
             LOG.debug("Setting special attribute [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
             id_suffix_literal = _xpath_literal(f".{normalized_special_attribute_key}")

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3971,21 +3971,6 @@ class TestConditionFallbackToGenericHandler:
         mock_find_all.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_condition_uses_dialog_when_available(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
-        """When condition dialog works, it should be used without falling back."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"category": "161/176", "special_attributes": {"condition_s": "ok"}})
-
-        with patch.object(
-            test_bot,
-            "_KleinanzeigenBot__set_condition",
-            new_callable = AsyncMock,
-            return_value = True,
-        ) as mock_set_condition:
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
-
-        mock_set_condition.assert_awaited_once_with("ok")
-
-    @pytest.mark.asyncio
     async def test_condition_s_missing_control_logs_warning_and_continues(
         self,
         test_bot:KleinanzeigenBot,


### PR DESCRIPTION
## ℹ️ Description
* Centralize `condition_s` normalization before dialog-specific handling.

- Link to the related issue(s): Fix #1023
- Describe the motivation and context for this change.

## 📋 Changes Summary

- Added a shared `_normalize_condition()` helper and reused it in both condition code paths.
- Preserved legacy warning behavior and canonical-first radio probing with legacy fallback.
- Removed a redundant snapshot-style unit test and updated lint configuration for existing PLW0717 noise.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Normalized item condition handling and added deprecation warnings for legacy condition formats; fallbacks now prefer canonical condition codes.

* **Bug Fixes**
  * Probe/lookup timeouts during condition handling now propagate instead of being silently skipped.

* **Tests**
  * Removed an outdated condition-dialog test and added tests verifying missing-control warning behavior and timeout propagation.

* **Chores**
  * Updated linting configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Second-Hand-Friends/kleinanzeigen-bot/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->