### PR TITLE
fix: redact contact zipcode from logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,13 @@ Before making non-trivial changes, review:
 Add or update tests when changing observable behavior, business logic, error handling, or fixing bugs.
 
 Tests may be skipped for:
+
 - log-only wording changes
 - diagnostic-only changes with no behavior impact
 - trivial wrappers already covered elsewhere
 
 Testing rules:
+
 - Test behavior, not implementation details.
 - Prefer extending existing tests over adding duplicates.
 - If you touch nearby tests, clean up obvious stale or duplicate coverage when it is cheap and in scope.

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2607,7 +2607,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             try:
                 await self.web_input(By.ID, "ad-zip-code", str(contact.zipcode))
             except TimeoutError as ex:
-                LOG.warning("Could not set contact zipcode: %s (%s)", contact.zipcode, ex)
+                LOG.warning("Could not set contact zipcode: %s", ex)
                 raise TimeoutError(_("Failed to set contact zipcode: %s") % contact.zipcode) from ex
 
             if contact.location:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -251,7 +251,7 @@ kleinanzeigen_bot/__init__.py:
   __set_contact_fields:
     "Could not set contact street.": "Kontaktstraße konnte nicht gesetzt werden."
     "Could not set contact name.": "Kontaktname konnte nicht gesetzt werden."
-    "Could not set contact zipcode: %s (%s)": "Kontakt-PLZ konnte nicht gesetzt werden: %s (%s)"
+    "Could not set contact zipcode: %s": "Kontakt-PLZ konnte nicht gesetzt werden: %s"
     "Failed to set contact zipcode: %s": "Kontakt-PLZ konnte nicht gesetzt werden: %s"
     "Could not set contact phone despite visible phone field: %s": "Telefonnummer konnte trotz sichtbarem Feld nicht gesetzt werden: %s"
     ? "Phone number field not present on page. This is expected for many private accounts; commercial accounts may still support phone numbers."


### PR DESCRIPTION
## ℹ️ Description
Fixes CodeQL alert 132 (`py/clear-text-logging-sensitive-data`) by avoiding clear-text logging of the configured contact ZIP code when the contact ZIP field cannot be filled.

- Link to the related issue(s): Code scanning alert 132
- The warning log now keeps the timeout/error context without writing the user-provided ZIP code to logs.

## 📋 Changes Summary

- Redacted `contact.zipcode` from the contact ZIP-code failure warning.
- Updated the German translation entry for the changed log message.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

Validation performed:

- `pdm run format`
- `pdm run lint`
- `pdm run pytest tests/unit/test_translations.py -q`
- `pdm run test` -> 1176 passed, 4 skipped

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted testing guidance section
  
* **Chores**
  * Updated error logging in contact field handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->