### PR TITLE
ci: publish multi-arch docker manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
 
         echo "Extracting upx zip..."
         mkdir /tmp/upx
-        7z e /tmp/upx.zip -o/tmp/upx -- ./*.exe -r
+        7z e /tmp/upx.zip -o/tmp/upx -- '*.exe' -r
         cygpath -wa /tmp/upx >> "$GITHUB_PATH"
 
         /tmp/upx/upx.exe --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
 
         echo "Extracting upx zip..."
         mkdir /tmp/upx
-        7z e /tmp/upx.zip -o/tmp/upx -- '*.exe' -r
+        7z e /tmp/upx.zip -o/tmp/upx '*.exe' -r
         cygpath -wa /tmp/upx >> "$GITHUB_PATH"
 
         /tmp/upx/upx.exe --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,19 @@ on:  # https://docs.github.com/en/actions/reference/workflows-and-actions/events
     # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
 
 
+# Serialize runs per branch so concurrent main merges cannot race on the shared
+# ghcr.io :latest tag. Main queues publishing runs; non-main runs cancel older
+# attempts when new commits land.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+
+env:
+  IMAGE_NAME: second-hand-friends/kleinanzeigen-bot
+  REGISTRY_IMAGE: ghcr.io/second-hand-friends/kleinanzeigen-bot
+
+
 defaults:
   run:
     shell: bash
@@ -57,6 +70,7 @@ jobs:
     # Skip push runs for non-main/release branches in the main repo; allow forks to run on feature branches.
     if: github.event_name != 'push' || github.ref_name == 'main' || github.ref_name == 'release' || github.repository != 'Second-Hand-Friends/kleinanzeigen-bot'
     permissions:
+      # Required to publish per-arch Docker images to ghcr.io.
       packages: write
 
     strategy:
@@ -168,6 +182,11 @@ jobs:
       run: pdm run python scripts/check_generated_artifacts.py
 
 
+    - name: Check GitHub Actions workflows
+      if: matrix.os == 'ubuntu-latest' && matrix.PYTHON_VERSION == '3.14'
+      run: pdm run lint:actions
+
+
     - name: Check with pip-audit
       # until https://github.com/astral-sh/ruff/issues/8277
       run:
@@ -251,12 +270,12 @@ jobs:
 
         upx_download_url=$(curl -fsSL -H "Authorization: token ${{ github.token }}" https://api.github.com/repos/upx/upx/releases/latest | grep browser_download_url | grep win64.zip | cut "-d\"" -f4)
         echo "Downloading [$upx_download_url]..."
-        curl -fL -o /tmp/upx.zip $upx_download_url
+        curl -fL -o /tmp/upx.zip "$upx_download_url"
 
         echo "Extracting upx zip..."
         mkdir /tmp/upx
-        7z e /tmp/upx.zip -o/tmp/upx *.exe -r
-        echo "$(cygpath -wa /tmp/upx)" >> $GITHUB_PATH
+        7z e /tmp/upx.zip -o/tmp/upx -- ./*.exe -r
+        cygpath -wa /tmp/upx >> "$GITHUB_PATH"
 
         /tmp/upx/upx.exe --version
 
@@ -309,9 +328,10 @@ jobs:
 
         echo "${{ github.token }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
-        image_name="second-hand-friends/kleinanzeigen-bot"
-        docker image tag $image_name ghcr.io/$image_name
-        docker push ghcr.io/$image_name
+        arch=$(docker image inspect "$IMAGE_NAME" --format '{{.Architecture}}')
+
+        docker image tag "$IMAGE_NAME" "$REGISTRY_IMAGE:latest-$arch"
+        docker push "$REGISTRY_IMAGE:latest-$arch"
 
 
     - name: Collect coverage reports
@@ -322,6 +342,39 @@ jobs:
         include-hidden-files: true
         path: .temp/coverage-*.xml
         if-no-files-found: error
+
+
+  ###########################################################
+  publish-docker-manifest:
+  ###########################################################
+    # Combine the per-arch tags from the matrix into one multi-arch :latest
+    # manifest. Without this, the last matrix push wins and :latest is single-arch.
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.repository_owner == 'Second-Hand-Friends' && github.ref_name == 'main' && !github.event.act
+
+    permissions:
+      # Required to publish the stitched multi-arch manifest to ghcr.io.
+      packages: write
+
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+    - name: Create and push multi-arch manifest
+      run: |
+        set -eux
+
+        echo "${{ github.token }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+        docker buildx imagetools create \
+          --tag "$REGISTRY_IMAGE:latest" \
+          "$REGISTRY_IMAGE:latest-amd64" \
+          "$REGISTRY_IMAGE:latest-arm64"
+
+        # Print the resulting manifest list for the run log.
+        docker buildx imagetools inspect "$REGISTRY_IMAGE:latest"
 
 
   ###########################################################
@@ -349,7 +402,7 @@ jobs:
 
 
     - name: List coverage reports
-      run: find . -name coverage-*.xml
+      run: find . -name 'coverage-*.xml'
 
 
     - name: Publish unit-test coverage
@@ -422,7 +475,7 @@ jobs:
     - name: "Show: GitHub context"
       env:
         GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: echo $GITHUB_CONTEXT
+      run: printf '%s\n' "$GITHUB_CONTEXT"
 
 
     - name: "Show: environment variables"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,7 +30,7 @@ jobs:
     - name: "Show: GitHub context"
       env:
         GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: echo $GITHUB_CONTEXT
+      run: printf '%s\n' "$GITHUB_CONTEXT"
 
 
     - name: "Show: environment variables"

--- a/.github/workflows/update-python-deps.yml
+++ b/.github/workflows/update-python-deps.yml
@@ -35,7 +35,7 @@ jobs:
     - name: "Show: GitHub context"
       env:
         GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: echo $GITHUB_CONTEXT
+      run: printf '%s\n' "$GITHUB_CONTEXT"
 
 
     - name: "Show: environment variables"
@@ -100,9 +100,11 @@ jobs:
           fi
           # https://github.com/orgs/community/discussions/26288#discussioncomment-3876281
           delimiter="$(openssl rand -hex 8)"
-          echo "updates<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          echo "$updates" >> "${GITHUB_OUTPUT}"
-          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "updates<<${delimiter}"
+            echo "$updates"
+            echo "${delimiter}"
+          } >> "${GITHUB_OUTPUT}"
         fi
 
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,10 +5,20 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:67c78edd313e8b850010d552efb91c3df81034ae9c28adbccc56a739ee785afe"
+content_hash = "sha256:ff9fbc3702aa72a482278cda7ef68dbff9c97cfefe9526851bbe071e6a6280f0"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.15"
+
+[[package]]
+name = "actionlint-py"
+version = "1.7.12.24"
+requires_python = ">=3.7"
+summary = "Python wrapper around invoking actionlint (https://github.com/rhysd/actionlint)"
+groups = ["dev"]
+files = [
+    {file = "actionlint_py-1.7.12.24.tar.gz", hash = "sha256:7571b0724fde79b2572b98b2b53792c470249d4db29951b57fc49b9cd3eaf11e"},
+]
 
 [[package]]
 name = "altgraph"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "types-requests>=2.32.0.20250515",
     "pytest-mock>=3.14.0",
     "jsonschema>=4.26.0",
+    "actionlint-py>=1.7.12.24",
 ]
 
 [project.urls]
@@ -105,10 +106,11 @@ format        = { composite = ["format:py", "format:yaml"] }
 "format:py"   = { shell = "autopep8 --recursive --in-place scripts src tests --verbose && python scripts/post_autopep8.py scripts src tests" }
 "format:yaml" = "yamlfix scripts/ src/ tests/"
 
-lint = { composite = ["lint:ruff", "lint:mypy", "lint:pyright"] }
+lint = { composite = ["lint:ruff", "lint:mypy", "lint:pyright", "lint:actions"] }
 "lint:ruff"    = "ruff check --preview"
 "lint:mypy"    = "mypy"
 "lint:pyright" = "basedpyright"
+"lint:actions" = "actionlint"
 "lint:fix"     = {shell = "ruff check --preview --fix" }
 
 # tests


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #1077
- Fixes GHCR `:latest` publishing so the amd64 and arm64 Docker matrix jobs no longer race by pushing the same single-arch tag.

## 📋 Changes Summary

- Publish architecture-specific Docker image tags from the Ubuntu matrix jobs (`:latest-amd64` / `:latest-arm64`).
- Add a dependent `publish-docker-manifest` job that stitches those per-arch tags into a multi-arch `:latest` manifest using Docker Buildx.
- Add workflow-level concurrency so `main` publishing runs are serialized while non-main runs cancel older attempts.
- Add `actionlint-py` as a PDM-managed dev dependency and include `actionlint` in `pdm run lint`.
- Fix existing workflow shellcheck findings reported by `actionlint`.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [ ] I have updated documentation where necessary. — N/A, CI-only behavior and dev dependency wiring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow serialization and concurrent run handling for improved build efficiency.
  * Enhanced Docker publishing to support multi-architecture image manifest generation.
  * Added GitHub Actions workflow validation to the development tooling pipeline.
  * Updated development dependencies and extended linting script coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->