### PR TITLE
refactor: extract _delete_old_ad_if_needed helper from publish paths

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -6,7 +6,7 @@ import urllib.parse as urllib_parse
 from dataclasses import dataclass, replace
 from gettext import gettext as _
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Sequence, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, Sequence, cast
 
 import certifi, colorama  # isort: skip
 from nodriver.core.connection import ProtocolException
@@ -923,6 +923,33 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             ):
                 LOG.info("Local path renaming (%s): no local paths needed renaming", id_label)
 
+    async def _delete_old_ad_if_needed(
+        self, ad_cfg:Ad, published_ads_list:list[PublishedAd],
+        *, timing:Literal["BEFORE_PUBLISH", "AFTER_PUBLISH"],
+    ) -> None:
+        """Delete an old ad before or after (re-)publishing, depending on config.
+
+        Skips deletion when keep_old_ads is True or when the configured
+        ``delete_old_ads`` timing does not match *timing*.
+
+        In ``AFTER_PUBLISH`` mode, title-based deletion is always disabled to
+        avoid accidentally removing the newly published ad.
+        """
+        if self.keep_old_ads:
+            return
+        if self.config.publishing.delete_old_ads != timing:
+            return
+        delete_old_ads_by_title = (
+            self.config.publishing.delete_old_ads_by_title
+            if timing == "BEFORE_PUBLISH" else False
+        )
+        await delete_flow.delete_ad(
+            web = self, root_url = self.root_url,
+            ad_cfg = ad_cfg,
+            published_ads_list = published_ads_list,
+            delete_old_ads_by_title = delete_old_ads_by_title,
+        )
+
     async def publish_ads(self, ad_cfgs:list[tuple[str, Ad, dict[str, Any]]]) -> None:
         count = 0
         failed_count = 0
@@ -992,13 +1019,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 except TimeoutError:
                     LOG.warning(" -> Could not confirm publishing for '%s', but ad may be online", ad_cfg.title)
 
-            if success and self.config.publishing.delete_old_ads == "AFTER_PUBLISH" and not self.keep_old_ads:
-                await delete_flow.delete_ad(
-                    web = self, root_url = self.root_url,
-                    ad_cfg = ad_cfg,
-                    published_ads_list = published_ads_list,
-                    delete_old_ads_by_title = False,
-                )
+                await self._delete_old_ad_if_needed(ad_cfg, published_ads_list, timing = "AFTER_PUBLISH")
 
         LOG.info("############################################")
         if failed_count > 0:
@@ -1027,13 +1048,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         old_ad_id = ad_cfg.id
 
         if mode == AdUpdateStrategy.REPLACE:
-            if self.config.publishing.delete_old_ads == "BEFORE_PUBLISH" and not self.keep_old_ads:
-                await delete_flow.delete_ad(
-                    web = self, root_url = self.root_url,
-                    ad_cfg = ad_cfg,
-                    published_ads_list = published_ads,
-                    delete_old_ads_by_title = self.config.publishing.delete_old_ads_by_title,
-                )
+            await self._delete_old_ad_if_needed(ad_cfg, published_ads, timing = "BEFORE_PUBLISH")
 
             # Apply auto price reduction in REPLACE mode (republish flow)
             _price_reduction.apply_auto_price_reduction(


### PR DESCRIPTION
## ℹ️ Description

Replace two near-duplicate delete-guard blocks in `publish_ads()` (`AFTER_PUBLISH`) and `publish_ad()` (`BEFORE_PUBLISH`) with a single `KleinanzeigenBot._delete_old_ad_if_needed()` private method that centralises `keep_old_ads`, `delete_old_ads` timing, and title-based-deletion logic.

## 📋 Changes Summary

- **New helper** `_delete_old_ad_if_needed(ad_cfg, published_ads_list, *, timing)` centralises `keep_old_ads`, `delete_old_ads` timing, and title-based-deletion guards; delegates to `delete_flow.delete_ad()`
- **`publish_ads` AFTER_PUBLISH**: 7-line `if success and ... and not keep_old_ads:` + `delete_flow.delete_ad()` → 1-line call inside existing `if success:` block
- **`publish_ad` BEFORE_PUBLISH**: Nested 7-line guard + `delete_flow.delete_ad()` → 1-line call under existing `if mode == REPLACE:`
- Added `Literal` to typing import

### ⚙️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

Internal refactoring only — no user-facing behavior or CLI changes.

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal logic for ad deletion handling to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->