### PR TITLE
refactor: rename form methods and remove fetch delegator in preparation for publishing workflow extraction

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -880,11 +880,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         return False
 
-    async def _fetch_published_ads(self, *, strict:bool = False) -> list[PublishedAd]:
-        """Temporary delegator to published_ads.fetch_published_ads."""
-        return await published_ads.fetch_published_ads(self, self.root_url, strict = strict)
-
-    async def __check_publishing_result(self) -> bool:
+    async def _check_publishing_result(self) -> bool:
         # Check for success messages
         return await self.web_check(By.ID, "checking-done", Is.DISPLAYED) or await self.web_check(By.ID, "not-completed", Is.DISPLAYED)
 
@@ -932,12 +928,12 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         failed_count = 0
         max_retries = SUBMISSION_MAX_RETRIES
 
-        published_ads = await self._fetch_published_ads()
+        published_ads_list = await published_ads.fetch_published_ads(self, self.root_url)
 
         for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ad_cfgs, start = 1):
             LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ad_cfgs), ad_cfg.title, ad_file)
 
-            if any(ad_matches_id(x, ad_cfg.id) and x.get("state") == "paused" for x in published_ads):
+            if any(ad_matches_id(x, ad_cfg.id) and x.get("state") == "paused" for x in published_ads_list):
                 LOG.info("Skipping because ad is reserved")
                 continue
 
@@ -952,7 +948,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     # remain idempotent for a single eligible reduction cycle.
                     ad_cfg.price = baseline_price
                     ad_cfg.price_reduction_count = baseline_price_reduction_count
-                    await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads, AdUpdateStrategy.REPLACE)
+                    await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads_list, AdUpdateStrategy.REPLACE)
                     success = True
                     break  # Publish succeeded, exit retry loop
                 except asyncio.CancelledError:
@@ -992,7 +988,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             if success:
                 try:
                     publish_timeout = self.timeout("publishing_result")
-                    await self.web_await(self.__check_publishing_result, timeout = publish_timeout)
+                    await self.web_await(self._check_publishing_result, timeout = publish_timeout)
                 except TimeoutError:
                     LOG.warning(" -> Could not confirm publishing for '%s', but ad may be online", ad_cfg.title)
 
@@ -1000,7 +996,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 await delete_flow.delete_ad(
                     web = self, root_url = self.root_url,
                     ad_cfg = ad_cfg,
-                    published_ads_list = published_ads,
+                    published_ads_list = published_ads_list,
                     delete_old_ads_by_title = False,
                 )
 
@@ -1070,13 +1066,13 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         #############################
         # set category (before title to avoid form reset clearing title)
         #############################
-        await self.__set_category(ad_cfg.category, ad_file)
+        await self._set_category(ad_cfg.category, ad_file)
         await self.web_sleep()  # wait for category-dependent fields to render before setting attributes
 
         #############################
         # set special attributes
         #############################
-        await self.__set_special_attributes(ad_cfg)
+        await self._set_special_attributes(ad_cfg)
 
         #############################
         # set shipping type/options/costs
@@ -1104,7 +1100,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                         LOG.warning("Failed to set shipping attribute for type '%s'!", shipping_type)
                         raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % shipping_type) from ex
             else:
-                await self.__set_shipping(ad_cfg, mode)
+                await self._set_shipping(ad_cfg, mode)
         else:
             LOG.debug("Shipping step skipped - reason: NOT_APPLICABLE")
 
@@ -1122,7 +1118,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 except TimeoutError as ex:
                     raise TimeoutError(_("Failed to set price type '%s'") % price_type) from ex
             if ad_cfg.price is not None:
-                await self.__set_input_value("ad-price-amount", str(ad_cfg.price))
+                await self._set_input_value("ad-price-amount", str(ad_cfg.price))
 
         #############################
         # set sell_directly
@@ -1151,9 +1147,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # set description
         #############################
         description = get_ad_description(ad_cfg, self.config.ad_defaults, with_affixes = True)
-        await self.__set_input_value("ad-description", description)
+        await self._set_input_value("ad-description", description)
 
-        await self.__set_contact_fields(ad_cfg.contact)
+        await self._set_contact_fields(ad_cfg.contact)
 
         #############################
         # delete previous images to ensure a clean slate
@@ -1191,7 +1187,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         #############################
         # upload images
         #############################
-        await self.__upload_images(ad_cfg)
+        await self._upload_images(ad_cfg)
 
         #############################
         # wait for captcha
@@ -1206,7 +1202,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # set title (right before submit to prevent React re-render clearing it)
         #############################
         LOG.debug("Setting title '%s' (deferred to prevent React re-render clearing it)", ad_cfg.title)
-        await self.__set_input_value("ad-title", ad_cfg.title)
+        await self._set_input_value("ad-title", ad_cfg.title)
 
         #############################
         # submit
@@ -1413,7 +1409,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         return None
 
-    async def __set_input_value(self, element_id:str, value:str) -> None:
+    async def _set_input_value(self, element_id:str, value:str) -> None:
         """Sets a framework-controlled input value using the native DOM setter to trigger onChange."""
         await self.web_find(By.ID, element_id)  # raises TimeoutError if element is absent
         js_element_id = json.dumps(element_id)
@@ -1432,7 +1428,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         )
 
     @staticmethod
-    def __location_matches_target(target:str, candidate:str | None) -> bool:
+    def _location_matches_target(target:str, candidate:str | None) -> bool:
         if not candidate:
             return False
 
@@ -1453,7 +1449,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         candidate_city = normalized_candidate.rsplit(" - ", maxsplit = 1)[-1]
         return normalized_target == candidate_city
 
-    async def __city_option_text(self, option:Element) -> str:
+    async def _city_option_text(self, option:Element) -> str:
         text = str(getattr(option, "text", "") or "").strip()
         if text:
             return text
@@ -1462,7 +1458,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         except TimeoutError:
             return ""
 
-    async def __read_city_selection_text(self) -> str | None:
+    async def _read_city_selection_text(self) -> str | None:
         city_timeout = self.timeout("default")
         quick_dom_timeout = self.timeout("quick_dom")
         try:
@@ -1497,7 +1493,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             return None
         return None
 
-    async def __select_city_combobox_option(self, target:str) -> None:
+    async def _select_city_combobox_option(self, target:str) -> None:
         quick_dom_timeout = self.timeout("quick_dom")
         city_flow_timeout = self.timeout("default")
 
@@ -1538,7 +1534,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             return " ".join(value.split()).casefold()
 
         target_norm = normalize(target)
-        option_entries = [(candidate, normalize(await self.__city_option_text(candidate))) for candidate in candidates]
+        option_entries = [(candidate, normalize(await self._city_option_text(candidate))) for candidate in candidates]
 
         exact_match = next((entry[0] for entry in option_entries if entry[1] == target_norm), None)
         city_matches:list[Element] = []
@@ -1560,21 +1556,21 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         await selected_option.click()
 
         async def _selection_converged() -> bool:
-            selected_city = await self.__read_city_selection_text()
-            return self.__location_matches_target(target, selected_city)
+            selected_city = await self._read_city_selection_text()
+            return self._location_matches_target(target, selected_city)
 
         try:
             await self.web_await(_selection_converged, timeout = city_flow_timeout)
         except TimeoutError as ex:
             raise TimeoutError(_("City selection did not converge for location: %s") % target) from ex
 
