### PR TITLE
feat: add preserve-local-settings toggle for download

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -189,6 +189,7 @@ download:
   folder_name_template: "ad_{id}_{title}"  # placeholders: {id}, {title}; each placeholder may appear at most once; must include {id}
   ad_file_name_template: "ad_{id}"  # placeholders: {id}, {title}; each placeholder may appear at most once; must include {id}
   rename_existing_folders: false  # if true, rename existing folders without titles to include titles (default: false)
+  preserve_local_settings: true  # if true, preserve local-only settings when re-downloading an already saved ad (default: true)
 ```
 
 - `download.dir` controls where `download` writes ad files.
@@ -202,6 +203,7 @@ download:
 - `download.ad_file_name_template`: each placeholder may appear at most once.
 - `download.ad_file_name_template` must include `{id}` so downloaded filenames remain stable and unique.
 - `download.folder_name_max_length` limits folder names only; downloaded file stems use a separate filename budget.
+- `download.preserve_local_settings` (default: `true`) keeps local-only per-ad settings (`auto_price_reduction`, `republication_interval`, `repost_count`, `price_reduction_count`) when re-downloading an already saved ad. Set to `false` to reset these to defaults on re-download.
 
 Assume this sample ad:
 

--- a/docs/config.default.yaml
+++ b/docs/config.default.yaml
@@ -158,6 +158,9 @@ download:
   # if true, rename existing folders without titles to include titles (default: false)
   rename_existing_folders: false
 
+  # if true, preserves local-only settings (auto_price_reduction, republication_interval, repost_count, price_reduction_count) when re-downloading an already saved ad. Useful for picking up live changes without losing local configuration.
+  preserve_local_settings: true
+
 # ################################################################################
 publishing:
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -562,6 +562,12 @@
           "description": "if true, rename existing folders without titles to include titles (default: false)",
           "title": "Rename Existing Folders",
           "type": "boolean"
+        },
+        "preserve_local_settings": {
+          "default": true,
+          "description": "if true, preserves local-only settings (auto_price_reduction, republication_interval, repost_count, price_reduction_count) when re-downloading an already saved ad. Useful for picking up live changes without losing local configuration.",
+          "title": "Preserve Local Settings",
+          "type": "boolean"
         }
       },
       "title": "DownloadConfig",

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -196,6 +196,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         self.ads_selector = parsed.ads_selector
         self._ads_selector_explicit = parsed.ads_selector_explicit
         self.keep_old_ads = parsed.keep_old_ads
+        self._preserve_local_settings = parsed.preserve_local_settings
         self._config_arg = parsed.config_arg
         self._workspace_mode_arg = cast(_xdg_paths.InstallationMode, parsed.workspace_mode) if parsed.workspace_mode else None
         self._logfile_arg = parsed.logfile_arg
@@ -377,6 +378,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                             sys.exit(2)
                         self.ads_selector = "new"
                     _bootstrap_runtime()
+                    if self._preserve_local_settings:
+                        self.config.download.preserve_local_settings = True
                     # Check for updates on startup
                     checker = UpdateChecker(self.config, self._update_check_state_path)
                     checker.check_for_updates()

--- a/src/kleinanzeigen_bot/cli.py
+++ b/src/kleinanzeigen_bot/cli.py
@@ -110,7 +110,7 @@ def _help_text() -> str:
                     * <id(s)>: Gibt bestimmte Anzeigen-IDs an, z. B. "--ads=1,2,3"
               --force           - Alias für '--ads=all'
               --keep-old        - Verhindert das Löschen alter Anzeigen bei erneuter Veröffentlichung
-              --preserve-local-settings - Behält lokale Einstellungen bei erneutem Download einer bereits gespeicherten Anzeige bei
+              --preserve-local-settings - Erzwingt das Beibehalten lokaler Einstellungen bei erneutem Download (überschreibt config-Wert false)
               --config=<PATH>   - Pfad zur YAML- oder JSON-Konfigurationsdatei (ändert den Workspace-Modus nicht implizit)
               --workspace-mode=portable|xdg - Überschreibt den Workspace-Modus für diesen Lauf
               --logfile=<PATH>  - Pfad zur Protokolldatei (STANDARD: vom aktiven Workspace-Modus abhängig)
@@ -164,7 +164,7 @@ def _help_text() -> str:
                 * <id(s)>: specify ad IDs to extend, e.g. "--ads=1,2,3"
           --force           - alias for '--ads=all'
           --keep-old        - don't delete old ads on republication
-          --preserve-local-settings - preserve local-only settings when re-downloading an already saved ad
+          --preserve-local-settings - force-enable preservation of local-only settings on re-download (overrides config value of false)
           --config=<PATH>   - path to the config YAML or JSON file (does not implicitly change workspace mode)
           --workspace-mode=portable|xdg - overrides workspace mode for this run
           --logfile=<PATH>  - path to the logfile (DEFAULT: depends on active workspace mode)

--- a/src/kleinanzeigen_bot/cli.py
+++ b/src/kleinanzeigen_bot/cli.py
@@ -110,6 +110,7 @@ def _help_text() -> str:
                     * <id(s)>: Gibt bestimmte Anzeigen-IDs an, z. B. "--ads=1,2,3"
               --force           - Alias für '--ads=all'
               --keep-old        - Verhindert das Löschen alter Anzeigen bei erneuter Veröffentlichung
+              --preserve-local-settings - Behält lokale Einstellungen bei erneutem Download einer bereits gespeicherten Anzeige bei
               --config=<PATH>   - Pfad zur YAML- oder JSON-Konfigurationsdatei (ändert den Workspace-Modus nicht implizit)
               --workspace-mode=portable|xdg - Überschreibt den Workspace-Modus für diesen Lauf
               --logfile=<PATH>  - Pfad zur Protokolldatei (STANDARD: vom aktiven Workspace-Modus abhängig)
@@ -163,6 +164,7 @@ def _help_text() -> str:
                 * <id(s)>: specify ad IDs to extend, e.g. "--ads=1,2,3"
           --force           - alias for '--ads=all'
           --keep-old        - don't delete old ads on republication
+          --preserve-local-settings - preserve local-only settings when re-downloading an already saved ad
           --config=<PATH>   - path to the config YAML or JSON file (does not implicitly change workspace mode)
           --workspace-mode=portable|xdg - overrides workspace mode for this run
           --logfile=<PATH>  - path to the logfile (DEFAULT: depends on active workspace mode)

--- a/src/kleinanzeigen_bot/cli.py
+++ b/src/kleinanzeigen_bot/cli.py
@@ -43,6 +43,7 @@ class ParsedArgs:
     ads_selector:str = "due"
     ads_selector_explicit:bool = False
     keep_old_ads:bool = False
+    preserve_local_settings:bool = False
     config_arg:str | None = None
     config_file_path:str | None = None
     logfile_arg:str | None = None
@@ -182,7 +183,7 @@ def parse_args(args:Sequence[str]) -> ParsedArgs:
         options, arguments = getopt.gnu_getopt(
             list(args)[1:],
             "hv",
-            ["ads=", "config=", "force", "help", "keep-old", "logfile=", "lang=", "verbose", "workspace-mode="],
+            ["ads=", "config=", "force", "help", "keep-old", "logfile=", "lang=", "preserve-local-settings", "verbose", "workspace-mode="],
         )
     except getopt.error as ex:
         LOG.error(ex.msg)
@@ -214,6 +215,8 @@ def parse_args(args:Sequence[str]) -> ParsedArgs:
                 parsed.ads_selector_explicit = True
             case "--keep-old":
                 parsed.keep_old_ads = True
+            case "--preserve-local-settings":
+                parsed.preserve_local_settings = True
             case "--lang":
                 set_current_locale(Locale.of(value))
             case "-v" | "--verbose":

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -333,8 +333,10 @@ class AdExtractor(WebScrapingMixin):
                         preserved["price_reduction_count"] = existing_data["price_reduction_count"]
 
                     if preserved:
-                        # Validate on a copy before committing to ad_cfg
-                        candidate = ad_cfg.model_copy(update = preserved)
+                        # Build a fully validated instance from merged data,
+                        # then commit only validated attributes back to ad_cfg.
+                        merged = {**ad_cfg.model_dump(), **preserved}
+                        candidate = ad_cfg.model_validate(merged)
                         candidate.content_hash = candidate.to_ad(self.config.ad_defaults).update_content_hash().content_hash
                         for key in preserved:
                             setattr(ad_cfg, key, getattr(candidate, key))

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -305,6 +305,13 @@ class AdExtractor(WebScrapingMixin):
         # Preserve local-only settings when re-downloading an existing ad
         if self.config.download.preserve_local_settings and await files.exists(final_dir):
             existing_yaml_path = final_dir / f"{ad_file_stem}.yaml"
+            # Fall back to glob if the rendered stem does not match (e.g. title changed)
+            if not await files.exists(existing_yaml_path):
+                yaml_candidates = await loop.run_in_executor(
+                    None, lambda: sorted(final_dir.glob("*.yaml"))
+                )
+                if len(yaml_candidates) == 1:
+                    existing_yaml_path = yaml_candidates[0]
             if await files.exists(existing_yaml_path):
                 try:
                     existing_data = await loop.run_in_executor(

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -312,13 +312,19 @@ class AdExtractor(WebScrapingMixin):
                     )
                     # Collect candidate local-only values without mutating ad_cfg yet
                     # to avoid saving partially corrupted state if validation fails.
-                    # dicts.load_dict returns ruamel CommentedMap; convert to plain
-                    # dict and validate explicitly since model_copy won't coerce nested models.
+                    # dicts.load_dict returns ruamel CommentedMap; auto_price_reduction is
+                    # validated independently so a malformed APR doesn't block other fields.
                     preserved:dict[str, Any] = {}
+
                     if "auto_price_reduction" in existing_data:
-                        preserved["auto_price_reduction"] = AutoPriceReductionConfig.model_validate(
-                            dict(existing_data["auto_price_reduction"])
-                        )
+                        try:
+                            preserved["auto_price_reduction"] = AutoPriceReductionConfig.model_validate(
+                                dict(existing_data["auto_price_reduction"])
+                            )
+                        except Exception as apr_ex:
+                            LOG.warning(
+                                "Could not preserve auto_price_reduction from existing ad %d: %s", ad_id, apr_ex
+                            )
                     if "republication_interval" in existing_data:
                         preserved["republication_interval"] = existing_data["republication_interval"]
                     if "repost_count" in existing_data:

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -19,7 +19,7 @@ from typing import Any, Final
 from kleinanzeigen_bot.model.ad_model import ContactPartial
 
 from .model.ad_model import OPTION_NAME_BY_CARRIER_CODE, AdPartial, validate_condition_api_mapping
-from .model.config_model import Config
+from .model.config_model import AutoPriceReductionConfig, Config
 from .utils import dicts, files, i18n, loggers, misc, reflect
 from .utils.web_scraping_mixin import Browser, By, Element, WebScrapingMixin
 
@@ -301,6 +301,42 @@ class AdExtractor(WebScrapingMixin):
         )
 
         loop = asyncio.get_running_loop()
+
+        # Preserve local-only settings when re-downloading an existing ad
+        if self.config.download.preserve_local_settings and await files.exists(final_dir):
+            existing_yaml_path = final_dir / f"{ad_file_stem}.yaml"
+            if await files.exists(existing_yaml_path):
+                try:
+                    existing_data = await loop.run_in_executor(
+                        None, lambda: dicts.load_dict(str(existing_yaml_path), content_label = f"existing ad {ad_id}")
+                    )
+                    # Collect candidate local-only values without mutating ad_cfg yet
+                    # to avoid saving partially corrupted state if validation fails.
+                    # dicts.load_dict returns ruamel CommentedMap; convert to plain
+                    # dict and validate explicitly since model_copy won't coerce nested models.
+                    preserved:dict[str, Any] = {}
+                    if "auto_price_reduction" in existing_data:
+                        preserved["auto_price_reduction"] = AutoPriceReductionConfig.model_validate(
+                            dict(existing_data["auto_price_reduction"])
+                        )
+                    if "republication_interval" in existing_data:
+                        preserved["republication_interval"] = existing_data["republication_interval"]
+                    if "repost_count" in existing_data:
+                        preserved["repost_count"] = existing_data["repost_count"]
+                    if "price_reduction_count" in existing_data:
+                        preserved["price_reduction_count"] = existing_data["price_reduction_count"]
+
+                    if preserved:
+                        # Validate on a copy before committing to ad_cfg
+                        candidate = ad_cfg.model_copy(update = preserved)
+                        candidate.content_hash = candidate.to_ad(self.config.ad_defaults).update_content_hash().content_hash
+                        for key in preserved:
+                            setattr(ad_cfg, key, getattr(candidate, key))
+                        ad_cfg.content_hash = candidate.content_hash
+                        LOG.info("Preserved local-only settings from existing ad %d.", ad_id)
+                except Exception as ex:
+                    LOG.warning("Could not preserve local settings from existing ad %d: %s", ad_id, ex)
+
         backup_dir = final_dir.with_name(f"{_BACKUP_DIR_PREFIX}{ad_file_stem}")
         final_yaml_path = final_dir / f"{ad_file_stem}.yaml"
         backup_created_by_us = False

--- a/src/kleinanzeigen_bot/model/config_model.py
+++ b/src/kleinanzeigen_bot/model/config_model.py
@@ -176,6 +176,14 @@ class DownloadConfig(ContextualModel):
         default = False,
         description = "if true, rename existing folders without titles to include titles (default: false)",
     )
+    preserve_local_settings:bool = Field(
+        default = True,
+        description = (
+            "if true, preserves local-only settings (auto_price_reduction, republication_interval, "
+            "repost_count, price_reduction_count) when re-downloading an already saved ad. "
+            "Useful for picking up live changes without losing local configuration."
+        ),
+    )
 
     @field_validator("dir")
     @classmethod

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -413,6 +413,8 @@ kleinanzeigen_bot/extract.py:
     "Could not remove backup directory %s: %s": "Konnte Sicherungsverzeichnis %s nicht entfernen: %s"
     "Failed to restore backup directory %s to %s after download failure: %s": "Konnte Sicherungsverzeichnis %s nach %s nach einem Download-Fehler nicht wiederherstellen: %s"
     "Could not remove staging directory %s: %s": "Konnte Staging-Verzeichnis %s nicht entfernen: %s"
+    "Preserved local-only settings from existing ad %d.": "Lokale Einstellungen von bestehender Anzeige %d beibehalten."
+    "Could not preserve local settings from existing ad %d: %s": "Konnte lokale Einstellungen von bestehender Anzeige %d nicht beibehalten: %s"
 
   _download_and_save_image_sync:
     "Failed to download image %s: %s": "Fehler beim Herunterladen des Bildes %s: %s"

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -415,6 +415,7 @@ kleinanzeigen_bot/extract.py:
     "Could not remove staging directory %s: %s": "Konnte Staging-Verzeichnis %s nicht entfernen: %s"
     "Preserved local-only settings from existing ad %d.": "Lokale Einstellungen von bestehender Anzeige %d beibehalten."
     "Could not preserve local settings from existing ad %d: %s": "Konnte lokale Einstellungen von bestehender Anzeige %d nicht beibehalten: %s"
+    "Could not preserve auto_price_reduction from existing ad %d: %s": "Konnte auto_price_reduction von bestehender Anzeige %d nicht beibehalten: %s"
 
   _download_and_save_image_sync:
     "Failed to download image %s: %s": "Fehler beim Herunterladen des Bildes %s: %s"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -109,6 +109,12 @@ class TestCliParseArgs:
 
         assert exc_info.value.code == 2
 
+    def test_parses_preserve_local_settings_flag(self) -> None:
+        parsed = cli.parse_args(["script.py", "--preserve-local-settings", "download"])
+
+        assert parsed.preserve_local_settings is True
+        assert parsed.command == "download"
+
 
 class TestCliHelpText:
     def test_show_help_uses_german_text(self, capsys:pytest.CaptureFixture[str], monkeypatch:pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2788,9 +2788,16 @@ class TestAdExtractorDownload:
         assert rendered.endswith("_12345")
         assert len(rendered) <= 20
 
+    @pytest.mark.parametrize(
+        "rendered_stem",
+        [
+            "ad_12345",            # matches saved filename — direct lookup
+            "ad_12345_newtitle",   # mismatched — triggers glob fallback
+        ],
+    )
     @pytest.mark.asyncio
     async def test_download_ad_preserves_local_settings_when_enabled(
-        self, extractor:extract_module.AdExtractor, tmp_path:Path
+        self, extractor:extract_module.AdExtractor, tmp_path:Path, rendered_stem:str
     ) -> None:
         """Re-downloading an existing ad with preserve_local_settings=True keeps local counters and overrides."""
         download_base = tmp_path / "downloaded-ads"
@@ -2823,12 +2830,12 @@ class TestAdExtractorDownload:
                 _create_test_ad_partial(),
                 staging_dir,
                 final_dir,
-                "ad_12345",
+                rendered_stem,
             )
 
             await extractor.download_ad(12345)
 
-        saved_data = await asyncio.to_thread(dicts.load_dict, str(final_dir / "ad_12345.yaml"))
+        saved_data = await asyncio.to_thread(dicts.load_dict, str(final_dir / f"{rendered_stem}.yaml"))
         assert saved_data["title"] == "Test Advertisement Title"
         assert saved_data["description"] == "Test Description"
         assert saved_data["category"] == "Dienstleistungen"

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -18,6 +18,7 @@ from ruamel.yaml import YAML
 import kleinanzeigen_bot.extract as extract_module
 from kleinanzeigen_bot.model.ad_model import OPTION_NAME_BY_CARRIER_CODE, AdPartial, ContactPartial
 from kleinanzeigen_bot.model.config_model import Config, DownloadConfig
+from kleinanzeigen_bot.utils import dicts
 from kleinanzeigen_bot.utils.web_scraping_mixin import Browser, By, Element
 
 SCHEMA_PATH:Final[Path] = Path(__file__).resolve().parents[2] / "schemas" / "ad.schema.json"
@@ -2786,6 +2787,58 @@ class TestAdExtractorDownload:
         assert "12345" in rendered
         assert rendered.endswith("_12345")
         assert len(rendered) <= 20
+
+    @pytest.mark.asyncio
+    async def test_download_ad_preserves_local_settings_when_enabled(
+        self, extractor:extract_module.AdExtractor, tmp_path:Path
+    ) -> None:
+        """Re-downloading an existing ad with preserve_local_settings=True keeps local counters and overrides."""
+        download_base = tmp_path / "downloaded-ads"
+        final_dir = download_base / "ad_12345_Test Advertisement Title"
+        staging_dir = download_base / ".tmp-ad_12345"
+
+        extractor.download_dir = download_base
+        final_dir.mkdir(parents = True)
+        staging_dir.mkdir(parents = True)
+
+        # Write an existing ad YAML with local-only fields set to non-default values
+        existing_yaml = final_dir / "ad_12345.yaml"
+        existing_data:dict[str, Any] = {
+            "title": "Old Advertisement Title",
+            "description": "Old description text",
+            "category": "Dienstleistungen",
+            "price": 100,
+            "price_type": "FIXED",
+            "repost_count": 5,
+            "price_reduction_count": 3,
+            "auto_price_reduction": {"enabled": True, "strategy": "PERCENTAGE", "amount": 10, "min_price": 1},
+            "republication_interval": 14,
+        }
+        await asyncio.get_running_loop().run_in_executor(
+            None, lambda: dicts.save_dict(str(existing_yaml), existing_data)
+        )
+
+        extractor.config.download.preserve_local_settings = True
+
+        with patch.object(extractor, "_extract_ad_page_info_with_directory_handling", new_callable = AsyncMock) as mock_extract:
+            mock_extract.return_value = (
+                _create_test_ad_partial(),
+                staging_dir,
+                final_dir,
+                "ad_12345",
+            )
+
+            await extractor.download_ad(12345)
+
+        saved_data = await asyncio.get_running_loop().run_in_executor(
+            None, lambda: dicts.load_dict(str(final_dir / "ad_12345.yaml"))
+        )
+        assert saved_data["repost_count"] == 5
+        assert saved_data["price_reduction_count"] == 3
+        assert saved_data["auto_price_reduction"]["enabled"] is True
+        assert saved_data["republication_interval"] == 14
+        assert isinstance(saved_data.get("content_hash"), str)
+        assert len(saved_data["content_hash"]) == 64
 
 
 class TestRenderDownloadNameWithBudgetWarnings:

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2895,6 +2895,53 @@ class TestAdExtractorDownload:
         assert not staging_dir.exists()
         assert any("Could not preserve local settings" in message for message in caplog.messages)
 
+    @pytest.mark.asyncio
+    async def test_download_ad_preserves_other_fields_when_apr_invalid(
+        self, extractor:extract_module.AdExtractor, tmp_path:Path
+    ) -> None:
+        """Malformed auto_price_reduction skips only that field; counters still preserved."""
+        download_base = tmp_path / "downloaded-ads"
+        final_dir = download_base / "ad_12345_Test Advertisement Title"
+        staging_dir = download_base / ".tmp-ad_12345"
+
+        extractor.download_dir = download_base
+        final_dir.mkdir(parents = True)
+        staging_dir.mkdir(parents = True)
+
+        # Write existing YAML with a malformed auto_price_reduction
+        existing_yaml = final_dir / "ad_12345.yaml"
+        existing_data:dict[str, Any] = {
+            "title": "Old Advertisement Title",
+            "description": "Old description text",
+            "category": "Dienstleistungen",
+            "price": 100,
+            "price_type": "FIXED",
+            "repost_count": 5,
+            "price_reduction_count": 3,
+            "republication_interval": 14,
+            "auto_price_reduction": {"enabled": True},  # missing required fields → validation fails
+        }
+        await asyncio.to_thread(dicts.save_dict, str(existing_yaml), existing_data)
+
+        extractor.config.download.preserve_local_settings = True
+
+        with patch.object(extractor, "_extract_ad_page_info_with_directory_handling", new_callable = AsyncMock) as mock_extract:
+            mock_extract.return_value = (
+                _create_test_ad_partial(),
+                staging_dir,
+                final_dir,
+                "ad_12345",
+            )
+
+            await extractor.download_ad(12345)
+
+        saved_data = await asyncio.to_thread(dicts.load_dict, str(final_dir / "ad_12345.yaml"))
+        assert saved_data["repost_count"] == 5
+        assert saved_data["price_reduction_count"] == 3
+        assert saved_data["republication_interval"] == 14
+        # auto_price_reduction was not preserved (malformed), so it stays at the fresh download's value
+        assert saved_data.get("auto_price_reduction") is None
+
 
 class TestRenderDownloadNameWithBudgetWarnings:
     """Tests for truncation warnings in download name rendering."""

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2838,6 +2838,48 @@ class TestAdExtractorDownload:
         assert isinstance(saved_data.get("content_hash"), str)
         assert len(saved_data["content_hash"]) == 64
 
+    @pytest.mark.asyncio
+    async def test_download_ad_logs_warning_when_preservation_fails(
+        self, extractor:extract_module.AdExtractor, tmp_path:Path, caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """When preservation validation fails, a warning is logged and the download proceeds normally."""
+        download_base = tmp_path / "downloaded-ads"
+        final_dir = download_base / "ad_12345_Test Advertisement Title"
+        staging_dir = download_base / ".tmp-ad_12345"
+
+        extractor.download_dir = download_base
+        final_dir.mkdir(parents = True)
+        staging_dir.mkdir(parents = True)
+
+        # Write an existing YAML so preservation is triggered
+        existing_yaml = final_dir / "ad_12345.yaml"
+        existing_data:dict[str, Any] = {
+            "title": "Old Advertisement Title",
+            "description": "Old description text",
+            "category": "Dienstleistungen",
+            "price": 100,
+            "price_type": "FIXED",
+            "repost_count": 5,
+        }
+        await asyncio.to_thread(dicts.save_dict, str(existing_yaml), existing_data)
+
+        extractor.config.download.preserve_local_settings = True
+
+        with (
+            patch.object(extractor, "_extract_ad_page_info_with_directory_handling", new_callable = AsyncMock) as mock_extract,
+            patch.object(AdPartial, "model_copy", side_effect = ValueError("validation failed")),
+        ):
+            mock_extract.return_value = (
+                _create_test_ad_partial(),
+                staging_dir,
+                final_dir,
+                "ad_12345",
+            )
+
+            await extractor.download_ad(12345)
+
+        assert any("Could not preserve local settings" in message for message in caplog.messages)
+
 
 class TestRenderDownloadNameWithBudgetWarnings:
     """Tests for truncation warnings in download name rendering."""

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2814,9 +2814,7 @@ class TestAdExtractorDownload:
             "auto_price_reduction": {"enabled": True, "strategy": "PERCENTAGE", "amount": 10, "min_price": 1},
             "republication_interval": 14,
         }
-        await asyncio.get_running_loop().run_in_executor(
-            None, lambda: dicts.save_dict(str(existing_yaml), existing_data)
-        )
+        await asyncio.to_thread(dicts.save_dict, str(existing_yaml), existing_data)
 
         extractor.config.download.preserve_local_settings = True
 
@@ -2830,9 +2828,7 @@ class TestAdExtractorDownload:
 
             await extractor.download_ad(12345)
 
-        saved_data = await asyncio.get_running_loop().run_in_executor(
-            None, lambda: dicts.load_dict(str(final_dir / "ad_12345.yaml"))
-        )
+        saved_data = await asyncio.to_thread(dicts.load_dict, str(final_dir / "ad_12345.yaml"))
         assert saved_data["repost_count"] == 5
         assert saved_data["price_reduction_count"] == 3
         assert saved_data["auto_price_reduction"]["enabled"] is True

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2806,9 +2806,9 @@ class TestAdExtractorDownload:
         existing_data:dict[str, Any] = {
             "title": "Old Advertisement Title",
             "description": "Old description text",
-            "category": "Dienstleistungen",
-            "price": 100,
-            "price_type": "FIXED",
+            "category": "Garten & Freizeit > Camping",
+            "price": 200,
+            "price_type": "NEGOTIABLE",
             "repost_count": 5,
             "price_reduction_count": 3,
             "auto_price_reduction": {"enabled": True, "strategy": "PERCENTAGE", "amount": 10, "min_price": 1},
@@ -2831,6 +2831,8 @@ class TestAdExtractorDownload:
         saved_data = await asyncio.to_thread(dicts.load_dict, str(final_dir / "ad_12345.yaml"))
         assert saved_data["title"] == "Test Advertisement Title"
         assert saved_data["description"] == "Test Description"
+        assert saved_data["category"] == "Dienstleistungen"
+        assert saved_data["price"] == 100
         assert saved_data["repost_count"] == 5
         assert saved_data["price_reduction_count"] == 3
         assert saved_data["auto_price_reduction"]["enabled"] is True
@@ -2865,12 +2867,15 @@ class TestAdExtractorDownload:
 
         extractor.config.download.preserve_local_settings = True
 
+        # Create the test ad before patching model_validate (since it uses model_validate internally)
+        ad_cfg = _create_test_ad_partial()
+
         with (
             patch.object(extractor, "_extract_ad_page_info_with_directory_handling", new_callable = AsyncMock) as mock_extract,
-            patch.object(AdPartial, "model_copy", side_effect = ValueError("validation failed")),
+            patch.object(AdPartial, "model_validate", side_effect = ValueError("validation failed")),
         ):
             mock_extract.return_value = (
-                _create_test_ad_partial(),
+                ad_cfg,
                 staging_dir,
                 final_dir,
                 "ad_12345",
@@ -2878,6 +2883,9 @@ class TestAdExtractorDownload:
 
             await extractor.download_ad(12345)
 
+        # Download completed normally despite preservation failure
+        assert (final_dir / "ad_12345.yaml").exists()
+        assert not staging_dir.exists()
         assert any("Could not preserve local settings" in message for message in caplog.messages)
 
 

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2829,6 +2829,8 @@ class TestAdExtractorDownload:
             await extractor.download_ad(12345)
 
         saved_data = await asyncio.to_thread(dicts.load_dict, str(final_dir / "ad_12345.yaml"))
+        assert saved_data["title"] == "Test Advertisement Title"
+        assert saved_data["description"] == "Test Description"
         assert saved_data["repost_count"] == 5
         assert saved_data["price_reduction_count"] == 3
         assert saved_data["auto_price_reduction"]["enabled"] is True


### PR DESCRIPTION
## ℹ️ Description

When re-downloading an ad that is already saved locally (via `--ads=all` or numeric IDs), the ad YAML is atomically replaced. The download only scrapes fields from the live page, so all **local-only settings** are reset to defaults or zero:

| Field | What happens |
|---|---|
| `auto_price_reduction` | Reset to `AdDefaults` value (or `null`) |
| `republication_interval` | Reset to `AdDefaults` value (or `null`) |
| `repost_count` | Reset to `0` — bot forgets how many times it published |
| `price_reduction_count` | Reset to `0` — bot forgets auto-reduction progress |

The `new` selector avoids this by skipping already-saved ads, but `all` and numeric IDs do not.

- Link to the related issue(s): N/A

## 📋 Changes Summary

- Add `download.preserve_local_settings` config option (default: `true`)
- Add `--preserve-local-settings` CLI flag with help text (English + German)
- In `download_ad()`, when re-downloading an existing ad with the toggle enabled, preserve four local-only fields from the existing YAML: `auto_price_reduction`, `republication_interval`, `repost_count`, `price_reduction_count`
- Uses validate-then-commit pattern: candidate values are staged on a model copy, validated, then committed only on success
- Added test verifying local fields survive re-download
- Regenerated schemas and config defaults
- Updated German translations for new log messages

### ⚙️ Type of Change
- [x] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--preserve-local-settings` CLI flag to retain local ad settings during re-downloads (including auto price reduction, republication interval, and repost count).
  * Settings now preserved by default; re-downloading existing ads maintains local configurations instead of resetting to defaults.

* **Documentation**
  * Updated configuration guide with details on the new `preserve_local_settings` option.

* **Tests**
  * Added unit tests for CLI flag parsing and preservation logic during ad re-downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->