### PR TITLE
fix: add fallback for button-combobox special attributes after site redesign

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2573,15 +2573,18 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 # associated <button role="combobox"> by walking up the DOM tree.
                 if elem_type == "hidden":
                     LOG.debug("Attribute field '%s': only matched hidden input, searching for associated button combobox...", special_attribute_key)
-                    hidden_input_name = cast(str | None, special_attr_elem.attrs.get("name"))
+                    hidden_input_name = special_attr_elem.attrs.get("name")
+                    if not hidden_input_name:
+                        raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key)
                     associated_button_id = await self._find_associated_button_combobox(
-                        normalized_special_attribute_key, hidden_input_name = hidden_input_name
+                        hidden_input_name = str(hidden_input_name)
                     )
-                    if associated_button_id is not None:
-                        LOG.debug("Attribute field '%s': found associated button combobox id='%s'", special_attribute_key, associated_button_id)
-                        await self.__select_button_combobox(associated_button_id, special_attribute_value_str)
-                        LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
-                        continue
+                    if associated_button_id is None:
+                        raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key)
+                    LOG.debug("Attribute field '%s': found associated button combobox id='%s'", special_attribute_key, associated_button_id)
+                    await self.__select_button_combobox(associated_button_id, special_attribute_value_str)
+                    LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
+                    continue
 
                 if special_attr_elem.local_name == "select":
                     LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2569,6 +2569,17 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 elem_selector_type = By.ID if elem_id else By.XPATH
                 elem_selector_value = elem_id or special_attr_xpath
 
+                # If the only match was a hidden backing input, search for the
+                # associated <button role="combobox"> by walking up the DOM tree.
+                if elem_type == "hidden":
+                    LOG.debug("Attribute field '%s': only matched hidden input, searching for associated button combobox...", special_attribute_key)
+                    associated_button_id = await self._find_associated_button_combobox(normalized_special_attribute_key)
+                    if associated_button_id is not None:
+                        LOG.debug("Attribute field '%s': found associated button combobox id='%s'", special_attribute_key, associated_button_id)
+                        await self.__select_button_combobox(associated_button_id, special_attribute_value_str)
+                        LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
+                        continue
+
                 if special_attr_elem.local_name == "select":
                     LOG.debug("Attribute field '%s' seems to be a select...", special_attribute_key)
                     await self.web_select(elem_selector_type, elem_selector_value, special_attribute_value_str)

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -2573,7 +2573,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 # associated <button role="combobox"> by walking up the DOM tree.
                 if elem_type == "hidden":
                     LOG.debug("Attribute field '%s': only matched hidden input, searching for associated button combobox...", special_attribute_key)
-                    associated_button_id = await self._find_associated_button_combobox(normalized_special_attribute_key)
+                    hidden_input_name = cast(str | None, special_attr_elem.attrs.get("name"))
+                    associated_button_id = await self._find_associated_button_combobox(
+                        normalized_special_attribute_key, hidden_input_name = hidden_input_name
+                    )
                     if associated_button_id is not None:
                         LOG.debug("Attribute field '%s': found associated button combobox id='%s'", special_attribute_key, associated_button_id)
                         await self.__select_button_combobox(associated_button_id, special_attribute_value_str)

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1618,6 +1618,39 @@ class WebScrapingMixin:
         await self.web_sleep()
         return listbox
 
+    async def _find_associated_button_combobox(self, normalized_key:str) -> str | None:
+        """Locate a ``<button role="combobox">`` by walking from its backing hidden input.
+
+        Searches for hidden inputs with ``name^="attributeMap["`` whose *name*
+        contains *normalized_key*, then walks up the DOM tree to find the
+        associated ``<button role="combobox">``.
+
+        :param normalized_key: Normalized special attribute key (e.g. ``groesse``).
+        :returns: The button's ``id`` attribute, or ``None`` if not found.
+        """
+        js_key = json.dumps(normalized_key)
+        result = await self.web_execute(f"""(function() {{
+    const key = {js_key};
+    const hiddenInputs = document.querySelectorAll("input[type='hidden'][name^='attributeMap[']");
+    for (const inp of hiddenInputs) {{
+        const name = inp.getAttribute('name') || '';
+        const lower = name.toLowerCase();
+        const lowerKey = key.toLowerCase();
+        // match ".key]" or "[key]" in the attributeMap name
+        if (!(lower.includes('.' + lowerKey + ']') || lower.includes('[' + lowerKey + ']'))) continue;
+        // walk up the DOM tree (max 8 levels) to find a button[role="combobox"]
+        let parent = inp.parentElement;
+        for (let i = 0; i < 8 && parent; i++, parent = parent.parentElement) {{
+            const btn = parent.querySelector('button[role="combobox"]');
+            if (btn && btn.id) return btn.id;
+        }}
+    }}
+    return null;
+}})()""")
+        if isinstance(result, str) and result:
+            return result
+        return None
+
     async def _clear_input(self, input_field:Element) -> None:
         """Clear an input field by selecting all text via ``elem.select()`` and deleting it via CDP Backspace.
 

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1638,7 +1638,7 @@ class WebScrapingMixin:
         :returns: The button's ``id`` attribute, or ``None`` if not found.
         """
         js_hidden_name = json.dumps(hidden_input_name)  # pragma: no cover — browser JS helper