-    async def __set_contact_location(self, location:str) -> None:
+    async def _set_contact_location(self, location:str) -> None:
         target = location.strip()
         if not target:
             return
 
-        selected_city = await self.__read_city_selection_text()
-        if self.__location_matches_target(target, selected_city):
+        selected_city = await self._read_city_selection_text()
+        if self._location_matches_target(target, selected_city):
             return
 
         city_timeout = self.timeout("default")
@@ -1599,9 +1595,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if city_tag != "button" or city_role != "combobox":
             raise TimeoutError(_("Unsupported city element type while setting contact location: <%s>") % city_tag)
 
-        await self.__select_city_combobox_option(target)
+        await self._select_city_combobox_option(target)
 
-    async def __set_contact_fields(self, contact:Contact) -> None:
+    async def _set_contact_fields(self, contact:Contact) -> None:
         #############################
         # set contact zipcode + location
         #############################
@@ -1613,7 +1609,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 raise TimeoutError(_("Failed to set contact zipcode: %s") % contact.zipcode) from ex
 
             if contact.location:
-                await self.__set_contact_location(contact.location)
+                await self._set_contact_location(contact.location)
 
         #############################
         # set contact street
@@ -1623,7 +1619,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 if await self.web_check(By.ID, "ad-street", Is.DISABLED):
                     await self.web_click(By.ID, "ad-address-visibility")
                     await self.web_sleep()
-                await self.__set_input_value("ad-street", contact.street)
+                await self._set_input_value("ad-street", contact.street)
             except TimeoutError:
                 LOG.warning("Could not set contact street.")
 
@@ -1633,7 +1629,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if contact.name:
             try:
                 if not await self.web_check(By.ID, "ad-name", Is.READONLY):
-                    await self.__set_input_value("ad-name", contact.name)
+                    await self._set_input_value("ad-name", contact.name)
             except TimeoutError:
                 LOG.warning("Could not set contact name.")
 
@@ -1651,7 +1647,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     if await self.web_check(By.ID, "ad-phone", Is.DISABLED, timeout = self.timeout("quick_dom")):
                         await self.web_click(By.ID, "ad-phone-visibility", timeout = self.timeout("quick_dom"))
                         await self.web_sleep()
-                    await self.__set_input_value("ad-phone", contact.phone)
+                    await self._set_input_value("ad-phone", contact.phone)
                 except TimeoutError as ex:
                     LOG.warning("Could not set contact phone despite visible phone field: %s", ex)
 
@@ -1671,12 +1667,12 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         failed_count = 0
         max_retries = SUBMISSION_MAX_RETRIES
 
-        published_ads = await self._fetch_published_ads()
+        published_ads_list = await published_ads.fetch_published_ads(self, self.root_url)
 
         for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ad_cfgs, start = 1):
             LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ad_cfgs), ad_cfg.title, ad_file)
 
-            ad = next((published_ad for published_ad in published_ads if ad_matches_id(published_ad, ad_cfg.id)), None)
+            ad = next((published_ad for published_ad in published_ads_list if ad_matches_id(published_ad, ad_cfg.id)), None)
 
             if not ad:
                 LOG.warning(" -> SKIPPED: ad '%s' (ID: %s) not found in published ads", ad_cfg.title, ad_cfg.id)
@@ -1695,7 +1691,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 try:
                     ad_cfg.price = baseline_price
                     ad_cfg.price_reduction_count = baseline_price_reduction_count
-                    await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads, AdUpdateStrategy.MODIFY)
+                    await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads_list, AdUpdateStrategy.MODIFY)
                     success = True
                     break
                 except asyncio.CancelledError:
@@ -1730,7 +1726,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             if success:
                 try:
                     publish_timeout = self.timeout("publishing_result")
-                    await self.web_await(self.__check_publishing_result, timeout = publish_timeout)
+                    await self.web_await(self._check_publishing_result, timeout = publish_timeout)
                 except TimeoutError:
                     LOG.warning(" -> Could not confirm update for '%s', but changes may be online", ad_cfg.title)
 
@@ -1741,7 +1737,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             LOG.info("DONE: updated %s", pluralize("ad", count))
         LOG.info("############################################")
 
-    async def __set_condition(self, condition_value:str) -> bool:
+    async def _set_condition(self, condition_value:str) -> bool:
         """Try to set condition via dialog path.
 
         Returns True when dialog handling succeeded, otherwise False to indicate
@@ -1817,7 +1813,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         return True
 
-    async def __set_category(self, category:str | None, ad_file:str) -> None:
+    async def _set_category(self, category:str | None, ad_file:str) -> None:
         # click on something to trigger automatic category detection
         await self.web_click(By.ID, "ad-description")
 
@@ -1838,11 +1834,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             # When the configured path cannot be resolved (e.g. outdated or ambiguous),
             # the site falls back to a React category-suggestion radio picker. Handle it
             # by matching a path segment against one of the offered suggestions.
-            await self.__resolve_category_suggestions(category)
+            await self._resolve_category_suggestions(category)
         else:
             ensure(is_category_auto_selected, f"No category specified in [{ad_file}] and automatic category detection failed")
 
-    async def __resolve_category_suggestions(self, category:str) -> None:
+    async def _resolve_category_suggestions(self, category:str) -> None:
         """Handle Kleinanzeigen's post-redesign category-suggestion picker.
 
         If ``fieldset#ad-category-picker`` is rendered after the category change
@@ -1911,7 +1907,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         raise CategoryResolutionError(message % {"category": category, "offered": offered})
 
     @staticmethod
-    def __special_attribute_candidate_priority(elem:Element) -> tuple[int, int]:
+    def _special_attribute_candidate_priority(elem:Element) -> tuple[int, int]:
         local_name = elem.local_name
         elem_type = str(cast(Any, elem.attrs.get("type")) or "").lower()
         role = str(cast(Any, elem.attrs.get("role")) or "").lower()
@@ -1931,35 +1927,35 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         return (8, 0)
 
     @staticmethod
-    def __describe_special_attribute_candidate(elem:Element) -> str:
+    def _describe_special_attribute_candidate(elem:Element) -> str:
         elem_id = cast(str | None, elem.attrs.get("id"))
         elem_name = cast(str | None, elem.attrs.get("name"))
         elem_type = cast(str | None, elem.attrs.get("type"))
         elem_role = cast(str | None, elem.attrs.get("role"))
         return f"{elem.local_name}#'{elem_id}' name='{elem_name}' type='{elem_type}' role='{elem_role}'"
 
-    def __pick_special_attribute_candidate(self, candidates:Sequence[Element], special_attribute_key:str) -> Element:
+    def _pick_special_attribute_candidate(self, candidates:Sequence[Element], special_attribute_key:str) -> Element:
         ensure(candidates, f"No candidates found for special attribute [{special_attribute_key}]")
         ranked_candidates = sorted(
             enumerate(candidates),
-            key = lambda entry: (self.__special_attribute_candidate_priority(entry[1]), entry[0]),
+            key = lambda entry: (self._special_attribute_candidate_priority(entry[1]), entry[0]),
         )
         selected_idx, selected = ranked_candidates[0]
 
         if len(candidates) > 1:
