### PR TITLE
ci: publish multi-arch docker image instead of racing single-arch pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,9 +309,12 @@ jobs:
 
         echo "${{ github.token }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
+        # Push a per-arch tag so the multi-arch :latest can be stitched together later.
+        arch=$(dpkg --print-architecture)
+
         image_name="second-hand-friends/kleinanzeigen-bot"
-        docker image tag $image_name ghcr.io/$image_name
-        docker push ghcr.io/$image_name
+        docker image tag $image_name ghcr.io/$image_name:latest-$arch
+        docker push ghcr.io/$image_name:latest-$arch
 
 
     - name: Collect coverage reports
@@ -322,6 +325,39 @@ jobs:
         include-hidden-files: true
         path: .temp/coverage-*.xml
         if-no-files-found: error
+
+
+  ###########################################################
+  publish-docker-manifest:
+  ###########################################################
+    # Combine the per-arch :latest-amd64 and :latest-arm64 tags that the matrix
+    # jobs pushed into a single multi-arch :latest manifest list. Without this,
+    # whichever matrix job finished second would silently overwrite the other
+    # and :latest would be single-arch. See issue #1077.
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.repository_owner == 'Second-Hand-Friends' && github.ref_name == 'main' && !github.event.act
+
+    permissions:
+      packages: write
+
+    steps:
+    - name: Create and push multi-arch manifest
+      run: |
+        set -eux
+
+        echo "${{ github.token }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+        image=ghcr.io/second-hand-friends/kleinanzeigen-bot
+
+        docker buildx imagetools create \
+          --tag $image:latest \
+          $image:latest-amd64 \
+          $image:latest-arm64
+
+        # Print the resulting manifest list for the run log.
+        docker buildx imagetools inspect $image:latest
 
 
   ###########################################################


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #1077
- `ghcr.io/second-hand-friends/kleinanzeigen-bot:latest` is currently a single-arch image: the matrix runs the publish step on both `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64), both push to `:latest`, and whichever finishes second silently overwrites the other. Today `:latest` happens to be arm64-only, so amd64 users pull an arm64 image that runs under QEMU with only a stderr warning.

## 📋 Changes Summary

- Each matrix leg now pushes a per-arch tag (`:latest-amd64` / `:latest-arm64`) derived from `dpkg --print-architecture` on the runner, instead of racing on the shared `:latest` tag.
- New `publish-docker-manifest` job runs once (not in the matrix), depends on `build`, and stitches the per-arch tags into a proper multi-arch manifest list at `:latest` via `docker buildx imagetools create`.
- No new dependencies; `docker buildx` is preinstalled on the `ubuntu-latest` runner.
- Side-effect to be aware of: after merge, `ghcr.io/.../kleinanzeigen-bot` will also expose `:latest-amd64` and `:latest-arm64` tags alongside `:latest`.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass  (`pdm run test`). — CI-workflow-only change, no python tests affected; verified `actionlint` clean on the touched workflow.
- [ ] I have formatted the code (`pdm run format`). — N/A, no python touched.
- [ ] I have verified that linting passes (`pdm run lint`). — N/A, no python touched.
- [ ] I have updated documentation where necessary. — none required; behavior change is invisible to users (`docker pull` just starts working on their architecture).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image publishing to reliably support multiple architectures in cross-platform deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->