### PR TITLE
ci: use non-interactive apt-get with progress suppression flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,10 @@ jobs:
     runs-on: ${{ matrix.os }} # https://github.com/actions/runner-images#available-images
     timeout-minutes: 20
 
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+
     steps:
     - name: "Show: GitHub context"
       env:
@@ -122,7 +126,12 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         if ! hash chromium &>/dev/null; then
-          sudo apt-get --no-install-recommends -y install chromium
+          sudo apt-get install -y --no-install-recommends \
+            -o Dpkg::Progress-Fancy=0 \
+            -o Dpkg::Use-Pty=0 \
+            -o Acquire::Progress-Fancy=0 \
+            -o APT::Color=0 \
+            chromium
         fi
 
 
@@ -187,7 +196,12 @@ jobs:
 
         case "${{ matrix.os }}" in
             ubuntu-*)
-               sudo apt-get install --no-install-recommends -y xvfb
+               sudo apt-get install -y --no-install-recommends \
+                 -o Dpkg::Progress-Fancy=0 \
+                 -o Dpkg::Use-Pty=0 \
+                 -o Acquire::Progress-Fancy=0 \
+                 -o APT::Color=0 \
+                 xvfb
                # Run tests INSIDE xvfb context
                xvfb-run bash -c 'pdm run ci:test:integration -vv'
                ;;
@@ -217,7 +231,13 @@ jobs:
 
     - name: "Install: binutils (strip)"
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install --no-install-recommends -y binutils
+      run: |
+        sudo apt-get install -y --no-install-recommends \
+          -o Dpkg::Progress-Fancy=0 \
+          -o Dpkg::Use-Pty=0 \
+          -o Acquire::Progress-Fancy=0 \
+          -o APT::Color=0 \
+          binutils
 
 
     - name: "Install: UPX"
@@ -374,6 +394,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+
     permissions:
       contents: write  # to delete/create GitHub releases
       packages: write  # to delete untagged docker images
@@ -439,8 +463,15 @@ jobs:
 
     - name: Install ClamAV
       run: |
-        sudo apt-get update
-        sudo apt-get install -y clamav
+        sudo apt-get update \
+          -o Acquire::Progress-Fancy=0 \
+          -o APT::Color=0
+        sudo apt-get install -y --no-install-recommends \
+          -o Dpkg::Progress-Fancy=0 \
+          -o Dpkg::Use-Pty=0 \
+          -o Acquire::Progress-Fancy=0 \
+          -o APT::Color=0 \
+          clamav
         sudo systemctl stop clamav-freshclam.service
         sudo freshclam
 


### PR DESCRIPTION
## ℹ️ Description
Suppress verbose apt-get progress/color output in CI by making apt-get invocations explicitly non-interactive with progress suppression flags.

- Link to the related issue(s): Issue #
- Motivation: `apt-get` in non-interactive CI environments produces noisy progress/color output that clutters logs (see linked run). Using `DEBIAN_FRONTEND=noninteractive` and the `-o` flags for Progress-Fancy and Color cleans this up.

## 📋 Changes Summary

- Added `DEBIAN_FRONTEND=noninteractive` env var to `build` and `publish-release` jobs
- Added `-o Dpkg::Progress-Fancy=0 -o Dpkg::Use-Pty=0 -o Acquire::Progress-Fancy=0 -o APT::Color=0` flags to all `apt-get install` commands (chromium, xvfb, binutils, clamav)
- Added `-o Acquire::Progress-Fancy=0 -o APT::Color=0` flags to `apt-get update` (ClamAV step)
- Added `--no-install-recommends` to the ClamAV install (was missing previously)

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.