### PR TITLE
feat: resolve login credentials from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,21 @@ login:
   password: "your_password"
 ```
 
+To avoid storing credentials in the config file, use environment variable substitution:
+
+```yaml
+login:
+  username: "${KLEINANZEIGEN_BOT_USERNAME}"
+  password: "${KLEINANZEIGEN_BOT_PASSWORD}"
+```
+
+```bash
+export KLEINANZEIGEN_BOT_USERNAME=your@email.com
+export KLEINANZEIGEN_BOT_PASSWORD=your_password
+```
+
+Plain-text values in config.yaml are still fully supported.
+
 📖 **[Complete Configuration Reference →](docs/CONFIGURATION.md)**
 
 Full documentation including timeout tuning, browser settings, ad defaults, diagnostics, and all available options.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -50,6 +50,13 @@ login:
 #   shipping_type: SHIPPING
 #   republication_interval: 7
 ```
+> **To keep credentials out of config.yaml**, replace values with environment variable references:
+> ```yaml
+> login:
+>   username: "${KLEINANZEIGEN_BOT_USERNAME}"
+>   password: "${KLEINANZEIGEN_BOT_PASSWORD}"
+> ```
+> Then set them in your environment: `export KLEINANZEIGEN_BOT_USERNAME=...`
 
 Run `kleinanzeigen-bot create-config` to generate a complete configuration with all available options and their default values.
 
@@ -324,11 +331,11 @@ Login credentials.
 
 ```yaml
 login:
-  username: ""
-  password: ""
+  username: "${KLEINANZEIGEN_BOT_USERNAME}"
+  password: "${KLEINANZEIGEN_BOT_PASSWORD}"
 ```
 
