### PR TITLE
fix: rename nodriver hook logs

### DIFF
--- a/scripts/fix_nodriver.py
+++ b/scripts/fix_nodriver.py
@@ -45,7 +45,7 @@ def _fix_network_encoding(path:Path) -> str:
     try:
         raw = path.read_bytes()
     except OSError as exc:
-        print(f"fix_nodriver_encoding: cannot read {path}: {exc}", file = sys.stderr)
+        print(f"fix_nodriver: cannot read {path}: {exc}", file = sys.stderr)
         sys.exit(1)
 
     bad = b"(\xb1Inf)"
@@ -55,7 +55,7 @@ def _fix_network_encoding(path:Path) -> str:
             return "already-ok"
         except UnicodeDecodeError as exc:
             print(
-                f"fix_nodriver_encoding: {path}: unexpected content: {exc}",
+                f"fix_nodriver: {path}: unexpected content: {exc}",
                 file = sys.stderr,
             )
             sys.exit(1)
@@ -67,7 +67,7 @@ def _fix_network_encoding(path:Path) -> str:
     try:
         fixed.decode("utf-8")
     except UnicodeDecodeError as exc:
-        print(f"fix_nodriver_encoding: {path}: invalid UTF-8: {exc}", file = sys.stderr)
+        print(f"fix_nodriver: {path}: invalid UTF-8: {exc}", file = sys.stderr)
         sys.exit(1)
     path.write_bytes(fixed)
     return "fixed"
@@ -141,7 +141,7 @@ def _fix_connection_send(path:Path) -> str:
     try:
         text = path.read_text("utf-8")
     except OSError as exc:
-        print(f"fix_nodriver_encoding: cannot read {path}: {exc}", file = sys.stderr)
+        print(f"fix_nodriver: cannot read {path}: {exc}", file = sys.stderr)
         sys.exit(1)
 
     if "for _retry in range(2):" in text:
@@ -149,12 +149,12 @@ def _fix_connection_send(path:Path) -> str:
 
     start = text.find(_SEND_START)
     if start == -1:
-        print("fix_nodriver_encoding: send start marker not found", file = sys.stderr)
+        print("fix_nodriver: send start marker not found", file = sys.stderr)
         sys.exit(1)
 
     err = text.find(_SEND_ERR_END, start)
     if err == -1:
-        print("fix_nodriver_encoding: send error end not found", file = sys.stderr)
+        print("fix_nodriver: send error end not found", file = sys.stderr)
         sys.exit(1)
 
     err_end = text.index("\n", err)
@@ -174,12 +174,12 @@ def main() -> int:
     ]:
         path = _locate_file(rel)
         if path is None:
-            print(f"fix_nodriver_encoding: nodriver not installed, cannot patch {rel}", file = sys.stderr)
+            print(f"fix_nodriver: nodriver not installed, cannot patch {rel}", file = sys.stderr)
             return 1
         if not path.is_file():
-            print(f"fix_nodriver_encoding: {path} not found, cannot patch", file = sys.stderr)
+            print(f"fix_nodriver: {path} not found, cannot patch", file = sys.stderr)
             return 1
-        print(f"fix_nodriver_encoding: {path} -> {fix(path)}")
+        print(f"fix_nodriver: {path} -> {fix(path)}")
     return 0
 
 


### PR DESCRIPTION
## ℹ️ Description
Update the post-install hook output to use the renamed `fix_nodriver` prefix instead of the old `fix_nodriver_encoding` string.

## 📋 Changes Summary
- Renamed the emitted log/prefix text in `scripts/fix_nodriver.py`.
- Kept the hook behavior unchanged.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [ ] I have formatted the code (`pdm run format`).
- [ ] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized error and diagnostic messages during post-installation setup for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->