-            debug_candidates = ", ".join(f"#{idx}:{self.__describe_special_attribute_candidate(candidate)}" for idx, candidate in enumerate(candidates))
+            debug_candidates = ", ".join(f"#{idx}:{self._describe_special_attribute_candidate(candidate)}" for idx, candidate in enumerate(candidates))
             LOG.debug(
                 "Attribute field '%s' matched %s elements. Selected #%s: %s. Candidates: %s",
                 special_attribute_key,
                 len(candidates),
                 selected_idx,
-                self.__describe_special_attribute_candidate(selected),
+                self._describe_special_attribute_candidate(selected),
                 debug_candidates,
             )
 
         return selected
 
-    async def __set_special_attributes(self, ad_cfg:Ad) -> None:
+    async def _set_special_attributes(self, ad_cfg:Ad) -> None:
         if not ad_cfg.special_attributes:
             return
 
@@ -1978,7 +1974,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
             if normalized_special_attribute_key == "condition":
                 LOG.debug("Special attribute [%s]: trying dedicated condition dialog path", special_attribute_key)
-                if await self.__set_condition(special_attribute_value_str):
+                if await self._set_condition(special_attribute_value_str):
                     LOG.debug("Special attribute [%s]: condition dialog path succeeded", special_attribute_key)
                     continue
 
@@ -2021,7 +2017,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     By.XPATH,
                     special_attr_xpath,
                 )
-                special_attr_elem = self.__pick_special_attribute_candidate(special_attr_candidates, special_attribute_key)
+                special_attr_elem = self._pick_special_attribute_candidate(special_attr_candidates, special_attribute_key)
             except AssertionError as ex:
                 LOG.debug(
                     "Attribute field '%s' (normalized: '%s') could not be found.",
@@ -2053,7 +2049,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     if associated_button_id is None:
                         raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key)
                     LOG.debug("Attribute field '%s': found associated button combobox id='%s'", special_attribute_key, associated_button_id)
-                    await self.__select_button_combobox(associated_button_id, special_attribute_value_str)
+                    await self._select_button_combobox(associated_button_id, special_attribute_value_str)
                     LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
                     continue
 
@@ -2089,7 +2085,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 elif special_attr_elem.local_name == "button" and elem_role == "combobox":
                     LOG.debug("Attribute field '%s' seems to be a button combobox (click-to-open dropdown)...", special_attribute_key)
                     ensure(elem_id, f"No id available for button combobox special attribute [{special_attribute_key}]")
-                    await self.__select_button_combobox(cast(str, elem_id), special_attribute_value_str)
+                    await self._select_button_combobox(cast(str, elem_id), special_attribute_value_str)
                 elif elem_role == "combobox" and elem_type in {"text", ""} and special_attr_elem.local_name == "input":
                     LOG.debug("Attribute field '%s' seems to be a Combobox (i.e. text input with filtering dropdown)...", special_attribute_key)
                     await self.web_select_combobox(elem_selector_type, elem_selector_value, special_attribute_value_str)
@@ -2102,7 +2098,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
 
     # TODO: Issue #930 — migrate to web_select_button_combobox (display-text-based, no React fiber)
