### PR TITLE
build: migrate nodriver to upstream 0.50.3 with post-install compat fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,10 @@ jobs:
         pdm sync --clean -v
 
 
+    - name: "Verify: nodriver import"
+      if: runner.os == 'Linux'
+      run: pdm run python -c "import nodriver.cdp.network"
+
     - name: Display project metadata
       run: pdm show
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:253dbcd64dd8909f6d6bb516cf684ac98255b6a5e7df6ebfd359a56fc5d873a8"
+content_hash = "sha256:67c78edd313e8b850010d552efb91c3df81034ae9c28adbccc56a739ee785afe"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.15"
@@ -1127,17 +1127,18 @@ files = [
 
 [[package]]
 name = "nodriver"
-version = "0.48.1.post1"
-requires_python = ">=3.10"
-git = "https://github.com/Second-Hand-Friends/nodriver.git"
-ref = "b0d1f0a59cd16e0d9001f32f35a663129e403efd"
-revision = "b0d1f0a59cd16e0d9001f32f35a663129e403efd"
-summary = "Asynchronous browser automation and web scraping for Chromium-based browsers."
+version = "0.50.3"
+requires_python = ">=3.9"
+summary = "[Docs here](https://ultrafunkamsterdam.github.io/nodriver)"
 groups = ["default"]
 dependencies = [
     "deprecated",
     "mss",
-    "websockets>=16.0",
+    "websockets>=14",
+]
+files = [
+    {file = "nodriver-0.50.3-py3-none-any.whl", hash = "sha256:a053533108c14c309a7613445e6c7fb460b6b165c144a062e1b2f39e4f7b396b"},
+    {file = "nodriver-0.50.3.tar.gz", hash = "sha256:24ca688d8646ef8ffad5c8ce65804e5e7671a779ad26a24d76f6465d5666c631"},
 ]
 
 [[package]]
@@ -1187,13 +1188,13 @@ files = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 requires_python = ">=3.10"
 summary = "The PyPA recommended tool for installing Python packages."
 groups = ["dev"]
 files = [
-    {file = "pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb"},
-    {file = "pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78"},
+    {file = "pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab"},
+    {file = "pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "certifi",
   "colorama",
   "jaraco.text", # required by pkg_resources during runtime
-  "nodriver @ git+https://github.com/Second-Hand-Friends/nodriver.git@b0d1f0a59cd16e0d9001f32f35a663129e403efd", # Temporary fork pin; track in #1036; review again on 2026-06-15
+  "nodriver==0.50.3",
   "platformdirs>=2.1.0",
   "pydantic>=2.11.0",
   "ruamel.yaml",
@@ -94,6 +94,7 @@ generate-artifacts = { composite = ["generate-schemas", "generate-config"] }
 compile.cmd = "python -O -m PyInstaller pyinstaller.spec --clean --workpath .temp"
 compile.env = {PYTHONHASHSEED = "1", SOURCE_DATE_EPOCH = "0"}  # https://pyinstaller.org/en/stable/advanced-topics.html#creating-a-reproducible-build
 
+post_install        = "python scripts/fix_nodriver_encoding.py"
 deps                = "pdm list --fields name,version,groups"
 "deps:tree"         = "pdm list --tree"
 "deps:runtime"      = "pdm list --fields name,version,groups --include default"

--- a/scripts/fix_nodriver_encoding.py
+++ b/scripts/fix_nodriver_encoding.py
@@ -173,8 +173,13 @@ def main() -> int:
         ("nodriver/core/connection.py", _fix_connection_send),
     ]:
         path = _locate_file(rel)
-        if path and path.is_file():
-            print(f"fix_nodriver_encoding: {path} -> {fix(path)}")
+        if path is None:
+            print(f"fix_nodriver_encoding: nodriver not installed, cannot patch {rel}", file = sys.stderr)
+            return 1
+        if not path.is_file():
+            print(f"fix_nodriver_encoding: {path} not found, cannot patch", file = sys.stderr)
+            return 1
+        print(f"fix_nodriver_encoding: {path} -> {fix(path)}")
     return 0
 
 

--- a/scripts/fix_nodriver_encoding.py
+++ b/scripts/fix_nodriver_encoding.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Fix UTF-8 encoding issues in installed nodriver cdp files.
+
+nodriver 0.50.3 ships ``cdp/network.py`` with an ISO-8859-1 ``±`` character
+(byte ``0xb1``) in the comment ``# JSON (±Inf)`` on line 1345, and no encoding
+declaration. Python 3.12+ rejects this at import time.
+
+This script patches the installed file to use proper UTF-8 and adds the
+required ``# -*- coding: utf-8 -*-`` declaration. The patch is idempotent.
+
+Designed as a PDM ``post_install`` hook. Exits non-zero if the file is found
+but does not contain the expected bad pattern.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import sys
+from pathlib import Path
+
+
+def _locate_target() -> Path | None:
+    """Locate the installed ``nodriver/cdp/network.py`` via importlib.metadata."""
+    try:
+        dist = importlib.metadata.distribution("nodriver")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+    try:
+        # Preferred public API
+        return Path(dist.locate_file("nodriver/cdp/network.py"))  # type: ignore[arg-type]
+    except AttributeError:
+        # Python 3.10-3.11 fallback: dist._path → .dist-info dir → site-packages
+        site_packages = Path(dist._path).parent  # type: ignore[attr-defined]  # noqa: SLF001
+        return site_packages / "nodriver" / "cdp" / "network.py"
+
+
+def _fix_file(path:Path) -> str:
+    """Fix encoding in *path*. Returns ``"fixed"``, ``"already-ok"``, or exits.
+
+    Exits with code 1 if the file is found but does not contain the expected
+    bad pattern and is not already valid UTF-8 — this indicates an unexpected
+    upstream change that needs human review.
+    """
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return "skipped"
+
+    # Known bad pattern in nodriver 0.50.3:
+    #   ``b"    #: JSON (\xb1Inf).\r\n"`` (line 1345)
+    # We match the specific context ``(\xb1Inf)`` to avoid false positives.
+    bad_pattern = b"(\xb1Inf)"
+
+    if bad_pattern not in raw:
+        # Pattern not found — verify the file is already valid UTF-8
+        try:
+            raw.decode("utf-8")
+            return "already-ok"
+        except UnicodeDecodeError as exc:
+            print(
+                f"fix_nodriver_encoding: {path}: file does not contain the "
+                f"expected bad pattern and is not valid UTF-8 ({exc}). "
+                f"Upstream may have changed — review needed.",
+                file = sys.stderr,
+            )
+            sys.exit(1)
+
+    # Patch: replace the specific bad byte sequence with proper UTF-8
+    fixed = raw.replace(bad_pattern, b"(\xc2\xb1Inf)")
+
+    # Add encoding declaration if not present
+    if not fixed.startswith(b"# -*- coding: utf-8 -*-"):
+        fixed = b"# -*- coding: utf-8 -*-\n" + fixed
+
+    # Normalize line endings (upstream uses CRLF in this file)
+    fixed = fixed.replace(b"\r\n", b"\n")
+
+    # Validate the result is valid UTF-8
+    try:
+        fixed.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        print(
+            f"fix_nodriver_encoding: {path}: patched file is not valid UTF-8: {exc}",
+            file = sys.stderr,
+        )
+        sys.exit(1)
+
+    path.write_bytes(fixed)
+    return "fixed"
+
+
+def main() -> int:
+    target = _locate_target()
+    if target is None:
+        print("fix_nodriver_encoding: nodriver not installed, skipping", file = sys.stderr)
+        return 0
+
+    if not target.is_file():
+        print(f"fix_nodriver_encoding: {target} not found, skipping", file = sys.stderr)
+        return 0
+
+    result = _fix_file(target)
+    print(f"fix_nodriver_encoding: {target} -> {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fix_nodriver_encoding.py
+++ b/scripts/fix_nodriver_encoding.py
@@ -1,20 +1,19 @@
 # SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-"""Post-install fixes for installed nodriver that upstream does not accept.
+"""Post-install fixes for installed nodriver.
 
-1. **Encoding fix** — ``cdp/network.py`` ISO-8859-1 ``±`` byte without
-   encoding declaration → add UTF-8 header + fix the byte.
+1. **Encoding fix** — ``cdp/network.py`` contains a lone ISO-8859-1 ``±``
+   byte (0xb1) without an encoding declaration. Python 3.12+ rejects this
+   at import time. The fix adds a ``# -*- coding: utf-8 -*-`` header and
+   replaces the byte with proper UTF-8.
 
-2. **Send retry** — nodriver 0.50.3+ flat-mode ``sessionId`` can go stale
-   after complex navigations (category flow). Edge 148 rejects stale-session
-   commands with ``-32601``. Wraps ``send`` to re-attach and retry once.
-
-3. **DOM.enable routing** — ``tab`` methods call ``send(cdp.dom.enable(),
-   _attach=True)``, which sends the command at browser level without
-   ``sessionId``. Edge 148 does not accept ``DOM.enable`` on the browser
-   target. Removes the ``_attach`` flag so the command reaches the page
-   target (with ``sessionId``).
+2. **Flat-mode session retry** — nodriver 0.50.3+ uses flat-mode CDP
+   (browser-level WebSocket + per-target ``sessionId``). Chromium 148+
+   rejects ``DOM.enable`` when sent to the browser target without a
+   ``sessionId``, and rejects stale-session commands with ``-32601``.
+   Wraps ``Connection.send`` to re-attach and retry once on that code,
+   switching ``_attach=True`` commands to include ``sessionId``.
 
 Designed as a PDM ``post_install`` hook. All patches are idempotent.
 """
@@ -48,14 +47,19 @@ def _fix_network_encoding(path:Path) -> str:
     except OSError as exc:
         print(f"fix_nodriver_encoding: cannot read {path}: {exc}", file = sys.stderr)
         sys.exit(1)
+
     bad = b"(\xb1Inf)"
     if bad not in raw:
         try:
             raw.decode("utf-8")
             return "already-ok"
-        except UnicodeDecodeError:
-            print(f"fix_nodriver_encoding: {path}: unexpected content", file = sys.stderr)
+        except UnicodeDecodeError as exc:
+            print(
+                f"fix_nodriver_encoding: {path}: unexpected content: {exc}",
+                file = sys.stderr,
+            )
             sys.exit(1)
+
     fixed = raw.replace(bad, b"(\xc2\xb1Inf)")
     if not fixed.startswith(b"# -*- coding: utf-8 -*-"):
         fixed = b"# -*- coding: utf-8 -*-\n" + fixed
@@ -63,13 +67,13 @@ def _fix_network_encoding(path:Path) -> str:
     try:
         fixed.decode("utf-8")
     except UnicodeDecodeError as exc:
-        print(f"fix_nodriver_encoding: {path}: invalid UTF-8 after patch: {exc}", file = sys.stderr)
+        print(f"fix_nodriver_encoding: {path}: invalid UTF-8: {exc}", file = sys.stderr)
         sys.exit(1)
     path.write_bytes(fixed)
     return "fixed"
 
 
-# ── connection.py send retry on stale session ──────────────────────────────
+# ── connection.py flat-mode session retry ──────────────────────────────────
 
 _SEND_START = "        if not _attach:"
 _SEND_ERR_END = "            raise exception"
@@ -122,8 +126,8 @@ _NEW_SEND = """\
 
             if "error" in response_message:
                 if _retry == 0 and response_message["error"].get("code") == -32601:
-                    # If the command was sent without sessionId (_attach=True),
-                    # re-attach and retry WITH sessionId so it reaches the page.
+                    # Chromium 148+: switch from browser-level to page-target
+                    # routing when the command is rejected without sessionId.
                     _attach = False
                     await self.attach()
                     continue
@@ -139,60 +143,38 @@ def _fix_connection_send(path:Path) -> str:
     except OSError as exc:
         print(f"fix_nodriver_encoding: cannot read {path}: {exc}", file = sys.stderr)
         sys.exit(1)
+
     if "for _retry in range(2):" in text:
         return "already-ok"
+
     start = text.find(_SEND_START)
     if start == -1:
         print("fix_nodriver_encoding: send start marker not found", file = sys.stderr)
         sys.exit(1)
+
     err = text.find(_SEND_ERR_END, start)
     if err == -1:
-        print("fix_nodriver_encoding: send error end marker not found", file = sys.stderr)
+        print("fix_nodriver_encoding: send error end not found", file = sys.stderr)
         sys.exit(1)
+
     err_end = text.index("\n", err)
     indent = text[text.rfind("\n", 0, start) + 1: start]
-    new_body = textwrap.indent(_NEW_SEND, indent).removeprefix("\n")
-    result = text[:start] + new_body + text[err_end:]
+    body = textwrap.indent(_NEW_SEND, indent).removeprefix("\n")
+    result = text[:start] + body + text[err_end:]
     path.write_text(result, "utf-8")
     return "fixed"
-
-
-# ── tab.py: remove _attach flag from DOM.enable/disable ────────────────────
-
-_TAB_PATCHES = [
-    ("self.send(cdp.dom.enable(), True)", "self.send(cdp.dom.enable())"),
-    ("self.send(cdp.dom.disable(), True)", "self.send(cdp.dom.disable())"),
-]
-
-
-def _fix_tab_dom_calls(path:Path) -> str:
-    try:
-        text = path.read_text("utf-8")
-    except OSError as exc:
-        print(f"fix_nodriver_encoding: cannot read {path}: {exc}", file = sys.stderr)
-        sys.exit(1)
-    changed = False
-    for old, new in _TAB_PATCHES:
-        # Only patch the first occurrence (find_all/find methods); the others
-        # (in query_selector etc.) don't have the _attach flag.
-        if old in text:
-            text = text.replace(old, new, 1)
-            changed = True
-    return "fixed" if changed else "already-ok"
 
 
 # ── main ───────────────────────────────────────────────────────────────────
 
 def main() -> int:
-    patches = [
+    for rel, fix in [
         ("nodriver/cdp/network.py", _fix_network_encoding),
         ("nodriver/core/connection.py", _fix_connection_send),
-        ("nodriver/core/tab.py", _fix_tab_dom_calls),
-    ]
-    for rel, fix in patches:
-        p = _locate_file(rel)
-        if p and p.is_file():
-            print(f"fix_nodriver_encoding: {p} -> {fix(p)}")
+    ]:
+        path = _locate_file(rel)
+        if path and path.is_file():
+            print(f"fix_nodriver_encoding: {path} -> {fix(path)}")
     return 0
 
 

--- a/scripts/fix_nodriver_encoding.py
+++ b/scripts/fix_nodriver_encoding.py
@@ -46,8 +46,12 @@ def _fix_file(path:Path) -> str:
     """
     try:
         raw = path.read_bytes()
-    except OSError:
-        return "skipped"
+    except OSError as exc:
+        print(
+            f"fix_nodriver_encoding: cannot read {path}: {exc}",
+            file = sys.stderr,
+        )
+        sys.exit(1)
 
     # Known bad pattern in nodriver 0.50.3:
     #   ``b"    #: JSON (\xb1Inf).\r\n"`` (line 1345)

--- a/scripts/fix_nodriver_encoding.py
+++ b/scripts/fix_nodriver_encoding.py
@@ -1,113 +1,198 @@
 # SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-"""Fix UTF-8 encoding issues in installed nodriver cdp files.
+"""Post-install fixes for installed nodriver that upstream does not accept.
 
-nodriver 0.50.3 ships ``cdp/network.py`` with an ISO-8859-1 ``±`` character
-(byte ``0xb1``) in the comment ``# JSON (±Inf)`` on line 1345, and no encoding
-declaration. Python 3.12+ rejects this at import time.
+1. **Encoding fix** — ``cdp/network.py`` ISO-8859-1 ``±`` byte without
+   encoding declaration → add UTF-8 header + fix the byte.
 
-This script patches the installed file to use proper UTF-8 and adds the
-required ``# -*- coding: utf-8 -*-`` declaration. The patch is idempotent.
+2. **Send retry** — nodriver 0.50.3+ flat-mode ``sessionId`` can go stale
+   after complex navigations (category flow). Edge 148 rejects stale-session
+   commands with ``-32601``. Wraps ``send`` to re-attach and retry once.
 
-Designed as a PDM ``post_install`` hook. Exits non-zero if the file is found
-but does not contain the expected bad pattern.
+3. **DOM.enable routing** — ``tab`` methods call ``send(cdp.dom.enable(),
+   _attach=True)``, which sends the command at browser level without
+   ``sessionId``. Edge 148 does not accept ``DOM.enable`` on the browser
+   target. Removes the ``_attach`` flag so the command reaches the page
+   target (with ``sessionId``).
+
+Designed as a PDM ``post_install`` hook. All patches are idempotent.
 """
 
 from __future__ import annotations
 
 import importlib.metadata
 import sys
+import textwrap
 from pathlib import Path
 
 
-def _locate_target() -> Path | None:
-    """Locate the installed ``nodriver/cdp/network.py`` via importlib.metadata."""
+def _locate_file(relative:str) -> Path | None:
+    """Locate an installed nodriver source file via importlib.metadata."""
     try:
         dist = importlib.metadata.distribution("nodriver")
     except importlib.metadata.PackageNotFoundError:
         return None
-
     try:
-        # Preferred public API
-        return Path(dist.locate_file("nodriver/cdp/network.py"))  # type: ignore[arg-type]
+        return Path(dist.locate_file(relative))  # type: ignore[arg-type]
     except AttributeError:
-        # Python 3.10-3.11 fallback: dist._path → .dist-info dir → site-packages
         site_packages = Path(dist._path).parent  # type: ignore[attr-defined]  # noqa: SLF001
-        return site_packages / "nodriver" / "cdp" / "network.py"
+        return site_packages / relative
 
 
-def _fix_file(path:Path) -> str:
-    """Fix encoding in *path*. Returns ``"fixed"``, ``"already-ok"``, or exits.
+# ── network.py encoding fix ────────────────────────────────────────────────
 
-    Exits with code 1 if the file is found but does not contain the expected
-    bad pattern and is not already valid UTF-8 — this indicates an unexpected
-    upstream change that needs human review.
-    """
+def _fix_network_encoding(path:Path) -> str:
     try:
         raw = path.read_bytes()
     except OSError as exc:
-        print(
-            f"fix_nodriver_encoding: cannot read {path}: {exc}",
-            file = sys.stderr,
-        )
+        print(f"fix_nodriver_encoding: cannot read {path}: {exc}", file = sys.stderr)
         sys.exit(1)
-
-    # Known bad pattern in nodriver 0.50.3:
-    #   ``b"    #: JSON (\xb1Inf).\r\n"`` (line 1345)
-    # We match the specific context ``(\xb1Inf)`` to avoid false positives.
-    bad_pattern = b"(\xb1Inf)"
-
-    if bad_pattern not in raw:
-        # Pattern not found — verify the file is already valid UTF-8
+    bad = b"(\xb1Inf)"
+    if bad not in raw:
         try:
             raw.decode("utf-8")
             return "already-ok"
-        except UnicodeDecodeError as exc:
-            print(
-                f"fix_nodriver_encoding: {path}: file does not contain the "
-                f"expected bad pattern and is not valid UTF-8 ({exc}). "
-                f"Upstream may have changed — review needed.",
-                file = sys.stderr,
-            )
+        except UnicodeDecodeError:
+            print(f"fix_nodriver_encoding: {path}: unexpected content", file = sys.stderr)
             sys.exit(1)
-
-    # Patch: replace the specific bad byte sequence with proper UTF-8
-    fixed = raw.replace(bad_pattern, b"(\xc2\xb1Inf)")
-
-    # Add encoding declaration if not present
+    fixed = raw.replace(bad, b"(\xc2\xb1Inf)")
     if not fixed.startswith(b"# -*- coding: utf-8 -*-"):
         fixed = b"# -*- coding: utf-8 -*-\n" + fixed
-
-    # Normalize line endings (upstream uses CRLF in this file)
     fixed = fixed.replace(b"\r\n", b"\n")
-
-    # Validate the result is valid UTF-8
     try:
         fixed.decode("utf-8")
     except UnicodeDecodeError as exc:
-        print(
-            f"fix_nodriver_encoding: {path}: patched file is not valid UTF-8: {exc}",
-            file = sys.stderr,
-        )
+        print(f"fix_nodriver_encoding: {path}: invalid UTF-8 after patch: {exc}", file = sys.stderr)
         sys.exit(1)
-
     path.write_bytes(fixed)
     return "fixed"
 
 
+# ── connection.py send retry on stale session ──────────────────────────────
+
+_SEND_START = "        if not _attach:"
+_SEND_ERR_END = "            raise exception"
+
+_NEW_SEND = """\
+        method, *params = next(cdp_obj).values()
+        if params:
+            params = params.pop()
+
+        for _retry in range(2):
+            if not _attach:
+                if not self.attached or not self.socket:
+                    await self.attach()
+
+            _id = next(self.__count__)
+            message = {"method": method, "params": params, "id": _id}
+            if not _attach:
+                message["sessionId"] = self.session_id
+            message.update(kwargs)
+
+            tx = Transaction(message)
+            self.transactions.append(tx)
+            self._tx_by_id[_id] = tx
+
+            future = asyncio.get_running_loop().create_future()
+            self._mapper[_id] = future
+
+            while len(self.transactions) > 25:
+                removed_tx = self.transactions.pop(0)
+                if removed_tx.id is not None:
+                    self._tx_by_id.pop(removed_tx.id, None)
+
+            ws = self.socket
+            if ws is None:
+                raise RuntimeError("WebSocket is not connected")
+
+            async with self.lock:
+                try:
+                    await ws.send(json.dumps(message))
+                except Exception:
+                    self._mapper.pop(_id, None)
+                    if not future.done():
+                        future.cancel()
+                    raise
+
+            try:
+                response_message = await future
+            finally:
+                self._mapper.pop(_id, None)
+
+            if "error" in response_message:
+                if _retry == 0 and response_message["error"].get("code") == -32601:
+                    # If the command was sent without sessionId (_attach=True),
+                    # re-attach and retry WITH sessionId so it reaches the page.
+                    _attach = False
+                    await self.attach()
+                    continue
+                exception = ProtocolException(response_message["error"])
+                tx.result = exception
+                raise exception
+            break"""
+
+
+def _fix_connection_send(path:Path) -> str:
+    try:
+        text = path.read_text("utf-8")
+    except OSError as exc:
+        print(f"fix_nodriver_encoding: cannot read {path}: {exc}", file = sys.stderr)
+        sys.exit(1)
+    if "for _retry in range(2):" in text:
+        return "already-ok"
+    start = text.find(_SEND_START)
+    if start == -1:
+        print("fix_nodriver_encoding: send start marker not found", file = sys.stderr)
+        sys.exit(1)
+    err = text.find(_SEND_ERR_END, start)
+    if err == -1:
+        print("fix_nodriver_encoding: send error end marker not found", file = sys.stderr)
+        sys.exit(1)
+    err_end = text.index("\n", err)
+    indent = text[text.rfind("\n", 0, start) + 1: start]
+    new_body = textwrap.indent(_NEW_SEND, indent).removeprefix("\n")
+    result = text[:start] + new_body + text[err_end:]
+    path.write_text(result, "utf-8")
+    return "fixed"
+
+
+# ── tab.py: remove _attach flag from DOM.enable/disable ────────────────────
+
+_TAB_PATCHES = [
+    ("self.send(cdp.dom.enable(), True)", "self.send(cdp.dom.enable())"),
+    ("self.send(cdp.dom.disable(), True)", "self.send(cdp.dom.disable())"),
+]
+
+
+def _fix_tab_dom_calls(path:Path) -> str:
+    try:
+        text = path.read_text("utf-8")
+    except OSError as exc:
+        print(f"fix_nodriver_encoding: cannot read {path}: {exc}", file = sys.stderr)
+        sys.exit(1)
+    changed = False
+    for old, new in _TAB_PATCHES:
+        # Only patch the first occurrence (find_all/find methods); the others
+        # (in query_selector etc.) don't have the _attach flag.
+        if old in text:
+            text = text.replace(old, new, 1)
+            changed = True
+    return "fixed" if changed else "already-ok"
+
+
+# ── main ───────────────────────────────────────────────────────────────────
+
 def main() -> int:
-    target = _locate_target()
-    if target is None:
-        print("fix_nodriver_encoding: nodriver not installed, skipping", file = sys.stderr)
-        return 0
-
-    if not target.is_file():
-        print(f"fix_nodriver_encoding: {target} not found, skipping", file = sys.stderr)
-        return 0
-
-    result = _fix_file(target)
-    print(f"fix_nodriver_encoding: {target} -> {result}")
+    patches = [
+        ("nodriver/cdp/network.py", _fix_network_encoding),
+        ("nodriver/core/connection.py", _fix_connection_send),
+        ("nodriver/core/tab.py", _fix_tab_dom_calls),
+    ]
+    for rel, fix in patches:
+        p = _locate_file(rel)
+        if p and p.is_file():
+            print(f"fix_nodriver_encoding: {p} -> {fix(p)}")
     return 0
 
 

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -888,7 +888,6 @@ class WebScrapingMixin:
                         LOG.debug("Re-attach failed: %s", re_exc)
                     continue
                 ex = ex1
-                ex = ex1
             except Exception as ex1:
                 ex = ex1
             elapsed = loop.time() - start_at

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, TypeGuard
 
 from nodriver.core.browser import Browser
 from nodriver.core.config import Config as NodriverConfig
+from nodriver.core.connection import ProtocolException
 from nodriver.core.element import Element
 from nodriver.core.tab import Tab as Page
 
@@ -876,6 +877,18 @@ class WebScrapingMixin:
                 result:T = cast(T, await result_raw if inspect.isawaitable(result_raw) else result_raw)
                 if result:
                     return result
+            except ProtocolException as ex1:
+                if ex1.code == -32601:  # noqa: PLR2004
+                    # Chromium 148+ rejects DOM commands on stale flat-mode
+                    # sessions.  Re-attach and retry.
+                    LOG.debug("Re-attaching CDP session after -32601")
+                    try:
+                        await self.page.attach()
+                    except Exception as re_exc:  # noqa: S110
+                        LOG.debug("Re-attach failed: %s", re_exc)
+                    continue
+                ex = ex1
+                ex = ex1
             except Exception as ex1:
                 ex = ex1
             elapsed = loop.time() - start_at

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -877,7 +877,7 @@ class WebScrapingMixin:
                 result:T = cast(T, await result_raw if inspect.isawaitable(result_raw) else result_raw)
                 if result:
                     return result
-            except ProtocolException as ex1:
+            except ProtocolException as ex1:  # pragma: no cover — needs live CDP session
                 if ex1.code == -32601:  # noqa: PLR2004
                     # Chromium 148+ rejects DOM commands on stale flat-mode
                     # sessions.  Re-attach and retry.


### PR DESCRIPTION
Closes #1036

## ℹ️ Description

Replace the forked nodriver (Second-Hand-Friends/nodriver@b0d1f0a) with upstream nodriver 0.50.3 from PyPI. Two compatibility issues are fixed:

1. **UTF-8 encoding bug** (post-install patch) — `cdp/network.py` contains a lone ISO-8859-1 `±` byte without an encoding declaration, rejected by Python 3.12+.

2. **Chromium 148+ flat-mode CDP routing** (post-install + bot-code) — nodriver 0.50.3 uses flat-mode connections (browser-level WebSocket + `sessionId`). Chromium 148+ rejects `DOM.enable` at the browser level without `sessionId` (`-32601`), and stale `sessionId` after category navigation.

### Why the fork worked

The fork connected directly to page-level WebSockets — no `sessionId`, no target routing. Upstream 0.50.1 switched to flat mode (commit `5efe0a5`); this is a valid design that simplifies iframe handling and target management, but Chromium 148+ is stricter about where DOM commands go, exposing two edge cases in the upstream implementation.

### Fixes applied

| Layer | Fix |
|---|---|
| `scripts/fix_nodriver_encoding.py` | Wraps `Connection.send` to retry on `-32601`, switching `_attach=True` commands to include `sessionId` |
| `web_scraping_mixin.py` | `web_await` catches `ProtocolException(-32601)`, re-attaches the CDP target, and retries |

### Tested browsers

All Chromium 148-based (released within the last few days), tested against real kleinanzeigen.de sessions:

| Browser | Version | Chromium base |
|---|---|---|
| Microsoft Edge | 148.0.3967.96 | 148 |
| Helium | 0.12.5.1 | 148.0.7778.215 |
| Chromium | 148.0.7778.215 | 148 |

### Tested scenarios

- Login page — page open + selectors ✅
- Publish form — page open + selectors ✅
- Manage-ads pagination — DOM queries + JS ✅
- Category selection flow — multi-page navigation, form interactions ✅
- Ad type switching + element checks after category nav ✅
- Shipping options — radio selection, dialog interaction ✅
- Condition/state read-back after form changes ✅
- Special attributes — set and read-back ✅
- Delete flow — element location + CSRF token extraction ✅
- Price type controls — combobox interactions ✅

## 📋 Changes Summary

- **pyproject.toml**: pin `nodriver==0.50.3`, add `post_install` PDM hook
- **scripts/fix_nodriver_encoding.py**: UTF-8 fix + flat-mode session retry
- **src/kleinanzeigen_bot/utils/web_scraping_mixin.py**: re-attach on `-32601` ProtocolException
- **.github/workflows/build.yml**: CI import sanity check after `pdm sync` (Linux only)
- **pdm.lock**: updated to upstream 0.50.3

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.