### PR TITLE
refactor: clean up package-root price imports

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -35,14 +35,7 @@ from .model.ad_model import (
 from .model.ad_model import (
     AdUpdateStrategy as AdUpdateStrategy,
 )
-from .model.ad_model import (
-    calculate_auto_price as calculate_auto_price,
-)
-from .model.ad_model import (
-    calculate_auto_price_with_trace as calculate_auto_price_with_trace,
-)
 from .model.config_model import DEFAULT_DOWNLOAD_DIR, Config
-from .price_reduction import _log_auto_price_reduction_preview
 from .update_checker import UpdateChecker
 from .utils import diagnostics as _diagnostics
 from .utils import dicts as _dicts
@@ -272,10 +265,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                         for ad_file, ad_cfg, _ad_cfg_orig in ads:
                             ad_file_relative = _ad_state.relative_ad_path(ad_file, self.config_file_path)
                             publish_decision = _price_reduction.evaluate_auto_price_reduction(ad_cfg, ad_file_relative, mode = AdUpdateStrategy.REPLACE)
-                            _log_auto_price_reduction_preview(ad_file_relative, publish_decision)
+                            _price_reduction.log_auto_price_reduction_preview(ad_file_relative, publish_decision)
 
                             update_decision = _price_reduction.evaluate_auto_price_reduction(ad_cfg, ad_file_relative, mode = AdUpdateStrategy.MODIFY)
-                            _log_auto_price_reduction_preview(ad_file_relative, update_decision)
+                            _price_reduction.log_auto_price_reduction_preview(ad_file_relative, update_decision)
                     LOG.info("############################################")
                     LOG.info("DONE: No configuration errors found.")
                     LOG.info("############################################")

--- a/src/kleinanzeigen_bot/price_reduction.py
+++ b/src/kleinanzeigen_bot/price_reduction.py
@@ -6,10 +6,10 @@
 
 __all__ = [
     "PriceReductionDecision",
-    "_log_auto_price_reduction_preview",
     "apply_auto_price_reduction",
     "evaluate_auto_price_reduction",
     "is_auto_price_reduction_due",
+    "log_auto_price_reduction_preview",
 ]
 
 from dataclasses import dataclass
@@ -336,7 +336,7 @@ def is_auto_price_reduction_due(ad_cfg:Ad, ad_file_relative:str) -> bool:
     return True
 
 
-def _log_auto_price_reduction_preview(ad_file_relative:str, decision:PriceReductionDecision) -> None:
+def log_auto_price_reduction_preview(ad_file_relative:str, decision:PriceReductionDecision) -> None:
     mode_label = _("publish") if decision.mode == AdUpdateStrategy.REPLACE else _("update")
     if not decision.enabled:
         LOG.info("Auto price reduction preview for [%s] (%s): disabled", ad_file_relative, mode_label)

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -379,7 +379,7 @@ kleinanzeigen_bot/price_reduction.py:
   is_auto_price_reduction_due:
     "Pending auto price reduction detected for ad [%s]": "Ausstehende automatische Preisreduzierung für Anzeige [%s] erkannt"
 
-  _log_auto_price_reduction_preview:
+  log_auto_price_reduction_preview:
     "publish": "veröffentlichen"
     "update": "aktualisieren"
     "Auto price reduction preview for [%s] (%s): disabled": "Vorschau automatische Preisreduzierung für [%s] (%s): deaktiviert"


### PR DESCRIPTION
## Description

Clean up the remaining package-root price-reduction drift before the next CLI/config extraction step.

- Related issue(s): None.
- Motivation: make price-reduction preview logging a normal module-level API and stop exporting unused price calculation helpers from the package root.

## Changes Summary

- Removed unused package-root re-exports for `calculate_auto_price` and `calculate_auto_price_with_trace`.
- Renamed `_log_auto_price_reduction_preview` to `log_auto_price_reduction_preview` and exported the public name from `price_reduction`.
- Updated verify preview calls to access the logger through the `price_reduction` module alias.
- Updated the German translation key for the renamed preview logger.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (adds new functionality without breaking existing usage)
- [ ] Breaking change (changes that might break existing user setups, scripts, or configurations)

Internal refactor only; none of the listed change types apply.

## Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-price reduction preview logging now consistently displays for both ad publishing and update decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->