-    async def __select_button_combobox(self, elem_id:str, value:str) -> None:
+    async def _select_button_combobox(self, elem_id:str, value:str) -> None:
         """Select an option from a <button role="combobox"> dropdown by its API value.
 
         Clicks the button to open the listbox, reads the options data from the React fiber
@@ -2139,7 +2135,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if not ok:
             raise TimeoutError(_("Option '%(value)s' not found in button combobox '%(id)s'") % {"value": value, "id": elem_id})
 
-    async def __set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
+    async def _set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
         short_timeout = self.timeout("quick_dom")
         if ad_cfg.shipping_type == "PICKUP":
             pickup_radio = await self.web_probe(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
@@ -2182,7 +2178,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                         await self.web_click(By.XPATH, '//button[contains(., "Zurück")]')
 
             await self.web_click(By.XPATH, '//button[contains(., "Andere Versandmethoden")]')
-            await self.__set_shipping_options(ad_cfg, mode)
+            await self._set_shipping_options(ad_cfg, mode)
         else:
             # Ensure shipping is enabled before opening the dialog (may already be selected)
             try:
@@ -2221,15 +2217,15 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 price_str = str(ad_cfg.shipping_costs).replace(".", ",")
                 # Native DOM setter + React-aware events: send_keys gets wiped by
                 # React re-render after the ad-individual-shipping-checkbox-control click.
-                # A re-render between web_find and web_execute inside __set_input_value can
+                # A re-render between web_find and web_execute inside _set_input_value can
                 # also leave the write as a silent no-op, so verify and retry before "Fertig".
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:
-                        await self.__set_input_value("ad-individual-shipping-price", price_str)
+                        await self._set_input_value("ad-individual-shipping-price", price_str)
                         actual = await self.web_execute("document.getElementById('ad-individual-shipping-price')?.value")
                     except TimeoutError as ex:
-                        # A re-render landing on web_find inside __set_input_value or on the
+                        # A re-render landing on web_find inside _set_input_value or on the
                         # readback web_execute can raise here; treat either as a transient
                         # failure so the outer loop can retry instead of bailing.
                         LOG.debug(ex, exc_info = True)
@@ -2255,7 +2251,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 LOG.debug(ex, exc_info = True)
                 raise TimeoutError(_("Unable to close shipping dialog!")) from ex
 
-    async def __set_shipping_options(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
+    async def _set_shipping_options(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
         if not ad_cfg.shipping_options:
             raise ValueError(_("shipping_options must be provided"))
 
@@ -2318,7 +2314,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         except TimeoutError as ex:
             raise TimeoutError(_("Unable to close shipping dialog!")) from ex
 
-    async def __upload_images(self, ad_cfg:Ad) -> None:
+    async def _upload_images(self, ad_cfg:Ad) -> None:
         if not ad_cfg.images:
             return
 

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -169,19 +169,19 @@ kleinanzeigen_bot/__init__.py:
     "DONE: updated %s": "FERTIG: %s aktualisiert"
     "ad": "Anzeige"
 
-  __set_condition:
+  _set_condition:
     "Condition value [%s] is deprecated; update your config to [%s].": "Zustandswert [%s] ist veraltet; aktualisieren Sie die Konfiguration auf [%s]."
     "Unable to close condition dialog!": "Kann den Dialog für Artikelzustand nicht schließen!"
     "Unable to select condition [%s]": "Zustand [%s] konnte nicht ausgewählt werden"
     "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"
 
-  __resolve_category_suggestions:
+  _resolve_category_suggestions:
     ? "Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path."
     : "Kategorievorschlag-Auswahl wurde angezeigt, aber kein Segment des konfigurierten Pfades '%(category)s' passte zu den angebotenen Vorschlägen [%(offered)s]. Aktualisieren Sie 'category' auf eine angebotene ID oder einen gültigen vollständigen Pfad."
     "Category suggestion picker: selected value=%s (matched path segment).": "Kategorievorschlag-Auswahl: Wert=%s ausgewählt (passendes Pfad-Segment)."
     "Category suggestion picker element found but no radio suggestions rendered after waiting.": "Kategorievorschlag-Auswahl gefunden, aber auch nach dem Warten wurden keine Radio-Vorschläge gerendert."
 
-  __set_contact_fields:
+  _set_contact_fields:
     "Could not set contact street.": "Kontaktstraße konnte nicht gesetzt werden."
     "Could not set contact name.": "Kontaktname konnte nicht gesetzt werden."
     "Could not set contact zipcode: %s": "Kontakt-PLZ konnte nicht gesetzt werden: %s"
@@ -190,17 +190,17 @@ kleinanzeigen_bot/__init__.py:
     ? "Phone number field not present on page. This is expected for many private accounts; commercial accounts may still support phone numbers."
     : "Telefonnummernfeld auf der Seite nicht vorhanden. Dies ist bei vielen privaten Konten zu erwarten; gewerbliche Konten unterstützen Telefonnummern möglicherweise weiterhin."
 
-  __select_city_combobox_option:
+  _select_city_combobox_option:
     "City combobox options did not load for location: %s": "Stadt-Combobox-Optionen für Ort nicht geladen: %s"
     "City combobox options are ambiguous for location: %s": "Stadt-Combobox-Optionen für Ort sind mehrdeutig: %s"
     "No city combobox option matched location: %s": "Keine Stadt-Combobox-Option passt zum Ort: %s"
     "City selection did not converge for location: %s": "Stadtauswahl ist nicht auf den Ort konvergiert: %s"
 
-  __set_contact_location:
+  _set_contact_location:
     "Unsupported city element type while setting contact location: <%s>": "Nicht unterstützter Stadt-Elementtyp beim Setzen des Kontaktorts: <%s>"
     "ad-city is a <input readonly> with value '%s' (zip-derived) - accepting instead of combobox selection.": "ad-city ist ein <input readonly> mit Wert '%s' (aus PLZ abgeleitet) - übernehme statt Combobox-Auswahl."
 
-  __upload_images:
+  _upload_images:
     " -> found %s": "-> %s gefunden"
     "image": "Bild"
     " -> uploading image %s/%s [%s]": " -> Lade Bild %s/%s [%s] hoch"
@@ -212,10 +212,10 @@ kleinanzeigen_bot/__init__.py:
   check_thumbnails_uploaded:
     " -> %d of %d images processed": " -> %d von %d Bildern verarbeitet"
 
-  __select_button_combobox:
+  _select_button_combobox:
     "Option '%(value)s' not found in button combobox '%(id)s'": "Option '%(value)s' nicht in Button-Combobox '%(id)s' gefunden"
 
-  __set_special_attributes:
+  _set_special_attributes:
     "Found %i special attributes": "%i spezielle Attribute gefunden"
     "Setting special attribute [%s] to [%s]...": "Setze spezielles Attribut [%s] auf [%s]..."
     "Successfully set attribute field [%s] to [%s]...": "Attributfeld [%s] erfolgreich auf [%s] gesetzt..."
@@ -243,7 +243,7 @@ kleinanzeigen_bot/__init__.py:
     "Unknown command: %s": "Unbekannter Befehl: %s"
     "Timing collector flush failed: %s": "Zeitmessdaten konnten nicht gespeichert werden: %s"
 
-  __set_shipping:
+  _set_shipping:
     "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
     "Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.": "Das Versand-Fieldset wird gerendert, aber die Abholungs-Option fehlt; die Seite wurde möglicherweise nicht vollständig geladen."
     ? "Shipping options dialog entry not found. Legacy '.versand_s' select UI is no longer supported and requires dedicated rebuild."
@@ -253,7 +253,7 @@ kleinanzeigen_bot/__init__.py:
     "Unable to set shipping price!": "Versandpreis konnte nicht gesetzt werden!"
     "Unable to close shipping dialog!": "Versanddialog konnte nicht geschlossen werden!"
 
-  __set_shipping_options:
+  _set_shipping_options:
     "Failed to configure shipping options in dialog!": "Versandoptionen konnten im Dialog nicht konfiguriert werden!"
     "Unable to close shipping dialog!": "Versanddialog konnte nicht geschlossen werden!"
     "shipping_options must be provided": "shipping_options müssen angegeben werden!"

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1587,7 +1587,7 @@ class WebScrapingMixin:
             This method uses standard DOM APIs (``querySelectorAll``,
             ``textContent``, ``click()``) and does **not** depend on React
             fiber internals.  It is intended as the future replacement for
-            the React-fiber-based ``__select_button_combobox`` used in special
+            the React-fiber-based ``_select_button_combobox`` used in special
             attribute handling — see GitHub issue #930.
         """
         if timeout is None:
@@ -1625,7 +1625,7 @@ class WebScrapingMixin:
         lives in the inline JavaScript and requires a live browser session for
         meaningful coverage.  The Python wrapper (``json.dumps``, ``isinstance``
         check, return) is trivial boilerplate.  Integration-level routing is
-        tested in ``test_init.py`` via the ``__set_special_attributes`` dispatch.
+        tested in ``test_init.py`` via the ``_set_special_attributes`` dispatch.
 
         Anchors to the specific hidden input identified by *hidden_input_name*
         (e.g. ``attributeMap[baby_kinderkleidung.groesse]``), derives the

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1198,7 +1198,7 @@ class TestKleinanzeigenBotBasics:
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock) as web_open_mock,
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_category", new_callable = AsyncMock, side_effect = TimeoutError("image upload timeout")),
+            patch.object(test_bot, "_set_category", new_callable = AsyncMock, side_effect = TimeoutError("image upload timeout")),
             pytest.raises(TimeoutError, match = "image upload timeout"),
         ):
             await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], mode)
@@ -1237,9 +1237,9 @@ class TestKleinanzeigenBotBasics:
         common_patches:list[Any] = [
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_category", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_special_attributes", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_category", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_contact_fields", new_callable = AsyncMock),
             patch.object(test_bot, "check_and_wait_for_captcha", new_callable = AsyncMock),
             patch.object(test_bot, "web_input", new_callable = AsyncMock),
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
@@ -1432,7 +1432,7 @@ class TestKleinanzeigenBotUpdateAdsResilience:
                 raise first_failure
 
         with (
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(101, 102)),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(101, 102)),
             patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
@@ -1460,7 +1460,7 @@ class TestKleinanzeigenBotUpdateAdsResilience:
                 raise PublishSubmissionUncertainError("submission may have succeeded before failure")
 
         with (
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(301, 302)),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(301, 302)),
             patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
@@ -1486,7 +1486,7 @@ class TestKleinanzeigenBotUpdateAdsResilience:
                 raise CategoryResolutionError("no suggestion matched")
 
         with (
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(303, 304)),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(303, 304)),
             patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
@@ -1502,7 +1502,7 @@ class TestKleinanzeigenBotUpdateAdsResilience:
         ad_two = self._build_update_ad(base_ad_config, 402, "Should Not Run")
 
         with (
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(401, 402)),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(401, 402)),
             patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = asyncio.CancelledError()) as publish_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
             pytest.raises(asyncio.CancelledError),
@@ -1516,7 +1516,7 @@ class TestKleinanzeigenBotUpdateAdsResilience:
         ad_one = self._build_update_ad(base_ad_config, 501, "Result Timeout")
 
         with (
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(501)),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(501)),
             patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = TimeoutError("result timeout")),
         ):
