### PR TITLE
fix(publish): dismiss 'Effektiver verkaufen' upsell dialog after submit click

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2439,6 +2439,21 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # Edit page uses 'Änderungen speichern' or 'Anzeige speichern'; publish page uses 'Anzeige aufgeben'
         await self.web_click(By.XPATH, "//button[contains(., 'Anzeige aufgeben') or contains(., 'Änderungen speichern') or contains(., 'Anzeige speichern')]")
 
+        # PostListingForm v2 may show an "Effektiver verkaufen" upsell
+        # dialog after clicking submit.  Dismiss it so the actual form
+        # POST can proceed.
+        quick_dom = self._timeout("quick_dom")
+        upsell_dialog = await self.web_probe(
+            By.XPATH, "//dialog[@open and contains(., 'Effektiver verkaufen')]", timeout = quick_dom
+        )
+        if upsell_dialog is not None:
+            LOG.info("Dismissing 'Effektiver verkaufen' upsell dialog...")
+            await self.web_click(
+                By.XPATH, "//dialog[@open]//button[contains(., 'Ohne Hochschieben weiter')]",
+                timeout = quick_dom,
+            )
+            await self.web_sleep(500)  # let the dialog close animation finish
+
         # Everything after the first click is uncertain: the ad may already have been submitted.
         ad_id:int | None = None
         try:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -212,6 +212,7 @@ kleinanzeigen_bot/__init__.py:
     "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
     "Shipping step skipped - reason: NOT_APPLICABLE": "Versandschritt übersprungen: Versand nicht anwendbar (Status = NOT_APPLICABLE)"
     "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
+    "Dismissing 'Effektiver verkaufen' upsell dialog...": "'Effektiver verkaufen'-Dialog schließen..."
     "Direct-buy (sell_directly) is not available for the selected category. Skipping.": "Direktkauf (sell_directly) ist für die ausgewählte Kategorie nicht verfügbar. Überspringe."
     "Image cleanup failed before upload. Removed %(removed)d of %(total)d existing images.": "Bildbereinigung vor dem Hochladen fehlgeschlagen. %(removed)d von %(total)d vorhandenen Bildern wurden entfernt."
     "# Payment form detected! Please proceed with payment.": "# Bestellformular gefunden! Bitte mit der Bezahlung fortfahren."


### PR DESCRIPTION
## ℹ️ Description

PostListingForm v2 shows an upsell dialog ("Effektiver verkaufen" — Sell more effectively) after clicking the submit button on the edit page, blocking the actual form POST. The bot's confirmation URL polling timed out because the page never navigated to the confirmation URL, causing `PublishSubmissionUncertainError` to be raised.

## 📋 Changes Summary

- After clicking the submit button, probe for an open dialog containing "Effektiver verkaufen"
- If detected, dismiss it by clicking "Ohne Hochschieben weiter" (the decline/continue-without-upsell button)
- Wait 500ms for the dialog close animation before proceeding with the normal post-submit flow
- Added German translation for the new log message

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where promotional dialogs could block the listing submission process, ensuring smooth and uninterrupted completion of ad postings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->