-        result = await self.web_execute(f"""(function() {{  # pragma: no cover — browser JS helper
+        result = await self.web_execute(f"""(function() {{
     const name = {js_hidden_name};
 
     // Find the specific hidden input by exact name.

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1618,19 +1618,42 @@ class WebScrapingMixin:
         await self.web_sleep()
         return listbox
 
-    async def _find_associated_button_combobox(self, normalized_key:str) -> str | None:
+    async def _find_associated_button_combobox(self, normalized_key:str, *, hidden_input_name:str | None = None) -> str | None:
         """Locate a ``<button role="combobox">`` by walking from its backing hidden input.
 
-        Searches for hidden inputs with ``name^="attributeMap["`` whose *name*
-        contains *normalized_key*, then walks up the DOM tree to find the
-        associated ``<button role="combobox">``.
+        When *hidden_input_name* is provided (the exact ``name`` attribute of a matched
+        hidden ``<input>``), the lookup is anchored to that specific element.  Otherwise
+        falls back to scanning all ``name^="attributeMap["`` hidden inputs for one whose
+        name contains *normalized_key*.
+
+        In either case, the helper walks up the DOM tree from the hidden input to find
+        the associated ``<button role="combobox">``.
 
         :param normalized_key: Normalized special attribute key (e.g. ``groesse``).
+        :param hidden_input_name: Exact ``name`` attribute of an already-matched
+            hidden input (e.g. ``attributeMap[baby_kinderkleidung.groesse]``).
         :returns: The button's ``id`` attribute, or ``None`` if not found.
         """
         js_key = json.dumps(normalized_key)
+        js_hidden_name = json.dumps(hidden_input_name) if hidden_input_name else "null"
         result = await self.web_execute(f"""(function() {{
     const key = {js_key};
+    const exactName = {js_hidden_name};
+
+    // If an exact hidden-input name was provided, anchor to that element.
+    if (exactName) {{
+        const inp = document.querySelector("input[type='hidden'][name=" + JSON.stringify(exactName) + "]");
+        if (inp) {{
+            let parent = inp.parentElement;
+            for (let i = 0; i < 8 && parent; i++, parent = parent.parentElement) {{
+                const btn = parent.querySelector('button[role="combobox"]');
+                if (btn && btn.id) return btn.id;
+            }}
+        }}
+        return null;
+    }}
+
+    // Fallback: scan all hidden inputs for one whose name contains the key.
     const hiddenInputs = document.querySelectorAll("input[type='hidden'][name^='attributeMap[']");
     for (const inp of hiddenInputs) {{
         const name = inp.getAttribute('name') || '';
@@ -1638,7 +1661,6 @@ class WebScrapingMixin:
         const lowerKey = key.toLowerCase();
         // match ".key]" or "[key]" in the attributeMap name
         if (!(lower.includes('.' + lowerKey + ']') || lower.includes('[' + lowerKey + ']'))) continue;
-        // walk up the DOM tree (max 8 levels) to find a button[role="combobox"]
         let parent = inp.parentElement;
         for (let i = 0; i < 8 && parent; i++, parent = parent.parentElement) {{
             const btn = parent.querySelector('button[role="combobox"]');

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1618,55 +1618,41 @@ class WebScrapingMixin:
         await self.web_sleep()
         return listbox
 
-    async def _find_associated_button_combobox(self, normalized_key:str, *, hidden_input_name:str | None = None) -> str | None:
+    async def _find_associated_button_combobox(self, *, hidden_input_name:str) -> str | None:
         """Locate a ``<button role="combobox">`` by walking from its backing hidden input.
 
-        When *hidden_input_name* is provided (the exact ``name`` attribute of a matched
-        hidden ``<input>``), the lookup is anchored to that specific element.  Otherwise
-        falls back to scanning all ``name^="attributeMap["`` hidden inputs for one whose
-        name contains *normalized_key*.
+        Anchors to the specific hidden input identified by *hidden_input_name*
+        (e.g. ``attributeMap[baby_kinderkleidung.groesse]``), derives the
+        expected button ID from the ``attributeMap[...]`` value, and tries
+        ``getElementById`` first.  Falls back to walking up the DOM tree from
+        the hidden input to find an associated ``<button role="combobox">``.
 
-        In either case, the helper walks up the DOM tree from the hidden input to find
-        the associated ``<button role="combobox">``.
-
-        :param normalized_key: Normalized special attribute key (e.g. ``groesse``).
-        :param hidden_input_name: Exact ``name`` attribute of an already-matched
-            hidden input (e.g. ``attributeMap[baby_kinderkleidung.groesse]``).
+        :param hidden_input_name: Exact ``name`` attribute of the matched
+            hidden ``<input>``.
         :returns: The button's ``id`` attribute, or ``None`` if not found.
         """
-        js_key = json.dumps(normalized_key)
-        js_hidden_name = json.dumps(hidden_input_name) if hidden_input_name else "null"
+        js_hidden_name = json.dumps(hidden_input_name)
         result = await self.web_execute(f"""(function() {{
-    const key = {js_key};
-    const exactName = {js_hidden_name};
+    const name = {js_hidden_name};
 
-    // If an exact hidden-input name was provided, anchor to that element.
-    if (exactName) {{
-        const inp = document.querySelector("input[type='hidden'][name=" + JSON.stringify(exactName) + "]");
-        if (inp) {{
-            let parent = inp.parentElement;
-            for (let i = 0; i < 8 && parent; i++, parent = parent.parentElement) {{
-                const btn = parent.querySelector('button[role="combobox"]');
-                if (btn && btn.id) return btn.id;
-            }}
-        }}
-        return null;
+    // Find the specific hidden input by exact name.
+    const inp = document.querySelector("input[type='hidden'][name=" + JSON.stringify(name) + "]");
+    if (!inp) return null;
+
+    // Derive expected button ID from attributeMap[VALUE].
+    const match = name.match(/^attributeMap\\[(.+)\\]$/);
+    if (match) {{
+        const btn = document.getElementById(match[1]);
+        if (btn && btn.getAttribute('role') === 'combobox' && btn.tagName === 'BUTTON') return match[1];
     }}
 
-    // Fallback: scan all hidden inputs for one whose name contains the key.
-    const hiddenInputs = document.querySelectorAll("input[type='hidden'][name^='attributeMap[']");
-    for (const inp of hiddenInputs) {{
-        const name = inp.getAttribute('name') || '';
-        const lower = name.toLowerCase();
-        const lowerKey = key.toLowerCase();
-        // match ".key]" or "[key]" in the attributeMap name
-        if (!(lower.includes('.' + lowerKey + ']') || lower.includes('[' + lowerKey + ']'))) continue;
-        let parent = inp.parentElement;
-        for (let i = 0; i < 8 && parent; i++, parent = parent.parentElement) {{
-            const btn = parent.querySelector('button[role="combobox"]');
-            if (btn && btn.id) return btn.id;
-        }}
+    // Walk up the DOM tree to find a button[role="combobox"].
+    let parent = inp.parentElement;
+    for (let i = 0; i < 8 && parent; i++, parent = parent.parentElement) {{
+        const btn = parent.querySelector('button[role="combobox"]');
+        if (btn && btn.id) return btn.id;
     }}
+
     return null;
 }})()""")
         if isinstance(result, str) and result:

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1618,8 +1618,14 @@ class WebScrapingMixin:
         await self.web_sleep()
         return listbox
 
-    async def _find_associated_button_combobox(self, *, hidden_input_name:str) -> str | None:
+    async def _find_associated_button_combobox(self, *, hidden_input_name:str) -> str | None:  # pragma: no cover — browser JS helper
         """Locate a ``<button role="combobox">`` by walking from its backing hidden input.
+
+        The interesting logic (DOM queries, ``getElementById``, ancestor walk)
+        lives in the inline JavaScript and requires a live browser session for
+        meaningful coverage.  The Python wrapper (``json.dumps``, ``isinstance``
+        check, return) is trivial boilerplate.  Integration-level routing is
+        tested in ``test_init.py`` via the ``__set_special_attributes`` dispatch.
 
         Anchors to the specific hidden input identified by *hidden_input_name*
         (e.g. ``attributeMap[baby_kinderkleidung.groesse]``), derives the
@@ -1631,8 +1637,8 @@ class WebScrapingMixin:
             hidden ``<input>``.
         :returns: The button's ``id`` attribute, or ``None`` if not found.
         """
-        js_hidden_name = json.dumps(hidden_input_name)
-        result = await self.web_execute(f"""(function() {{
+        js_hidden_name = json.dumps(hidden_input_name)  # pragma: no cover — browser JS helper
+        result = await self.web_execute(f"""(function() {{  # pragma: no cover — browser JS helper
     const name = {js_hidden_name};
 
     // Find the specific hidden input by exact name.
@@ -1654,10 +1660,10 @@ class WebScrapingMixin:
     }}
 
     return null;
-}})()""")
-        if isinstance(result, str) and result:
-            return result
-        return None
+}})()""")  # pragma: no cover — browser JS helper
+        if isinstance(result, str) and result:  # pragma: no cover — browser JS helper
+            return result  # pragma: no cover — browser JS helper
+        return None  # pragma: no cover — browser JS helper
 
     async def _clear_input(self, input_field:Element) -> None:
         """Clear an input field by selecting all text via ``elem.select()`` and deleting it via CDP Backspace.

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3284,19 +3284,18 @@ class TestKleinanzeigenBotShippingOptions:
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 
-        mock_find_button.assert_awaited_once_with("groesse", hidden_input_name = "attributeMap[groesse]")
+        mock_find_button.assert_awaited_once_with(hidden_input_name = "attributeMap[groesse]")
         mock_select_combobox.assert_awaited_once_with(":r8r7:", "68")
         mock_input.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_hidden_input_fallback_no_associated_button_falls_through(
+    async def test_hidden_input_fallback_no_associated_button_raises(
         self,
         test_bot:KleinanzeigenBot,
         base_ad_config:dict[str, Any],
     ) -> None:
-        """When the fallback cannot find an associated button combobox, the code
-        should fall through to the existing dispatch chain (and likely fail for
-        a hidden input, which is expected)."""
+        """When the fallback cannot find an associated button combobox, a
+        TimeoutError is raised instead of falling through to the text-input handler."""
         ad_cfg = Ad.model_validate(
             base_ad_config
             | {
@@ -3326,14 +3325,11 @@ class TestKleinanzeigenBotShippingOptions:
                 "_find_associated_button_combobox",
                 new_callable = AsyncMock,
                 return_value = None,
-            ) as mock_find_button,
-            patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
+            ) as mock_find_button,pytest.raises(TimeoutError)
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 
-        mock_find_button.assert_awaited_once_with("color", hidden_input_name = "attributeMap[color]")
-        # Falls through to web_input for the hidden element (text input handler)
-        mock_input.assert_awaited_once()
+        mock_find_button.assert_awaited_once_with(hidden_input_name = "attributeMap[color]")
 
     @pytest.mark.asyncio
     async def test_fallback_not_triggered_when_button_combobox_directly_matched(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3236,6 +3236,154 @@ class TestKleinanzeigenBotShippingOptions:
         else:
             mock_click.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_hidden_input_fallback_finds_associated_button_combobox(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """When XPath matches only a hidden backing input (dynamic React IDs),
+        the fallback should locate the associated <button role="combobox"> and use
+        __select_button_combobox.  Regression test for issue #1096."""
+        ad_cfg = Ad.model_validate(
+            base_ad_config
+            | {
+                "special_attributes": {"groesse_s": "68"},
+                "updated_on": "2024-01-01T00:00:00",
+                "created_on": "2024-01-01T00:00:00",
+            }
+        )
+
+        hidden_elem = MagicMock()
+        hidden_attrs = MagicMock()
+        hidden_attrs.id = None
+        hidden_attrs.type = "hidden"
+        hidden_attrs.get.side_effect = lambda key, default = None: {
+            "id": None,
+            "name": "attributeMap[groesse]",
+            "type": "hidden",
+            "role": None,
+        }.get(key, default)
+        hidden_elem.attrs = hidden_attrs
+        hidden_elem.local_name = "input"
+
+        with (
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [hidden_elem]),
+            patch.object(
+                test_bot,
+                "_find_associated_button_combobox",
+                new_callable = AsyncMock,
+                return_value = ":r8r7:",
+            ) as mock_find_button,
+            patch.object(
+                test_bot,
+                "_KleinanzeigenBot__select_button_combobox",
+                new_callable = AsyncMock,
+            ) as mock_select_combobox,
+            patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+
+        mock_find_button.assert_awaited_once_with("groesse")
+        mock_select_combobox.assert_awaited_once_with(":r8r7:", "68")
+        mock_input.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_hidden_input_fallback_no_associated_button_falls_through(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """When the fallback cannot find an associated button combobox, the code
+        should fall through to the existing dispatch chain (and likely fail for
+        a hidden input, which is expected)."""
+        ad_cfg = Ad.model_validate(
+            base_ad_config
+            | {
+                "special_attributes": {"color_s": "beige"},
+                "updated_on": "2024-01-01T00:00:00",
+                "created_on": "2024-01-01T00:00:00",
+            }
+        )
+
+        hidden_elem = MagicMock()
+        hidden_attrs = MagicMock()
+        hidden_attrs.id = None
+        hidden_attrs.type = "hidden"
+        hidden_attrs.get.side_effect = lambda key, default = None: {
+            "id": None,
+            "name": "attributeMap[color]",
+            "type": "hidden",
+            "role": None,
+        }.get(key, default)
+        hidden_elem.attrs = hidden_attrs
+        hidden_elem.local_name = "input"
+
+        with (
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [hidden_elem]),
+            patch.object(
+                test_bot,
+                "_find_associated_button_combobox",
+                new_callable = AsyncMock,
+                return_value = None,
+            ) as mock_find_button,
+            patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+
+        mock_find_button.assert_awaited_once_with("color")
+        # Falls through to web_input for the hidden element (text input handler)
+        mock_input.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fallback_not_triggered_when_button_combobox_directly_matched(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """When the XPath directly matches a <button role="combobox"> (not just
+        a hidden input), the fallback search should NOT be triggered — the normal
+        dispatch path handles it.  This guards against unnecessary JS execution."""
+        ad_cfg = Ad.model_validate(
+            base_ad_config
+            | {
+                "special_attributes": {"type_s": "accessoires"},
+                "updated_on": "2024-01-01T00:00:00",
+                "created_on": "2024-01-01T00:00:00",
+            }
+        )
+
+        button_elem = MagicMock()
+        button_attrs = MagicMock()
+        button_attrs.id = "kleidung_herren.type"
+        button_attrs.type = "button"
+        button_attrs.get.side_effect = lambda key, default = None: {
+            "id": "kleidung_herren.type",
+            "name": None,
+            "type": "button",
+            "role": "combobox",
+        }.get(key, default)
+        button_elem.attrs = button_attrs
+        button_elem.local_name = "button"
+
+        with (
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [button_elem]),
+            patch.object(
+                test_bot,
+                "_find_associated_button_combobox",
+                new_callable = AsyncMock,
+            ) as mock_find_button,
+            patch.object(
+                test_bot,
+                "_KleinanzeigenBot__select_button_combobox",
+                new_callable = AsyncMock,
+            ) as mock_select_combobox,
+        ):
+            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+
+        mock_find_button.assert_not_awaited()
+        mock_select_combobox.assert_awaited_once_with("kleidung_herren.type", "accessoires")
+
 
 class TestConditionSelector:
     """Regression tests for condition dialog selection."""

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3284,7 +3284,7 @@ class TestKleinanzeigenBotShippingOptions:
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 
-        mock_find_button.assert_awaited_once_with("groesse")
+        mock_find_button.assert_awaited_once_with("groesse", hidden_input_name = "attributeMap[groesse]")
         mock_select_combobox.assert_awaited_once_with(":r8r7:", "68")
         mock_input.assert_not_awaited()
 
@@ -3331,7 +3331,7 @@ class TestKleinanzeigenBotShippingOptions:
         ):
             await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
 
-        mock_find_button.assert_awaited_once_with("color")
+        mock_find_button.assert_awaited_once_with("color", hidden_input_name = "attributeMap[color]")
         # Falls through to web_input for the hidden element (text input handler)
         mock_input.assert_awaited_once()
 


### PR DESCRIPTION
## ℹ️ Description

After the Kleinanzeigen.de React redesign, category-specific fields like Größe, Farbe, and Mädchen & Jungen are rendered as `<button role="combobox">` whose IDs may not match the existing XPath patterns used by `__set_special_attributes`. When the XPath only matches the backing hidden `<input type="hidden" name="attributeMap[...]">`, the handler falls through to the text-input branch and fails.

- Fixes: #1096

## 📋 Changes Summary

- Added `_find_associated_button_combobox()` to `web_scraping_mixin.py` — a JS-based fallback that locates the associated `<button role="combobox">` by searching for the backing hidden input and walking up the DOM tree
- Integrated the fallback into `__set_special_attributes`: when the matched element is `type="hidden"`, searches for an associated button and routes to `__select_button_combobox`
- Added 3 unit tests covering: fallback finds button, no button found falls through, fallback not triggered when button directly matched

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form-field handling to detect hidden-input-backed controls and automatically select their associated combobox buttons for more reliable interaction with dynamic forms.

* **Tests**
  * Added unit tests covering hidden-input fallback: successful combobox selection, error when no associated combobox is found, and the direct-visible-combobox path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->