@@ -1551,7 +1551,7 @@ class TestDisplayCounterProgression:
 
         with (
             caplog.at_level(logging.INFO),
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
             patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
@@ -1586,7 +1586,7 @@ class TestDisplayCounterProgression:
 
         with (
             caplog.at_level(logging.INFO),
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
             patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
@@ -1621,7 +1621,7 @@ class TestDisplayCounterProgression:
 
         with (
             caplog.at_level(logging.INFO),
-            patch.object(test_bot, "_fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
             patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
@@ -1656,7 +1656,7 @@ class TestKleinanzeigenBotContactLocationHardening:
         ],
     )
     def test_location_matches_target(self, test_bot:KleinanzeigenBot, target:str, candidate:str | None, expected:bool) -> None:
-        matcher = getattr(test_bot, "_KleinanzeigenBot__location_matches_target")
+        matcher = getattr(test_bot, "_location_matches_target")
         assert matcher(target, candidate) is expected
 
     @pytest.mark.asyncio
@@ -1669,7 +1669,7 @@ class TestKleinanzeigenBotContactLocationHardening:
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = city_input),
             patch.object(test_bot, "web_text", new_callable = AsyncMock) as web_text_mock,
         ):
-            selected = await getattr(test_bot, "_KleinanzeigenBot__read_city_selection_text")()
+            selected = await getattr(test_bot, "_read_city_selection_text")()
 
         assert selected == "Live City"
         web_text_mock.assert_not_awaited()
@@ -1684,10 +1684,10 @@ class TestKleinanzeigenBotContactLocationHardening:
 
         with (
             patch.object(test_bot, "web_input", new_callable = AsyncMock, side_effect = TimeoutError("zip timeout")),
-            patch.object(test_bot, "_KleinanzeigenBot__set_contact_location", new_callable = AsyncMock) as set_location_mock,
+            patch.object(test_bot, "_set_contact_location", new_callable = AsyncMock) as set_location_mock,
             pytest.raises(TimeoutError, match = "Failed to set contact zipcode"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_contact_fields")(ad_cfg.contact)
+            await getattr(test_bot, "_set_contact_fields")(ad_cfg.contact)
 
         set_location_mock.assert_not_awaited()
 
@@ -1703,10 +1703,10 @@ class TestKleinanzeigenBotContactLocationHardening:
 
         with (
             patch.object(test_bot, "web_input", new_callable = AsyncMock) as web_input_mock,
-            patch.object(test_bot, "_KleinanzeigenBot__set_contact_location", new_callable = AsyncMock) as set_location_mock,
+            patch.object(test_bot, "_set_contact_location", new_callable = AsyncMock) as set_location_mock,
             patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = True),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_contact_fields")(ad_cfg.contact)
+            await getattr(test_bot, "_set_contact_fields")(ad_cfg.contact)
 
         web_input_mock.assert_not_awaited()
         set_location_mock.assert_not_awaited()
@@ -1735,11 +1735,11 @@ class TestKleinanzeigenBotContactLocationHardening:
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [option_a, option_b]),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = _web_await_side_effect),
-            patch.object(test_bot, "_KleinanzeigenBot__read_city_selection_text", new_callable = AsyncMock, return_value = None),
-            patch.object(test_bot, "_KleinanzeigenBot__city_option_text", new_callable = AsyncMock, side_effect = _mock_city_option_text),
+            patch.object(test_bot, "_read_city_selection_text", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "_city_option_text", new_callable = AsyncMock, side_effect = _mock_city_option_text),
             pytest.raises(TimeoutError, match = "City combobox options are ambiguous for location: Metroville"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_contact_location")("Metroville")
+            await getattr(test_bot, "_set_contact_location")("Metroville")
 
     @pytest.mark.asyncio
     async def test_set_contact_location_raises_when_selection_does_not_converge(self, test_bot:KleinanzeigenBot) -> None:
@@ -1768,10 +1768,10 @@ class TestKleinanzeigenBotContactLocationHardening:
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [target_option]),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = web_await_side_effect),
-            patch.object(test_bot, "_KleinanzeigenBot__read_city_selection_text", new_callable = AsyncMock, return_value = "20095 - Rivertown"),
+            patch.object(test_bot, "_read_city_selection_text", new_callable = AsyncMock, return_value = "20095 - Rivertown"),
             pytest.raises(TimeoutError, match = "City selection did not converge"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_contact_location")("10115 - Metroville")
+            await getattr(test_bot, "_set_contact_location")("10115 - Metroville")
 
     @pytest.mark.asyncio
     async def test_set_contact_location_accepts_readonly_input_with_zip_derived_value(self, test_bot:KleinanzeigenBot) -> None:
@@ -1781,11 +1781,11 @@ class TestKleinanzeigenBotContactLocationHardening:
         city_input.attrs = {"readonly": "", "value": "Metroville - Riverside"}
 
         with (
-            patch.object(test_bot, "_KleinanzeigenBot__read_city_selection_text", new_callable = AsyncMock, return_value = "Metroville - Riverside"),
+            patch.object(test_bot, "_read_city_selection_text", new_callable = AsyncMock, return_value = "Metroville - Riverside"),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = city_input),
-            patch.object(test_bot, "_KleinanzeigenBot__select_city_combobox_option", new_callable = AsyncMock) as combobox_mock,
+            patch.object(test_bot, "_select_city_combobox_option", new_callable = AsyncMock) as combobox_mock,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_contact_location")("Metroville")
+            await getattr(test_bot, "_set_contact_location")("Metroville")
             combobox_mock.assert_not_called()
 
 
@@ -1981,7 +1981,7 @@ class TestKleinanzeigenBotShippingOptions:
             patch.object(test_bot, "web_request", new_callable = AsyncMock),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock),
             patch.object(test_bot, "web_await", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_contact_fields", new_callable = AsyncMock),
             patch("builtins.input", return_value = ""),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
         ):
@@ -2150,7 +2150,7 @@ class TestKleinanzeigenBotShippingOptions:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "check_and_wait_for_captcha", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_contact_fields", new_callable = AsyncMock),
             patch("builtins.input", return_value = ""),
             patch("kleinanzeigen_bot.utils.misc.ainput", new_callable = AsyncMock, return_value = ""),
         ):
@@ -2221,7 +2221,7 @@ class TestKleinanzeigenBotShippingOptions:
 
             mock_find_all.side_effect = find_all_side_effect
 
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
             assert mock_select.await_count == 1
             assert mock_select.await_args is not None
@@ -2273,10 +2273,10 @@ class TestKleinanzeigenBotShippingOptions:
 
         with (
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [hidden_elem, button_elem]),
-            patch.object(test_bot, "_KleinanzeigenBot__select_button_combobox", new_callable = AsyncMock) as mock_button_combobox,
+            patch.object(test_bot, "_select_button_combobox", new_callable = AsyncMock) as mock_button_combobox,
             patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_button_combobox.assert_awaited_once_with("kleidung_herren.color", "beige")
         mock_input.assert_not_awaited()
@@ -2330,7 +2330,7 @@ class TestKleinanzeigenBotShippingOptions:
             patch.object(test_bot, "web_select_combobox", new_callable = AsyncMock) as mock_select_combobox,
             patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_select_combobox.assert_awaited_once_with(By.ID, "kleidung_herren.brand", "armani")
         mock_input.assert_not_awaited()