-> **Security Note:** Never commit your credentials to version control. Keep your `config.yaml` secure and exclude it from git if it contains sensitive information.
+> **Security Note:** Never commit your credentials to version control. Use environment variables (`${KLEINANZEIGEN_BOT_USERNAME}`, `${KLEINANZEIGEN_BOT_PASSWORD}`) to keep credentials out of `config.yaml`. Plain-text values without `${}` are still supported for local-only use.
 
 ### diagnostics
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -50,13 +50,23 @@ login:
 #   shipping_type: SHIPPING
 #   republication_interval: 7
 ```
-> **To keep credentials out of config.yaml**, replace values with environment variable references:
+>
+> **To keep credentials out of config.yaml**, use environment variable references instead of plain text:
+>
 > ```yaml
 > login:
 >   username: "${KLEINANZEIGEN_BOT_USERNAME}"
 >   password: "${KLEINANZEIGEN_BOT_PASSWORD}"
 > ```
-> Then set them in your environment: `export KLEINANZEIGEN_BOT_USERNAME=...`
+>
+> Then set both variables in your environment:
+>
+> ```bash
+> export KLEINANZEIGEN_BOT_USERNAME=your@email.com
+> export KLEINANZEIGEN_BOT_PASSWORD=your_password
+> ```
+>
+> Never commit plaintext credentials to version control — environment variable references make your `config.yaml` safe to share.
 
 Run `kleinanzeigen-bot create-config` to generate a complete configuration with all available options and their default values.
 

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -47,6 +47,7 @@ LOG.setLevel(loggers.INFO)
 SUBMISSION_MAX_RETRIES:Final[int] = 3
 _NUMERIC_IDS_RE:Final[re.Pattern[str]] = re.compile(r"^\d+(,\d+)*$")
 _SPECIAL_ATTRIBUTE_TOKEN_RE:Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_]+$")
+_LOGIN_ENV_PATTERN:Final[re.Pattern[str]] = re.compile(r"^\$\{(?P<var>\w+)(?::-(?P<default>.*))?\}$")
 # See issue #930 for migrating __select_button_combobox to web_select_button_combobox
 _WANTED_SHIPPING_LABELS:Final[dict[str, str]] = {
     "SHIPPING": "Versand möglich",
@@ -1257,6 +1258,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             self.create_default_config()
 
         config_yaml = dicts.load_dict_if_exists(self.config_file_path, _("config"))
+        if isinstance(config_yaml, dict):
+            self._resolve_login_credentials(config_yaml)
         self.config = Config.model_validate(config_yaml, strict = True, context = self.config_file_path)
 
         timing_enabled = self.config.diagnostics.timing_collection
@@ -1292,6 +1295,47 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         elif self.workspace:
             self.browser_config.user_data_dir = str(self.workspace.browser_profile_dir)
         self.browser_config.profile_name = self.config.browser.profile_name
+
+    @staticmethod
+    def _resolve_login_credentials(config_yaml:dict[str, Any]) -> None:
+        """Resolve ``login.username`` and ``login.password`` from environment variables.
+
+        Supports two patterns:
+        - ``${VAR}`` : required — raises if VAR is unset
+        - ``${VAR:-default}`` : optional — uses *default* when VAR is unset
+
+        Non-placeholder values are left unchanged.
+
+        Note:
+            Mutates *config_yaml* in place. Caller must ensure *config_yaml* is a
+            dict before calling — the method is a no-op on non-dict values.
+        """
+        if not isinstance(config_yaml, dict):
+            return
+
+        login = config_yaml.get("login")
+        if not isinstance(login, dict):
+            return
+
+        for field in ("username", "password"):
+            value = login.get(field)
+            if not isinstance(value, str):
+                continue
+
+            m = _LOGIN_ENV_PATTERN.match(value)
+            if not m:
+                continue
+
+            var_name = m.group("var")
+            resolved = os.environ.get(var_name)
+            if resolved is not None:
+                login[field] = resolved
+            elif m.group("default") is not None:
+                login[field] = m.group("default")
+            else:
+                raise ValueError(
+                    _("Environment variable %s is required for login.%s but is not set") % (var_name, field)
+                )
 
     def __check_ad_republication(self, ad_cfg:Ad, ad_file_relative:str) -> bool:
         """

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -75,6 +75,9 @@ kleinanzeigen_bot/__init__.py:
     "Loaded %s categories in total": "%s Kategorien insgesamt geladen"
     "No categories loaded - category files may be missing or empty": "Keine Kategorien geladen - Kategorie-Dateien fehlen oder sind leer"
 
+  _resolve_login_credentials:
+    "Environment variable %s is required for login.%s but is not set": "Umgebungsvariable %s ist für login.%s erforderlich, ist aber nicht gesetzt"
+
   check_and_wait_for_captcha:
     "# Captcha present! Please solve the captcha.": "# Captcha vorhanden! Bitte lösen Sie das Captcha."
     "Captcha recognized - auto-restart enabled, abort run...": "Captcha erkannt - Auto-Neustart aktiviert, Durchlauf wird beendet..."

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -797,6 +797,7 @@ class TestKleinanzeigenBotInitialization:
         assert config_path.exists()
         content = config_path.read_text()
         assert "username: changeme" in content
+        assert "password: changeme" in content
 
 
 class TestKleinanzeigenBotLogging:
@@ -912,8 +913,10 @@ class TestKleinanzeigenBotCommandLine:
 class TestKleinanzeigenBotConfiguration:
     """Tests for configuration loading and validation."""
 
-    def test_load_config_handles_missing_file(self, test_bot:KleinanzeigenBot, test_data_dir:str) -> None:
+    def test_load_config_handles_missing_file(self, test_bot:KleinanzeigenBot, test_data_dir:str, monkeypatch:pytest.MonkeyPatch) -> None:
         """Verify that loading a missing config file creates default config. No info log is expected anymore."""
+        monkeypatch.setenv("KLEINANZEIGEN_BOT_USERNAME", "dummy_user")
+        monkeypatch.setenv("KLEINANZEIGEN_BOT_PASSWORD", "dummy_pass")
         config_path = Path(test_data_dir) / "missing_config.yaml"
         config_path.unlink(missing_ok = True)
         test_bot.config_file_path = str(config_path)
@@ -936,6 +939,128 @@ login:
             test_bot.load_config()
         assert "login.username" not in str(exc_info.value)
         assert "login.password" in str(exc_info.value)
+
+
+class TestResolveLoginCredentials:
+    """Tests for _resolve_login_credentials env var resolution."""
+    # ruff: noqa: S105 test strings are not real passwords
+
+    def test_resolves_var_from_environment(self, monkeypatch:pytest.MonkeyPatch) -> None:
+        """${VAR} is replaced by the env var value."""
+        monkeypatch.setenv("TEST_BOT_USER", "resolved_user")
+        monkeypatch.setenv("TEST_BOT_PASS", "resolved_pass")
+        config:dict[str, Any] = {
+            "login": {
+                "username": "${TEST_BOT_USER}",
+                "password": "${TEST_BOT_PASS}",
+            },
+        }
+        KleinanzeigenBot._resolve_login_credentials(config)
+        assert config["login"]["username"] == "resolved_user"
+        assert config["login"]["password"] == "resolved_pass"
+
+    def test_uses_fallback_when_var_unset(self, monkeypatch:pytest.MonkeyPatch) -> None:
+        """${VAR:-default} uses the default when VAR is not set."""
+        monkeypatch.delenv("OPTIONAL_USER", raising = False)
+        monkeypatch.delenv("OPTIONAL_PASS", raising = False)
+        config:dict[str, Any] = {
+            "login": {
+                "username": "${OPTIONAL_USER:-fallback_user}",
+                "password": "${OPTIONAL_PASS:-fallback_pass}",
+            },
+        }
+        KleinanzeigenBot._resolve_login_credentials(config)
+        assert config["login"]["username"] == "fallback_user"
+        assert config["login"]["password"] == "fallback_pass"
+
+    def test_raises_value_error_when_required_var_unset(self, monkeypatch:pytest.MonkeyPatch) -> None:
+        """${VAR} raises ValueError when VAR is not set and no default."""
+        monkeypatch.delenv("MUST_HAVE_USER", raising = False)
+        config:dict[str, Any] = {
+            "login": {
+                "username": "${MUST_HAVE_USER}",
+                "password": "${MUST_HAVE_PASS}",
+            },
+        }
+        with pytest.raises(ValueError, match = "Environment variable MUST_HAVE_USER is required for login"):
+            KleinanzeigenBot._resolve_login_credentials(config)
+
+    def test_leaves_plain_text_values_unchanged(self) -> None:
+        """Non-placeholder values are not modified."""
+        config:dict[str, Any] = {
+            "login": {
+                "username": "real_user",
+                "password": "real_pass",
+            },
+        }
+        KleinanzeigenBot._resolve_login_credentials(config)
+        assert config["login"]["username"] == "real_user"
+        assert config["login"]["password"] == "real_pass"
+
+    def test_handles_missing_login_key(self) -> None:
+        """Missing 'login' key does nothing."""
+        config:dict[str, Any] = {}
+        KleinanzeigenBot._resolve_login_credentials(config)
+        assert "login" not in config
+
+    def test_handles_login_as_non_dict(self) -> None:
+        """Login being a non-dict (e.g. str) does nothing."""
+        config:dict[str, Any] = {"login": "some_string"}
+        KleinanzeigenBot._resolve_login_credentials(config)
+        assert config["login"] == "some_string"
+
+    def test_handles_non_string_field_values(self) -> None:
+        """Non-string values like None or int are left untouched."""
+        config:dict[str, Any] = {
+            "login": {
+                "username": None,
+                "password": 12345,
+            },
+        }
+        KleinanzeigenBot._resolve_login_credentials(config)
+        assert config["login"]["username"] is None
+        assert config["login"]["password"] == 12345
+
+    def test_resolves_only_username_and_password(self, monkeypatch:pytest.MonkeyPatch) -> None:
+        """Arbitrary login fields (like api_key) are NOT resolved."""
+        monkeypatch.setenv("USER", "user1")
+        monkeypatch.setenv("PASS", "pass1")
+        monkeypatch.setenv("API_KEY", "secret123")
+        config:dict[str, Any] = {
+            "login": {
+                "username": "${USER}",
+                "password": "${PASS}",
+                "api_key": "${API_KEY}",
+            },
+        }
+        KleinanzeigenBot._resolve_login_credentials(config)
+        assert config["login"]["username"] == "user1"
+        assert config["login"]["password"] == "pass1"
+        assert config["login"]["api_key"] == "${API_KEY}"  # unchanged
+
+    def test_load_config_resolves_env_vars_in_login(self, test_bot:KleinanzeigenBot, tmp_path:Path, monkeypatch:pytest.MonkeyPatch) -> None:
+        """load_config resolves ${VAR} placeholders from environment into the Config object."""
+        monkeypatch.setenv("BOT_USERNAME", "env_user")
+        monkeypatch.setenv("BOT_PASSWORD", "env_pass")
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("""
+login:
+  username: ${BOT_USERNAME}
+  password: ${BOT_PASSWORD}
+ad_defaults:
+  contact:
+    name: Test User
+    zipcode: "12345"
+publishing:
+  delete_old_ads: BEFORE_PUBLISH
+  delete_old_ads_by_title: false
+""")
+        test_bot.config_file_path = str(config_path)
+        test_bot.load_config()
+
+        assert test_bot.config.login.username == "env_user"
+        assert test_bot.config.login.password == "env_pass"
 
 
 class TestKleinanzeigenBotAuthentication:


### PR DESCRIPTION
## ℹ️ Description

Adds support for `${KLEINANZEIGEN_BOT_USERNAME}` and `${KLEINANZEIGEN_BOT_PASSWORD}` environment variable substitution in `login.username` and `login.password` config values. Also supports `${VAR:-default}` fallback syntax.

This allows users to commit `config.yaml` to VCS without exposing credentials.

Closes #1060.

## 📋 Changes Summary

- New `_resolve_login_credentials()` static method on `KleinanzeigenBot` — resolves `${VAR}` and `${VAR:-default}` patterns from `os.environ` for `login.username` and `login.password` only
- Called in `load_config()` after YAML loading, before Pydantic validation — `LoginConfig` model remains unchanged (`Field(..., min_length=1)`)
- Module-level `_LOGIN_ENV_PATTERN` regex for the `${VAR}` / `${VAR:-default}` pattern
- Guard against non-dict YAML input (passes through to Pydantic for clean validation errors)
- Updated `README.md` and `docs/CONFIGURATION.md` with env var examples
- Removed obsolete "Config file not found" translation (no longer raised)
- 9 new unit tests in `TestResolveLoginCredentials` covering resolution, fallback, error cases, edge cases, and `load_config` integration

### ⚙️ Type of Change
- [x] ✨ New feature (adds new functionality without breaking existing usage)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login credentials support environment variable substitution using ${VARIABLE} with optional fallbacks (${VARIABLE:-default}); plaintext values remain supported.

* **Documentation**
  * Configuration docs updated with YAML and shell examples (exporting variables) and an explicit security note advising against committing plaintext credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Second-Hand-Friends/kleinanzeigen-bot/pull/1061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->