### PR TITLE
fix(publish): accept readonly <input> for ad-city (zip-derived value)

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2900,7 +2900,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # value, accept it instead of trying (and failing) to open a combobox.
         if city_tag == "input" and "readonly" in city_attrs and selected_city:
             LOG.info(
-                _("ad-city is a <input readonly> with value '%s' (zip-derived) - accepting instead of combobox selection."),
+                "ad-city is a <input readonly> with value '%s' (zip-derived) - accepting instead of combobox selection.",
                 selected_city,
             )
             return

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2900,7 +2900,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # value, accept it instead of trying (and failing) to open a combobox.
         if city_tag == "input" and "readonly" in city_attrs and selected_city:
             LOG.info(
-                _("ad-city is a <input readonly> with value '%s' (zip-derived) — accepting instead of combobox selection."),
+                _("ad-city is a <input readonly> with value '%s' (zip-derived) - accepting instead of combobox selection."),
                 selected_city,
             )
             return

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2891,7 +2891,20 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if city_element is None:
             raise TimeoutError(_("Unsupported city element type while setting contact location: <%s>") % "missing")
         city_tag = city_element.local_name
-        city_role = str(city_element.attrs.get("role") or "").casefold()
+        city_attrs = getattr(city_element, "attrs", {}) or {}
+        city_role = str(city_attrs.get("role") or "").casefold()
+
+        # kleinanzeigen.de switched the city field to a read-only <input> whose
+        # value is derived from the entered zip code; it is no longer a
+        # selectable combobox. When the page already prefilled a non-empty
+        # value, accept it instead of trying (and failing) to open a combobox.
+        if city_tag == "input" and "readonly" in city_attrs and selected_city:
+            LOG.info(
+                "ad-city is a <input readonly> with value '%s' (zip-derived) — accepting instead of combobox selection.",
+                selected_city,
+            )
+            return
+
         if city_tag != "button" or city_role != "combobox":
             raise TimeoutError(_("Unsupported city element type while setting contact location: <%s>") % city_tag)
 

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2900,7 +2900,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # value, accept it instead of trying (and failing) to open a combobox.
         if city_tag == "input" and "readonly" in city_attrs and selected_city:
             LOG.info(
-                "ad-city is a <input readonly> with value '%s' (zip-derived) — accepting instead of combobox selection.",
+                _("ad-city is a <input readonly> with value '%s' (zip-derived) — accepting instead of combobox selection."),
                 selected_city,
             )
             return

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -265,6 +265,7 @@ kleinanzeigen_bot/__init__.py:
 
   __set_contact_location:
     "Unsupported city element type while setting contact location: <%s>": "Nicht unterstützter Stadt-Elementtyp beim Setzen des Kontaktorts: <%s>"
+    "ad-city is a <input readonly> with value '%s' (zip-derived) — accepting instead of combobox selection.": "ad-city ist ein <input readonly> mit Wert '%s' (aus PLZ abgeleitet) — übernehme statt Combobox-Auswahl."
 
   __upload_images:
     " -> found %s": "-> %s gefunden"

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -265,7 +265,7 @@ kleinanzeigen_bot/__init__.py:
 
   __set_contact_location:
     "Unsupported city element type while setting contact location: <%s>": "Nicht unterstützter Stadt-Elementtyp beim Setzen des Kontaktorts: <%s>"
-    "ad-city is a <input readonly> with value '%s' (zip-derived) — accepting instead of combobox selection.": "ad-city ist ein <input readonly> mit Wert '%s' (aus PLZ abgeleitet) — übernehme statt Combobox-Auswahl."
+    "ad-city is a <input readonly> with value '%s' (zip-derived) - accepting instead of combobox selection.": "ad-city ist ein <input readonly> mit Wert '%s' (aus PLZ abgeleitet) - übernehme statt Combobox-Auswahl."
 
   __upload_images:
     " -> found %s": "-> %s gefunden"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2594,6 +2594,21 @@ class TestKleinanzeigenBotContactLocationHardening:
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_contact_location")("10115 - Metroville")
 
+    @pytest.mark.asyncio
+    async def test_set_contact_location_accepts_readonly_input_with_zip_derived_value(self, test_bot:KleinanzeigenBot) -> None:
+        """When ad-city is a readonly <input> with a non-empty prefilled value (zip-derived), accept it."""
+        city_input = MagicMock(spec = Element)
+        city_input.local_name = "input"
+        city_input.attrs = {"readonly": "", "value": "Metroville - Riverside"}
+
+        with (
+            patch.object(test_bot, "_KleinanzeigenBot__read_city_selection_text", new_callable = AsyncMock, return_value = "Metroville - Riverside"),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = city_input),
+            patch.object(test_bot, "_KleinanzeigenBot__select_city_combobox_option", new_callable = AsyncMock) as combobox_mock,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_contact_location")("Metroville")
+            combobox_mock.assert_not_called()
+
 
 class TestKleinanzeigenBotArgParsing:
     """Tests for command line argument parsing."""


### PR DESCRIPTION
## Summary

kleinanzeigen.de migrated the contact-location city field from a `<button role=\"combobox\">` with selectable options to a read-only `<input>` whose value is derived from the entered zip code. The bot currently raises `Unsupported city element type: <input>` and fails publish/update for every ad with a contact location.

When the page presents a readonly `<input>` with a non-empty prefilled value (the zip-derived city), this PR accepts that value instead of attempting the now-removed combobox flow.

## Reproduction

Production form, PLZ `81545`:

\`\`\`html
<input id=\"ad-city\" readonly=\"\" value=\"München - Untergiesing-Harlaching\">
\`\`\`

Before this PR: every publish attempt fails with
\`Unsupported city element type while setting contact location: <input>\`

After this PR: bot logs
\`ad-city is a <input readonly> with value 'München - Untergiesing-Harlaching' (zip-derived) — accepting instead of combobox selection.\`
and continues the publish flow to success.

## Test plan

- [x] New unit test \`test_set_contact_location_accepts_readonly_input_with_zip_derived_value\` covering the readonly `<input>` path; asserts the combobox helper is NOT invoked
- [x] Existing \`__set_contact_location\` tests still pass
- [x] End-to-end \`publish --ads=new\` against live kleinanzeigen.de succeeds (ad ID 3420177898)

## Notes

The fix is conservative: it only short-circuits when *all three* hold — element is `<input>`, has the `readonly` attribute, and \`__read_city_selection_text\` returned a non-empty value. Falls back to the existing combobox path otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The bot now correctly recognizes readonly, pre-filled city fields (for example, values derived from ZIP) and accepts them, skipping unnecessary combobox selection and reducing incorrect interaction attempts.

* **Tests**
  * Added a unit test that verifies readonly, pre-filled city inputs are accepted and that combobox interaction is not attempted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Second-Hand-Friends/kleinanzeigen-bot/pull/1059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->