@@ -2376,7 +2376,7 @@ class TestKleinanzeigenBotShippingOptions:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [checkbox_elem]),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         if expect_click:
             mock_click.assert_awaited_once_with(By.ID, "feature")
@@ -2391,7 +2391,7 @@ class TestKleinanzeigenBotShippingOptions:
     ) -> None:
         """When XPath matches only a hidden backing input (dynamic React IDs),
         the fallback should locate the associated <button role="combobox"> and use
-        __select_button_combobox.  Regression test for issue #1096."""
+        _select_button_combobox.  Regression test for issue #1096."""
         ad_cfg = Ad.model_validate(
             base_ad_config
             | {
@@ -2424,12 +2424,12 @@ class TestKleinanzeigenBotShippingOptions:
             ) as mock_find_button,
             patch.object(
                 test_bot,
-                "_KleinanzeigenBot__select_button_combobox",
+                "_select_button_combobox",
                 new_callable = AsyncMock,
             ) as mock_select_combobox,
             patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_find_button.assert_awaited_once_with(hidden_input_name = "attributeMap[groesse]")
         mock_select_combobox.assert_awaited_once_with(":r8r7:", "68")
@@ -2474,7 +2474,7 @@ class TestKleinanzeigenBotShippingOptions:
                 return_value = None,
             ) as mock_find_button,pytest.raises(TimeoutError)
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_find_button.assert_awaited_once_with(hidden_input_name = "attributeMap[color]")
 
@@ -2518,11 +2518,11 @@ class TestKleinanzeigenBotShippingOptions:
             ) as mock_find_button,
             patch.object(
                 test_bot,
-                "_KleinanzeigenBot__select_button_combobox",
+                "_select_button_combobox",
                 new_callable = AsyncMock,
             ) as mock_select_combobox,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_find_button.assert_not_awaited()
         mock_select_combobox.assert_awaited_once_with("kleidung_herren.type", "accessoires")
@@ -2559,7 +2559,7 @@ class TestConditionSelector:
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("ok")
+            handled = await getattr(test_bot, "_set_condition")("ok")
 
             assert handled is True
 
@@ -2620,7 +2620,7 @@ class TestConditionSelector:
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")(configured)
+            handled = await getattr(test_bot, "_set_condition")(configured)
 
         assert handled is True
         warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
@@ -2674,7 +2674,7 @@ class TestConditionSelector:
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("wie_neu")
+            handled = await getattr(test_bot, "_set_condition")("wie_neu")
 
         assert handled is True
         warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
@@ -2695,7 +2695,7 @@ class TestConditionSelector:
         caplog.set_level(logging.WARNING, logger = LOG.name)
 
         with patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None):
-            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("wie_neu")
+            handled = await getattr(test_bot, "_set_condition")("wie_neu")
 
         assert handled is False
         warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
@@ -2723,7 +2723,7 @@ class TestConditionSelector:
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = dialog),
             pytest.raises(TimeoutError, match = "Failed to set attribute 'condition_s'"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_condition")("totally_unknown_value")
+            await getattr(test_bot, "_set_condition")("totally_unknown_value")
 
     @pytest.mark.asyncio
     async def test_condition_rejects_shipping_trigger(self, test_bot:KleinanzeigenBot) -> None:
@@ -2746,7 +2746,7 @@ class TestConditionSelector:
             patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            handled = await getattr(test_bot, "_KleinanzeigenBot__set_condition")("new")
+            handled = await getattr(test_bot, "_set_condition")("new")
 
         assert handled is False
         # Regression guard: wrong shipping trigger must never be clicked by condition handler
@@ -2757,8 +2757,8 @@ class TestConditionSelector:
 class TestConditionFallbackToGenericHandler:
     """Regression tests for condition_s fallback behavior.
 
-    When __set_condition reports "not handled" (e.g. category uses a button-combobox
-    instead of a dialog), __set_special_attributes should fall through to the generic
+    When _set_condition reports "not handled" (e.g. category uses a button-combobox
+    instead of a dialog), _set_special_attributes should fall through to the generic
     XPath-based handler.
     """
 
@@ -2796,7 +2796,7 @@ class TestConditionFallbackToGenericHandler:
         with (
             patch.object(
                 test_bot,
-                "_KleinanzeigenBot__set_condition",
+                "_set_condition",
                 new_callable = AsyncMock,
                 return_value = False,
             ) as mock_set_condition,
@@ -2804,11 +2804,11 @@ class TestConditionFallbackToGenericHandler:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [button_elem]),
             patch.object(
                 test_bot,
-                "_KleinanzeigenBot__select_button_combobox",
+                "_select_button_combobox",
                 new_callable = AsyncMock,
             ) as mock_select_combobox,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_set_condition.assert_awaited_once_with(condition_s)
         mock_select_combobox.assert_awaited_once_with("modellbau.condition", expected_generic_value)
@@ -2821,14 +2821,14 @@ class TestConditionFallbackToGenericHandler:
         with (
             patch.object(
                 test_bot,
-                "_KleinanzeigenBot__set_condition",
+                "_set_condition",
                 new_callable = AsyncMock,
                 side_effect = TimeoutError("dialog timeout"),
             ),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock) as mock_find_all,
             pytest.raises(TimeoutError, match = "dialog timeout"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_find_all.assert_not_awaited()
 
@@ -2880,12 +2880,12 @@ class TestConditionFallbackToGenericHandler:
             return None
 
         with (
-            patch.object(test_bot, "_KleinanzeigenBot__set_condition", new_callable = AsyncMock, return_value = False) as mock_set_condition,
+            patch.object(test_bot, "_set_condition", new_callable = AsyncMock, return_value = False) as mock_set_condition,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, side_effect = find_all_side_effect),
-            patch.object(test_bot, "_KleinanzeigenBot__select_button_combobox", new_callable = AsyncMock) as mock_select_combobox,
+            patch.object(test_bot, "_select_button_combobox", new_callable = AsyncMock) as mock_select_combobox,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_set_condition.assert_awaited_once_with("ok")
         mock_select_combobox.assert_awaited_once_with("kleidung_herren.color", "beige")
@@ -2905,12 +2905,12 @@ class TestConditionFallbackToGenericHandler:
         condition_probe.attrs = {"id": "condition_s"}
 
         with (
-            patch.object(test_bot, "_KleinanzeigenBot__set_condition", new_callable = AsyncMock, return_value = False),
+            patch.object(test_bot, "_set_condition", new_callable = AsyncMock, return_value = False),
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = condition_probe),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, side_effect = TimeoutError("lookup timeout")),
             pytest.raises(TimeoutError, match = "lookup timeout"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_special_attributes")(ad_cfg)
+            await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
 
 class TestCategoryProbeBehavior:
@@ -2918,7 +2918,7 @@ class TestCategoryProbeBehavior:
 
     @pytest.mark.asyncio
     async def test_set_category_uses_probe_for_auto_selected_marker(self, test_bot:KleinanzeigenBot) -> None:
-        """In __set_category, category marker lookup should go through web_probe."""
+        """In _set_category, category marker lookup should go through web_probe."""
         category_marker = MagicMock()
         category_marker.apply = AsyncMock(return_value = "Auto Category")
 
@@ -2934,7 +2934,7 @@ class TestCategoryProbeBehavior:
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_category")("185/249", "data/my_ads/ad.yaml")
+            await getattr(test_bot, "_set_category")("185/249", "data/my_ads/ad.yaml")
 
         mock_probe.assert_any_await(By.ID, "ad-category-path")
 
@@ -2946,7 +2946,7 @@ class TestCategoryProbeBehavior:
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             pytest.raises(AssertionError, match = "No category specified"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_category")(None, "data/my_ads/ad.yaml")
+            await getattr(test_bot, "_set_category")(None, "data/my_ads/ad.yaml")
 
 
 class TestCategorySuggestionPicker:
@@ -2982,7 +2982,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock) as mock_find_all,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("73/76/sachbuecher")
+            await getattr(test_bot, "_resolve_category_suggestions")("73/76/sachbuecher")
 
         mock_find_all.assert_not_awaited()
         mock_click.assert_not_awaited()
@@ -2997,7 +2997,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             pytest.raises(TimeoutError, match = "Category suggestion picker element found but no radio suggestions rendered after waiting."),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("73/76/sachbuecher")
+            await getattr(test_bot, "_resolve_category_suggestions")("73/76/sachbuecher")
 
         assert mock_find_all.await_count == 2
         mock_sleep.assert_awaited_once()
@@ -3017,7 +3017,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("73/77")
+            await getattr(test_bot, "_resolve_category_suggestions")("73/77")
 
         mock_click.assert_awaited_once()
         selector_type, selector_value = mock_click.call_args.args[:2]
@@ -3040,7 +3040,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             pytest.raises(CategoryResolutionError, match = r"Category suggestion picker shown.*offered") as exc_info,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("999/888")
+            await getattr(test_bot, "_resolve_category_suggestions")("999/888")
 
         mock_click.assert_not_awaited()
         error_message = str(exc_info.value)
@@ -3060,7 +3060,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__resolve_category_suggestions")("76/77")
+            await getattr(test_bot, "_resolve_category_suggestions")("76/77")
 
         mock_click.assert_awaited_once()
         assert "label[@for='id-for-77']" in mock_click.call_args.args[1]
@@ -3085,7 +3085,7 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = selected),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
         mock_probe.assert_awaited_once()
         assert mock_probe.call_args.args[:2] == (By.ID, "ad-shipping-enabled-no")
@@ -3105,7 +3105,7 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = TimeoutError("pickup lookup timed out")),
             pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'PICKUP'!"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
     @pytest.mark.asyncio
     async def test_pickup_shipping_skips_when_toggle_not_rendered(
@@ -3123,7 +3123,7 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_check", new_callable = AsyncMock) as mock_check,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
         mock_check.assert_not_awaited()
         mock_click.assert_not_awaited()
@@ -3146,7 +3146,7 @@ class TestShippingDialogFlow:
                 match = "Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.",
             ),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
         assert mock_probe.await_count == 2
         assert [call.args[:2] for call in mock_probe.await_args_list] == [
@@ -3165,11 +3165,11 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "_KleinanzeigenBot__set_input_value", new_callable = AsyncMock) as mock_set_input,
+            patch.object(test_bot, "_set_input_value", new_callable = AsyncMock) as mock_set_input,
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = "4,95"),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
             click_args = [c.args for c in mock_click.await_args_list]
             assert any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
@@ -3192,7 +3192,7 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             pytest.raises(TimeoutError, match = "Unable to close shipping dialog!"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
     @pytest.mark.asyncio
     async def test_shipping_without_options_does_not_toggle_checkbox_when_price_input_visible(
@@ -3207,11 +3207,11 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "_KleinanzeigenBot__set_input_value", new_callable = AsyncMock) as mock_set_input,
+            patch.object(test_bot, "_set_input_value", new_callable = AsyncMock) as mock_set_input,
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = "4,95"),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
         click_args = [c.args for c in mock_click.await_args_list]
         assert not any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
@@ -3227,9 +3227,9 @@ class TestShippingDialogFlow:
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
 
         async def set_input_side_effect(element_id:str, value:str) -> None:
-            # Simulate __set_input_value succeeding (no TimeoutError) but
+            # Simulate _set_input_value succeeding (no TimeoutError) but
             # the JS returning early because the element is null after re-render.
-            # The real __set_input_value does a web_find + web_execute whose JS
+            # The real _set_input_value does a web_find + web_execute whose JS
             # silently returns on `if(!el) return;`.  By mocking at this level we
             # model the observable effect: the call completes without error, but
             # the DOM value was never written.
@@ -3239,12 +3239,12 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "_KleinanzeigenBot__set_input_value", new_callable = AsyncMock, side_effect = set_input_side_effect),
+            patch.object(test_bot, "_set_input_value", new_callable = AsyncMock, side_effect = set_input_side_effect),
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             pytest.raises(TimeoutError, match = "Unable to set shipping price!"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
         # Fertig must never be clicked when the price was not confirmed
         fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
@@ -3263,11 +3263,11 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "_KleinanzeigenBot__set_input_value", new_callable = AsyncMock) as mock_set_input,
+            patch.object(test_bot, "_set_input_value", new_callable = AsyncMock) as mock_set_input,
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = [None, "4,95"]),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
         assert mock_set_input.await_count == 2, "expected exactly one retry after the first mismatch"
         inter_attempt_sleeps = [c for c in mock_sleep.await_args_list if c.args == (300, 500)]
@@ -3296,11 +3296,11 @@ class TestShippingDialogFlow:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "_KleinanzeigenBot__set_input_value", new_callable = AsyncMock) as mock_set_input,
+            patch.object(test_bot, "_set_input_value", new_callable = AsyncMock) as mock_set_input,
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = readback_side_effect),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping")(ad_cfg)
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
 
         assert mock_set_input.await_count == 2, "expected one retry after the readback raised"
         fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
@@ -3308,7 +3308,7 @@ class TestShippingDialogFlow:
 
 
 class TestShippingOptionsDialog:
-    """Tests for __set_shipping_options using carrier-code-based selectors."""
+    """Tests for _set_shipping_options using carrier-code-based selectors."""
 
     @staticmethod
     def _make_ad_with_options(base_ad_config:dict[str, Any], options:list[str]) -> Ad:
@@ -3373,7 +3373,7 @@ class TestShippingOptionsDialog:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.REPLACE)
+            await getattr(test_bot, "_set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.REPLACE)
 
         click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
 
@@ -3418,7 +3418,7 @@ class TestShippingOptionsDialog:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.REPLACE)
+            await getattr(test_bot, "_set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.REPLACE)
 
         click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
 
@@ -3455,7 +3455,7 @@ class TestShippingOptionsDialog:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.MODIFY)
+            await getattr(test_bot, "_set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.MODIFY)
 
         click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
         # HERMES_002 should be deselected (was checked, not wanted)
@@ -3480,7 +3480,7 @@ class TestShippingOptionsDialog:
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
             pytest.raises(KeyError, match = "Unknown shipping option"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping_options")(ad_cfg)
+            await getattr(test_bot, "_set_shipping_options")(ad_cfg)
 
         # Validation errors must occur before any DOM interaction
         mock_find.assert_not_awaited()
@@ -3502,7 +3502,7 @@ class TestShippingOptionsDialog:
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
             pytest.raises(ValueError, match = "one package size"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping_options")(ad_cfg)
+            await getattr(test_bot, "_set_shipping_options")(ad_cfg)
 
         # Validation errors must occur before any DOM interaction
         mock_find.assert_not_awaited()
@@ -3520,7 +3520,7 @@ class TestShippingOptionsDialog:
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             pytest.raises(TimeoutError, match = "Failed to configure shipping options in dialog!"),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__set_shipping_options")(ad_cfg)
+            await getattr(test_bot, "_set_shipping_options")(ad_cfg)
 
 
 class TestWantedShippingSelection:
@@ -3551,12 +3551,12 @@ class TestWantedShippingSelection:
             patch("kleinanzeigen_bot.ainput", new_callable = AsyncMock, return_value = ""),
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_category", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_special_attributes", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_shipping", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__upload_images", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_input_value", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_category", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_shipping", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_contact_fields", new_callable = AsyncMock),
+            patch.object(test_bot, "_upload_images", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_input_value", new_callable = AsyncMock),
             patch.object(test_bot, "check_and_wait_for_captcha", new_callable = AsyncMock),
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
@@ -3781,16 +3781,16 @@ class TestBuyNowRadioWarning:
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_category", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_special_attributes", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_shipping", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_category", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_shipping", new_callable = AsyncMock),
             patch.object(test_bot, "web_input", new_callable = AsyncMock),
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect) as mock_probe,
             patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = check_side_effect) as mock_check,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_execute", side_effect = execute_side_effect),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_contact_fields", new_callable = AsyncMock),
             patch.object(test_bot, "web_find", new_callable = AsyncMock),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
@@ -3975,7 +3975,7 @@ class TestImageUploadProcessedMarkerFallback:
             raise TimeoutError("condition did not pass")
 
         with self._mock_upload_dependencies(test_bot, file_input, find_all_side_effect, await_side_effect):
-            await getattr(test_bot, "_KleinanzeigenBot__upload_images")(ad_cfg)
+            await getattr(test_bot, "_upload_images")(ad_cfg)
 
         file_input.send_file.assert_any_await(image_a)
         file_input.send_file.assert_any_await(image_b)
@@ -4026,7 +4026,7 @@ class TestImageUploadProcessedMarkerFallback:
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = await_side_effect),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__upload_images")(ad_cfg)
+            await getattr(test_bot, "_upload_images")(ad_cfg)
 
         first_file_input.send_file.assert_awaited_once_with(image_a)
         second_file_input.send_file.assert_awaited_once_with(image_b)
@@ -4073,7 +4073,7 @@ class TestImageUploadProcessedMarkerFallback:
             pytest.raises(TimeoutError, match = rf"Expected 2, found {expected_found} processed"),
             self._mock_upload_dependencies(test_bot, file_input, find_all_side_effect, await_timeout),
         ):
-            await getattr(test_bot, "_KleinanzeigenBot__upload_images")(ad_cfg)
+            await getattr(test_bot, "_upload_images")(ad_cfg)
 
         file_input.send_file.assert_any_await(image_a)
         file_input.send_file.assert_any_await(image_b)
@@ -4111,7 +4111,7 @@ class TestImageUploadProcessedMarkerFallback:
             raise TimeoutError("condition did not pass")
 
         with self._mock_upload_dependencies(test_bot, file_input, find_all_side_effect, await_side_effect):
-            await getattr(test_bot, "_KleinanzeigenBot__upload_images")(ad_cfg)
+            await getattr(test_bot, "_upload_images")(ad_cfg)
 
         file_input.send_file.assert_any_await(image_a)
         file_input.send_file.assert_any_await(image_b)
@@ -4148,7 +4148,7 @@ class TestImageUploadProcessedMarkerFallback:
             raise TimeoutError("condition did not pass")
 
         with self._mock_upload_dependencies(test_bot, file_input, find_all_side_effect, await_side_effect):
-            await getattr(test_bot, "_KleinanzeigenBot__upload_images")(ad_cfg)
+            await getattr(test_bot, "_upload_images")(ad_cfg)
 
         file_input.send_file.assert_any_await(image_a)
         file_input.send_file.assert_any_await(image_b)
@@ -4193,7 +4193,7 @@ class TestImageUploadProcessedMarkerFallback:
             raise TimeoutError("condition did not pass")
 
         with self._mock_upload_dependencies(test_bot, file_input, find_all_side_effect, await_side_effect):
-            await getattr(test_bot, "_KleinanzeigenBot__upload_images")(ad_cfg)
+            await getattr(test_bot, "_upload_images")(ad_cfg)
 
         file_input.send_file.assert_any_await(image_a)
         file_input.send_file.assert_any_await(image_b)
@@ -4258,9 +4258,9 @@ class TestImageCleanupInPublishAd:
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_category", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_special_attributes", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_shipping", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_category", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_shipping", new_callable = AsyncMock),
             patch.object(test_bot, "web_input", new_callable = AsyncMock),
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
             patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
@@ -4268,8 +4268,8 @@ class TestImageCleanupInPublishAd:
             patch.object(test_bot, "web_execute", side_effect = execute_side_effect),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__set_contact_fields", new_callable = AsyncMock),
-            patch.object(test_bot, "_KleinanzeigenBot__upload_images", new_callable = AsyncMock, side_effect = upload_side_effect) as mock_upload,
+            patch.object(test_bot, "_set_contact_fields", new_callable = AsyncMock),
+            patch.object(test_bot, "_upload_images", new_callable = AsyncMock, side_effect = upload_side_effect) as mock_upload,
             patch.object(test_bot, "check_and_wait_for_captcha", new_callable = AsyncMock),
             patch.object(test_bot, "web_find", new_callable = AsyncMock),
             patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, side_effect = find_all_side_effect),


### PR DESCRIPTION
## ℹ️ Description

Mechanical prep work for the publishing/update workflow extraction. No behavior changes — purely renaming and cleanup.

## 📋 Changes Summary

- Rename 19 double-underscore form methods (`__method` → `_method`) in `__init__.py`
- Remove the temporary `_fetch_published_ads()` delegator; `publish_ads()` and `update_ads()` now call `published_ads.fetch_published_ads()` directly
- Fix local variable naming in publish/update to use `published_ads_list` to avoid shadowing the `published_ads` module
- Update 95 test references from mangled names (`_KleinanzeigenBot__*`) to single-underscore names (`_*`)
- Update 8 test patches from `patch.object(test_bot, "_fetch_published_ads", ...)` to `patch("kleinanzeigen_bot.published_ads.fetch_published_ads", ...)`
- Update 10 translation section headers in `translations.de.yaml` to match renamed method names
- Preserve `@staticmethod` decorators on `_location_matches_target`, `_special_attribute_candidate_priority`, and `_describe_special_attribute_candidate`

### ⚙️ Type of Change

- [x] ✨ New feature (adds new functionality without breaking existing usage)
  → Actually a refactor: no user-facing changes, purely internal restructuring.

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shipping price persistence with retry logic to ensure values are correctly set and verified.

* **Refactor**
  * Internal code structure improvements for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->