### PR TITLE
refactor: extract persist_published_ad() to publishing_flow.py

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1293,7 +1293,13 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         ad_id = await self._submit_and_confirm_ad(ad_file, ad_cfg, mode)
 
-        publishing_flow.persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode, config = self.config)
+        try:
+            publishing_flow.persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode, config = self.config)
+        except Exception:
+            LOG.error(  # noqa: G201 — must use .error(exc_info=True) for translation lookup to resolve publish_ad
+                "Post-publish persistence failed for '%s' (ad ID %s — ad is live on Kleinanzeigen but local YAML may be out of sync)",
+                ad_cfg.title, ad_id, exc_info = True,
+            )
 
     async def _try_recover_ad_id_from_redirect(self) -> int | None:
         """Try to extract the published ad ID from page tracking data.

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -13,9 +13,10 @@ from nodriver.core.connection import ProtocolException
 from ruamel.yaml import YAML
 
 from . import ad_form_helpers as _ad_form_helpers
-from . import ad_loading, delete_flow, download_flow, extend_flow, published_ads, publishing_flow
+from . import ad_loading, delete_flow, download_flow, extend_flow, published_ads
 from . import ad_state as _ad_state
 from . import price_reduction as _price_reduction
+from . import publishing_flow as _publishing_flow
 from . import runtime_config as _runtime_config
 from ._version import __version__
 from .ad_description import get_ad_description
@@ -1294,7 +1295,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         ad_id = await self._submit_and_confirm_ad(ad_file, ad_cfg, mode)
 
         try:
-            publishing_flow.persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode, config = self.config)
+            _publishing_flow.persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode, config = self.config)
         except Exception:
             LOG.error(  # noqa: G201 — must use .error(exc_info=True) for translation lookup to resolve publish_ad
                 "Post-publish persistence failed for '%s' (ad ID %s - ad is live on Kleinanzeigen but local YAML may be out of sync)",

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 import asyncio, enum, importlib, json, os, re, sys  # isort: skip
 import urllib.parse as urllib_parse
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from gettext import gettext as _
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Literal, Sequence, cast
@@ -13,9 +13,8 @@ from nodriver.core.connection import ProtocolException
 from ruamel.yaml import YAML
 
 from . import ad_form_helpers as _ad_form_helpers
-from . import ad_loading, delete_flow, download_flow, extend_flow, published_ads
+from . import ad_loading, delete_flow, download_flow, extend_flow, published_ads, publishing_flow
 from . import ad_state as _ad_state
-from . import local_path_renaming as _local_path_renaming
 from . import price_reduction as _price_reduction
 from . import runtime_config as _runtime_config
 from ._version import __version__
@@ -25,7 +24,6 @@ from .model.ad_model import (
     CARRIER_CODES_BY_SIZE,
     SIZE_INFO_BY_CARRIER_CODE,
     Ad,
-    AdPartial,
     Contact,
 )
 from .model.ad_model import (
@@ -35,7 +33,6 @@ from .model.config_model import Config  # noqa: TC001 — used at runtime, confi
 from .published_ads import PublishedAd, ad_matches_id
 from .update_checker import UpdateChecker
 from .utils import diagnostics as _diagnostics
-from .utils import dicts as _dicts
 from .utils import loggers as _loggers
 from .utils import misc as _misc
 from .utils import xdg_paths as _xdg_paths
@@ -884,45 +881,6 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # Check for success messages
         return await self.web_check(By.ID, "checking-done", Is.DISPLAYED) or await self.web_check(By.ID, "not-completed", Is.DISPLAYED)
 
-    def _log_local_path_rename_result(self, result:_local_path_renaming.LocalPathRenameResult, ad_id:int) -> None:
-        """Log a human-readable summary of local path renaming after a republish."""
-        path_old_id = result.path_old_id if result.path_old_id is not None else result.yaml_old_id
-        id_label = f"ID {path_old_id} -> ID {ad_id}"
-        if result.path_old_id is not None and result.yaml_old_id is not None and result.path_old_id != result.yaml_old_id:
-            id_label += f" (YAML had ID {result.yaml_old_id})"
-
-        renamed:list[str] = []
-        if result.folder_status == _local_path_renaming.RenameStatus.RENAMED:
-            renamed.append(_("folder"))
-        if result.file_status == _local_path_renaming.RenameStatus.RENAMED:
-            renamed.append(_("ad file"))
-        if result.renamed_image_count > 0:
-            renamed.append(f"{result.renamed_image_count} {_('image(s)')}")
-
-        blocked:list[str] = []
-        if result.file_status in {_local_path_renaming.RenameStatus.TARGET_EXISTS, _local_path_renaming.RenameStatus.ERROR}:
-            blocked.append(_("ad file"))
-        if result.folder_status in {_local_path_renaming.RenameStatus.TARGET_EXISTS, _local_path_renaming.RenameStatus.ERROR}:
-            blocked.append(_("ad folder"))
-        if result.blocked_image_count > 0:
-            blocked.append(f"{result.blocked_image_count} {_('image(s)')}")
-
-        if renamed:
-            LOG.info("Local path renaming (%s): %s", id_label, ", ".join(renamed))
-            if _local_path_renaming.RenameStatus.RENAMED in {result.file_status, result.folder_status}:
-                LOG.info("Updated ad file: %s", result.ad_file)
-
-        if blocked:
-            LOG.warning("Local path renaming (%s): could not rename %s (target exists or error)", id_label, ", ".join(blocked))
-
-        if not renamed and not blocked:
-            if (
-                result.yaml_old_id is not None
-                and result.yaml_old_id != ad_id
-                and self.config.publishing.local_path_renaming.mode == "TEMPLATE_MATCH"
-            ):
-                LOG.info("Local path renaming (%s): no local paths needed renaming", id_label)
-
     async def _delete_old_ad_if_needed(
         self, ad_cfg:Ad, published_ads_list:list[PublishedAd],
         *, timing:Literal["BEFORE_PUBLISH", "AFTER_PUBLISH"],
@@ -1281,85 +1239,6 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         return ad_id
 
-    async def _persist_published_ad(
-        self, ad_file:str, ad_cfg:Ad, ad_cfg_orig:dict[str, Any],
-        old_ad_id:int | None, ad_id:int, mode:AdUpdateStrategy,
-    ) -> None:
-        """Write the published ad ID, hash, timestamps, and counters back to the
-        YAML file, then rename local paths to match the new ID."""
-
-        ad_cfg_orig["id"] = ad_id
-        # Rename referenced images before hashing/saving so the YAML content and
-        # content_hash reflect only image file renames that actually succeeded.
-        image_result = _local_path_renaming.rename_referenced_local_image_files_after_id_change(
-            Path(ad_file),
-            ad_cfg_orig.get("images"),
-            old_id = old_ad_id,
-            new_id = ad_id,
-            ad_file_name_template = self.config.download.ad_file_name_template,
-            enabled = self.config.publishing.local_path_renaming.mode == "TEMPLATE_MATCH",
-        )
-        if image_result.updated_images is not None:
-            ad_cfg_orig["images"] = image_result.updated_images
-
-        # Update content hash after successful publication
-        # Calculate hash on original config to ensure consistent comparison on restart
-        ad_cfg_orig["content_hash"] = AdPartial.model_validate(ad_cfg_orig).update_content_hash().content_hash
-        ad_cfg_orig["updated_on"] = _misc.now().isoformat(timespec = "seconds")
-        if not ad_cfg.created_on and not ad_cfg.id:
-            ad_cfg_orig["created_on"] = ad_cfg_orig["updated_on"]
-
-        # Increment repost_count only for REPLACE operations (actual reposts)
-        if mode == AdUpdateStrategy.REPLACE:
-            # Increment repost_count after successful publish
-            # Note: This happens AFTER publish, so price reduction logic (which runs before publish)
-            # sees the count from the PREVIOUS run. This is intentional: the first publish uses
-            # repost_count=0 (no reduction), the second publish uses repost_count=1 (first reduction), etc.
-            current_reposts = int(ad_cfg_orig.get("repost_count", ad_cfg.repost_count or 0))
-            ad_cfg_orig["repost_count"] = current_reposts + 1
-            ad_cfg.repost_count = ad_cfg_orig["repost_count"]
-
-        # Persist price_reduction_count after successful publish/update.
-        # This ensures failed submissions don't incorrectly increment the reduction counter.
-        if ad_cfg.price_reduction_count is not None and ad_cfg.price_reduction_count > 0:
-            ad_cfg_orig["price_reduction_count"] = ad_cfg.price_reduction_count
-
-        if mode == AdUpdateStrategy.REPLACE:
-            LOG.info(" -> SUCCESS: ad published with ID %s", ad_id)
-        else:
-            LOG.info(" -> SUCCESS: ad updated with ID %s", ad_id)
-
-        try:
-            _dicts.save_dict(ad_file, ad_cfg_orig)
-        except Exception:
-            for old_path, new_path in image_result.renamed_paths:
-                try:
-                    new_path.rename(old_path)
-                except OSError:
-                    LOG.warning("Failed to rollback image rename: %s -> %s", new_path, old_path)
-            raise
-        # Rename the YAML file and containing folder after saving, because the
-        # saved file itself may move as part of this opt-in local migration.
-        file_folder_result = _local_path_renaming.rename_local_ad_file_and_folder_after_id_change(
-            Path(ad_file),
-            old_id = old_ad_id,
-            new_id = ad_id,
-            ad_file_name_template = self.config.download.ad_file_name_template,
-            folder_name_template = self.config.download.folder_name_template,
-            enabled = self.config.publishing.local_path_renaming.mode == "TEMPLATE_MATCH",
-        )
-        rename_result = replace(
-            file_folder_result,
-            renamed_image_count = image_result.renamed_count,
-            blocked_image_count = image_result.blocked_count,
-            yaml_old_id = old_ad_id,
-        )
-        self._log_local_path_rename_result(rename_result, ad_id)
-        # NOTE: ad_file string may differ from rename_result.ad_file after the call above.
-        # ad_file is stale at this point (pointing to the pre-rename path), but
-        # no code in publish_ad() dereferences it after this line, so the drift
-        # has no runtime impact.
-
     async def publish_ad(
         self, ad_file:str, ad_cfg:Ad, ad_cfg_orig:dict[str, Any], published_ads_list:list[PublishedAd], mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE
     ) -> None:
@@ -1414,7 +1293,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         ad_id = await self._submit_and_confirm_ad(ad_file, ad_cfg, mode)
 
-        await self._persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode)
+        publishing_flow.persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode, config = self.config)
 
     async def _try_recover_ad_id_from_redirect(self) -> int | None:
         """Try to extract the published ad ID from page tracking data.

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1297,7 +1297,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             publishing_flow.persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode, config = self.config)
         except Exception:
             LOG.error(  # noqa: G201 — must use .error(exc_info=True) for translation lookup to resolve publish_ad
-                "Post-publish persistence failed for '%s' (ad ID %s — ad is live on Kleinanzeigen but local YAML may be out of sync)",
+                "Post-publish persistence failed for '%s' (ad ID %s - ad is live on Kleinanzeigen but local YAML may be out of sync)",
                 ad_cfg.title, ad_id, exc_info = True,
             )
 

--- a/src/kleinanzeigen_bot/delete_flow.py
+++ b/src/kleinanzeigen_bot/delete_flow.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """Ad deletion browser workflow."""

--- a/src/kleinanzeigen_bot/download_flow.py
+++ b/src/kleinanzeigen_bot/download_flow.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """Ad download browser workflow."""

--- a/src/kleinanzeigen_bot/extend_flow.py
+++ b/src/kleinanzeigen_bot/extend_flow.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """Ad extension browser workflow."""

--- a/src/kleinanzeigen_bot/published_ads.py
+++ b/src/kleinanzeigen_bot/published_ads.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """Published ads fetching with API pagination."""

--- a/src/kleinanzeigen_bot/publishing_flow.py
+++ b/src/kleinanzeigen_bot/publishing_flow.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+from dataclasses import replace
+from gettext import gettext as _
+from pathlib import Path
+from typing import Any
+
+from . import local_path_renaming as _local_path_renaming
+from .model.ad_model import Ad, AdPartial, AdUpdateStrategy
+from .model.config_model import Config
+from .utils import dicts as _dicts
+from .utils import loggers as _loggers
+from .utils import misc as _misc
+
+LOG = _loggers.get_logger(__name__)
+
+
+def _log_local_path_rename_result(
+    result:_local_path_renaming.LocalPathRenameResult,
+    ad_id:int,
+    local_path_renaming_mode:str,
+) -> None:
+    """Log a human-readable summary of local path renaming after a republish."""
+    path_old_id = result.path_old_id if result.path_old_id is not None else result.yaml_old_id
+    id_label = f"ID {path_old_id} -> ID {ad_id}"
+    if result.path_old_id is not None and result.yaml_old_id is not None and result.path_old_id != result.yaml_old_id:
+        id_label += f" (YAML had ID {result.yaml_old_id})"
+
+    renamed:list[str] = []
+    if result.folder_status == _local_path_renaming.RenameStatus.RENAMED:
+        renamed.append(_("folder"))
+    if result.file_status == _local_path_renaming.RenameStatus.RENAMED:
+        renamed.append(_("ad file"))
+    if result.renamed_image_count > 0:
+        renamed.append(f"{result.renamed_image_count} {_('image(s)')}")
+
+    blocked:list[str] = []
+    if result.file_status in {_local_path_renaming.RenameStatus.TARGET_EXISTS, _local_path_renaming.RenameStatus.ERROR}:
+        blocked.append(_("ad file"))
+    if result.folder_status in {_local_path_renaming.RenameStatus.TARGET_EXISTS, _local_path_renaming.RenameStatus.ERROR}:
+        blocked.append(_("ad folder"))
+    if result.blocked_image_count > 0:
+        blocked.append(f"{result.blocked_image_count} {_('image(s)')}")
+
+    if renamed:
+        LOG.info("Local path renaming (%s): %s", id_label, ", ".join(renamed))
+        if _local_path_renaming.RenameStatus.RENAMED in {result.file_status, result.folder_status}:
+            LOG.info("Updated ad file: %s", result.ad_file)
+
+    if blocked:
+        LOG.warning("Local path renaming (%s): could not rename %s (target exists or error)", id_label, ", ".join(blocked))
+
+    if not renamed and not blocked:
+        if (
+            result.yaml_old_id is not None
+            and result.yaml_old_id != ad_id
+            and local_path_renaming_mode == "TEMPLATE_MATCH"
+        ):
+            LOG.info("Local path renaming (%s): no local paths needed renaming", id_label)
+
+
+def persist_published_ad(
+    ad_file:str,
+    ad_cfg:Ad,
+    ad_cfg_orig:dict[str, Any],
+    old_ad_id:int | None,
+    ad_id:int,
+    mode:AdUpdateStrategy,
+    *,
+    config:Config,
+) -> None:
+    """Write the published ad ID, hash, timestamps, and counters back to the
+    YAML file, then rename local paths to match the new ID."""
+    ad_cfg_orig["id"] = ad_id
+    # Rename referenced images before hashing/saving so the YAML content and
+    # content_hash reflect only image file renames that actually succeeded.
+    image_result = _local_path_renaming.rename_referenced_local_image_files_after_id_change(
+        Path(ad_file),
+        ad_cfg_orig.get("images"),
+        old_id = old_ad_id,
+        new_id = ad_id,
+        ad_file_name_template = config.download.ad_file_name_template,
+        enabled = config.publishing.local_path_renaming.mode == "TEMPLATE_MATCH",
+    )
+    if image_result.updated_images is not None:
+        ad_cfg_orig["images"] = image_result.updated_images
+
+    # Update content hash after successful publication
+    # Calculate hash on original config to ensure consistent comparison on restart
+    ad_cfg_orig["content_hash"] = AdPartial.model_validate(ad_cfg_orig).update_content_hash().content_hash
+    ad_cfg_orig["updated_on"] = _misc.now().isoformat(timespec = "seconds")
+    if not ad_cfg.created_on and not ad_cfg.id:
+        ad_cfg_orig["created_on"] = ad_cfg_orig["updated_on"]
+
+    # Increment repost_count only for REPLACE operations (actual reposts)
+    if mode == AdUpdateStrategy.REPLACE:
+        # Increment repost_count after successful publish
+        # Note: This happens AFTER publish, so price reduction logic (which runs before publish)
+        # sees the count from the PREVIOUS run. This is intentional: the first publish uses
+        # repost_count=0 (no reduction), the second publish uses repost_count=1 (first reduction), etc.
+        current_reposts = int(ad_cfg_orig.get("repost_count", ad_cfg.repost_count or 0))
+        ad_cfg_orig["repost_count"] = current_reposts + 1
+        ad_cfg.repost_count = ad_cfg_orig["repost_count"]
+
+    # Persist price_reduction_count after successful publish/update.
+    # This ensures failed submissions don't incorrectly increment the reduction counter.
+    if ad_cfg.price_reduction_count is not None and ad_cfg.price_reduction_count > 0:
+        ad_cfg_orig["price_reduction_count"] = ad_cfg.price_reduction_count
+
+    if mode == AdUpdateStrategy.REPLACE:
+        LOG.info(" -> SUCCESS: ad published with ID %s", ad_id)
+    else:
+        LOG.info(" -> SUCCESS: ad updated with ID %s", ad_id)
+
+    try:
+        _dicts.save_dict(ad_file, ad_cfg_orig)
+    except Exception:
+        for old_path, new_path in image_result.renamed_paths:
+            try:
+                new_path.rename(old_path)
+            except OSError:
+                LOG.warning("Failed to rollback image rename: %s -> %s", new_path, old_path)
+        raise
+    # Rename the YAML file and containing folder after saving, because the
+    # saved file itself may move as part of this opt-in local migration.
+    file_folder_result = _local_path_renaming.rename_local_ad_file_and_folder_after_id_change(
+        Path(ad_file),
+        old_id = old_ad_id,
+        new_id = ad_id,
+        ad_file_name_template = config.download.ad_file_name_template,
+        folder_name_template = config.download.folder_name_template,
+        enabled = config.publishing.local_path_renaming.mode == "TEMPLATE_MATCH",
+    )
+    rename_result = replace(
+        file_folder_result,
+        renamed_image_count = image_result.renamed_count,
+        blocked_image_count = image_result.blocked_count,
+        yaml_old_id = old_ad_id,
+    )
+    _log_local_path_rename_result(rename_result, ad_id, local_path_renaming_mode = config.publishing.local_path_renaming.mode)
+    # NOTE: ad_file string may differ from rename_result.ad_file after the call above.
+    # ad_file is stale at this point (pointing to the pre-rename path), but
+    # no code in publish_ad() dereferences it after this line, so the drift
+    # has no runtime impact.

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -146,21 +146,6 @@ kleinanzeigen_bot/__init__.py:
     "Confirmation page redirected too fast; extracted ad ID %s from page tracking data": "Bestätigungsseite wurde zu schnell weitergeleitet; Anzeigen-ID %s aus Seiten-Trackingdaten extrahiert"
     "ad_id is unexpectedly None after confirmation flow for %s": "ad_id ist unerwartet None nach dem Bestätigungsablauf für %s"
 
-  _persist_published_ad:
-    " -> SUCCESS: ad published with ID %s": " -> ERFOLG: Anzeige mit ID %s veröffentlicht"
-    " -> SUCCESS: ad updated with ID %s": " -> ERFOLG: Anzeige mit ID %s aktualisiert"
-    "Failed to rollback image rename: %s -> %s": "Fehler beim Rückgängigmachen der Bildumbenennung: %s -> %s"
-
-  _log_local_path_rename_result:
-    "Local path renaming (%s): %s": "Lokale Pfadumbenennung (%s): %s"
-    "Updated ad file: %s": "Aktualisierte Anzeigendatei: %s"
-    "Local path renaming (%s): no local paths needed renaming": "Lokale Pfadumbenennung (%s): keine lokalen Pfade mussten umbenannt werden"
-    "Local path renaming (%s): could not rename %s (target exists or error)": "Lokale Pfadumbenennung (%s): %s konnte nicht umbenannt werden (Ziel existiert oder Fehler)"
-    "folder": "Ordner"
-    "ad file": "Anzeigendatei"
-    "image(s)": "Bild(er)"
-    "ad folder": "Anzeigenordner"
-
   update_ads:
     "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' von [%s]..."
     "Skipping because ad is reserved": "Überspringen, da Anzeige reserviert ist"
@@ -283,6 +268,24 @@ kleinanzeigen_bot/published_ads.py:
     "No ads found on page %s, stopping pagination": "Keine Anzeigen auf Seite %s gefunden, beende Paginierung"
     "Invalid 'next' page value in paging info: %s, stopping pagination": "Ungültiger 'next'-Seitenwert in Paginierungsinfo: %s, beende Paginierung"
     "Invalid 'pageNum' in paging info: %s, stopping pagination": "Ungültiger 'pageNum'-Wert in Paginierungsinfo: %s, beende Paginierung"
+
+#################################################
+kleinanzeigen_bot/publishing_flow.py:
+#################################################
+  persist_published_ad:
+    " -> SUCCESS: ad published with ID %s": " -> ERFOLG: Anzeige mit ID %s veröffentlicht"
+    " -> SUCCESS: ad updated with ID %s": " -> ERFOLG: Anzeige mit ID %s aktualisiert"
+    "Failed to rollback image rename: %s -> %s": "Fehler beim Rückgängigmachen der Bildumbenennung: %s -> %s"
+
+  _log_local_path_rename_result:
+    "Local path renaming (%s): %s": "Lokale Pfadumbenennung (%s): %s"
+    "Updated ad file: %s": "Aktualisierte Anzeigendatei: %s"
+    "Local path renaming (%s): no local paths needed renaming": "Lokale Pfadumbenennung (%s): keine lokalen Pfade mussten umbenannt werden"
+    "Local path renaming (%s): could not rename %s (target exists or error)": "Lokale Pfadumbenennung (%s): %s konnte nicht umbenannt werden (Ziel existiert oder Fehler)"
+    "folder": "Ordner"
+    "ad file": "Anzeigendatei"
+    "image(s)": "Bild(er)"
+    "ad folder": "Anzeigenordner"
 
 #################################################
 kleinanzeigen_bot/delete_flow.py:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -129,7 +129,7 @@ kleinanzeigen_bot/__init__.py:
     "Publishing ad '%s'...": "Veröffentliche Anzeige '%s'..."
     "Updating ad '%s'...": "Aktualisiere Anzeige '%s'..."
     " -> effective ad meta:": " -> effektive Anzeigen-Metadaten:"
-    "Post-publish persistence failed for '%s' (ad ID %s — ad is live on Kleinanzeigen but local YAML may be out of sync)": "Persistenz nach Veröffentlichung fehlgeschlagen für '%s' (Anzeigen-ID %s — Anzeige ist auf Kleinanzeigen live, aber die lokale YAML ist möglicherweise nicht synchron)"
+    "Post-publish persistence failed for '%s' (ad ID %s - ad is live on Kleinanzeigen but local YAML may be out of sync)": "Persistenz nach Veröffentlichung fehlgeschlagen für '%s' (Anzeigen-ID %s - Anzeige ist auf Kleinanzeigen live, aber die lokale YAML ist möglicherweise nicht synchron)"
 
   _fill_ad_form:
     "Failed to set price type '%s'": "Fehler beim Setzen des Preistyps '%s'"

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -129,6 +129,7 @@ kleinanzeigen_bot/__init__.py:
     "Publishing ad '%s'...": "Veröffentliche Anzeige '%s'..."
     "Updating ad '%s'...": "Aktualisiere Anzeige '%s'..."
     " -> effective ad meta:": " -> effektive Anzeigen-Metadaten:"
+    "Post-publish persistence failed for '%s' (ad ID %s — ad is live on Kleinanzeigen but local YAML may be out of sync)": "Persistenz nach Veröffentlichung fehlgeschlagen für '%s' (Anzeigen-ID %s — Anzeige ist auf Kleinanzeigen live, aber die lokale YAML ist möglicherweise nicht synchron)"
 
   _fill_ad_form:
     "Failed to set price type '%s'": "Fehler beim Setzen des Preistyps '%s'"

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Sebastian Thomschke and contributors
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 from pathlib import Path

--- a/tests/unit/test_dicts.py
+++ b/tests/unit/test_dicts.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """Tests for the dicts utility module."""

--- a/tests/unit/test_price_reduction.py
+++ b/tests/unit/test_price_reduction.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 import logging

--- a/tests/unit/test_publishing_flow.py
+++ b/tests/unit/test_publishing_flow.py
@@ -52,6 +52,26 @@ def _make_image_rename_result() -> ImageRenameResult:
     )
 
 
+def _make_image_rename_result_with_updates() -> ImageRenameResult:
+    """Build an ImageRenameResult with updated_images set."""
+    return ImageRenameResult(
+        renamed_count = 0,
+        blocked_count = 0,
+        updated_images = ["new_image.jpg"],
+        renamed_paths = [],
+    )
+
+
+def _make_image_rename_result_with_rollback() -> ImageRenameResult:
+    """Build an ImageRenameResult with renamed_paths for rollback testing."""
+    return ImageRenameResult(
+        renamed_count = 1,
+        blocked_count = 0,
+        updated_images = None,
+        renamed_paths = [(Path("old.jpg"), Path("new.jpg"))],
+    )
+
+
 def _make_config() -> Config:
     """Minimal config with TEMPLATE_MATCH enabled for local path renaming."""
     return Config.model_validate({
@@ -205,7 +225,7 @@ class TestPersistPublishedAdSaveRollback:
     """Test that a save failure propagates the exception after rollback."""
 
     def test_propagates_save_error(self) -> None:
-        """When save_dict raises, the exception is re-raised (after rollback)."""
+        """When save_dict raises, the exception is re-raised after rollback."""
         ad = _make_min_ad()
         ad_cfg_orig:dict[str, Any] = {"title": "Test Ad Title", "description": "Test description for the ad listing.", "type": "OFFER", "category": "160"}
         cfg = _make_config()
@@ -213,7 +233,7 @@ class TestPersistPublishedAdSaveRollback:
         with (
             patch("kleinanzeigen_bot.utils.dicts.save_dict", side_effect = RuntimeError("disk full")),
             patch("kleinanzeigen_bot.local_path_renaming.rename_referenced_local_image_files_after_id_change",
-                  return_value = _make_image_rename_result()),
+                  return_value = _make_image_rename_result_with_rollback()),
             patch("kleinanzeigen_bot.local_path_renaming.rename_local_ad_file_and_folder_after_id_change",
                   return_value = _local_path_renaming.LocalPathRenameResult(
                       ad_file = Path("test.yaml"),
@@ -232,6 +252,36 @@ class TestPersistPublishedAdSaveRollback:
                 mode = AdUpdateStrategy.REPLACE,
                 config = cfg,
             )
+
+    def test_updates_images_from_rename_result(self) -> None:
+        """When image_result.updated_images is not None, persist_published_ad writes it to ad_cfg_orig."""
+        ad = _make_min_ad()
+        ad_cfg_orig:dict[str, Any] = {"title": "Test Ad Title", "description": "Test description for the ad listing.", "type": "OFFER", "category": "160"}
+        cfg = _make_config()
+
+        with (
+            patch("kleinanzeigen_bot.utils.dicts.save_dict"),
+            patch("kleinanzeigen_bot.local_path_renaming.rename_referenced_local_image_files_after_id_change",
+                  return_value = _make_image_rename_result_with_updates()),
+            patch("kleinanzeigen_bot.local_path_renaming.rename_local_ad_file_and_folder_after_id_change",
+                  return_value = _local_path_renaming.LocalPathRenameResult(
+                      ad_file = Path("test.yaml"),
+                      file_status = RenameStatus.SAME,
+                      folder_status = RenameStatus.SAME,
+                  )),
+            patch("kleinanzeigen_bot.utils.misc.now"),
+        ):
+            publishing_flow.persist_published_ad(
+                ad_file = "test.yaml",
+                ad_cfg = ad,
+                ad_cfg_orig = ad_cfg_orig,
+                old_ad_id = None,
+                ad_id = 12345,
+                mode = AdUpdateStrategy.REPLACE,
+                config = cfg,
+            )
+
+        assert ad_cfg_orig["images"] == ["new_image.jpg"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_publishing_flow.py
+++ b/tests/unit/test_publishing_flow.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Tests for publishing flow functionality."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kleinanzeigen_bot import (
+    KleinanzeigenBot,
+    publishing_flow,
+)
+from kleinanzeigen_bot import (
+    local_path_renaming as _local_path_renaming,
+)
+from kleinanzeigen_bot.local_path_renaming import ImageRenameResult, LocalPathRenameResult, RenameStatus
+from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
+from kleinanzeigen_bot.model.config_model import Config
+
+
+def _make_rename_result(*, renamed:bool = False, blocked:bool = False, id_mismatch:bool = True) -> LocalPathRenameResult:
+    """Build a LocalPathRenameResult for _log_local_path_rename_result tests."""
+    return LocalPathRenameResult(
+        ad_file = Path("test_123.yaml"),
+        file_status = (
+            RenameStatus.TARGET_EXISTS if blocked else
+            RenameStatus.RENAMED if renamed else
+            RenameStatus.SAME
+        ),
+        folder_status = (
+            RenameStatus.TARGET_EXISTS if blocked else
+            RenameStatus.RENAMED if renamed else
+            RenameStatus.SAME
+        ),
+        renamed_image_count = 0,
+        blocked_image_count = 0,
+        path_old_id = 1 if id_mismatch else 2,
+        yaml_old_id = 1 if id_mismatch else 2,
+    )
+
+
+def _make_image_rename_result() -> ImageRenameResult:
+    """Build an ImageRenameResult with no renamed paths."""
+    return ImageRenameResult(
+        renamed_count = 0,
+        blocked_count = 0,
+        updated_images = None,
+        renamed_paths = [],
+    )
+
+
+def _make_config() -> Config:
+    """Minimal config with TEMPLATE_MATCH enabled for local path renaming."""
+    return Config.model_validate({
+        "active": True,
+        "download": {
+            "ad_file_name_template": "{id}_{title}",
+            "folder_name_template": "{id}",
+        },
+        "publishing": {
+            "local_path_renaming": {
+                "mode": "TEMPLATE_MATCH",
+            },
+        },
+    })
+
+
+def _make_min_ad() -> Ad:
+    return Ad.model_validate({
+        "title": "Test Ad Title",
+        "description": "Test description for the ad listing.",
+        "type": "OFFER",
+        "price_type": "FIXED",
+        "price": 10,
+        "sell_directly": False,
+        "shipping_type": "NOT_APPLICABLE",
+        "category": "160",
+        "special_attributes": {},
+        "images": [],
+        "active": True,
+        "republication_interval": 7,
+        "contact": {
+            "name": "Test User",
+            "zipcode": "12345",
+            "location": "Test City",
+        },
+    })
+
+
+class TestLogLocalPathRenameResult:
+    """Tests for the _log_local_path_rename_result helper."""
+
+    @pytest.mark.parametrize(("renamed", "blocked", "id_mismatch", "mode", "expect_info", "expect_warning"), [
+        pytest.param(  # noqa: ERA001
+            True, False, True, "TEMPLATE_MATCH", True, False,
+            id = "renamed-logs-info",
+        ),
+        pytest.param(  # noqa: ERA001
+            False, True, True, "TEMPLATE_MATCH", False, True,
+            id = "blocked-logs-warning",
+        ),
+        pytest.param(  # noqa: ERA001
+            False, False, True, "OFF", False, False,
+            id = "neither-off-mode-skips",
+        ),
+        pytest.param(  # noqa: ERA001
+            False, False, True, "TEMPLATE_MATCH", True, False,
+            id = "neither-template-match-logs-info",
+        ),
+    ])
+    def test_covers_all_branches(  # noqa: PLR0913
+        self, renamed:bool, blocked:bool, id_mismatch:bool, mode:str, expect_info:bool, expect_warning:bool,
+    ) -> None:
+        result = _make_rename_result(renamed = renamed, blocked = blocked, id_mismatch = id_mismatch)
+        with (
+            patch.object(publishing_flow.LOG, "info") as mock_info,
+            patch.object(publishing_flow.LOG, "warning") as mock_warning,
+        ):
+            publishing_flow._log_local_path_rename_result(result, ad_id = 2, local_path_renaming_mode = mode)
+
+        assert mock_info.called == expect_info
+        assert mock_warning.called == expect_warning
+
+
+class TestPersistPublishedAdPriceReductionCount:
+    """Tests for price_reduction_count persistence in persist_published_ad."""
+
+    @staticmethod
+    def _make_ad_cfg_orig() -> dict[str, Any]:
+        """Minimal ad_cfg_orig with required fields for AdPartial validation."""
+        return {
+            "title": "Test Ad Title",
+            "description": "Test description for the ad listing.",
+            "type": "OFFER",
+            "category": "160",
+        }
+
+    def test_persists_when_positive(self) -> None:
+        """When price_reduction_count > 0, it is written to ad_cfg_orig."""
+        ad = _make_min_ad()
+        ad.price_reduction_count = 3
+        ad_cfg_orig = self._make_ad_cfg_orig()
+        cfg = _make_config()
+
+        with (
+            patch("kleinanzeigen_bot.local_path_renaming.rename_referenced_local_image_files_after_id_change",
+                  return_value = _make_image_rename_result()),
+            patch("kleinanzeigen_bot.local_path_renaming.rename_local_ad_file_and_folder_after_id_change",
+                  return_value = _local_path_renaming.LocalPathRenameResult(
+                      ad_file = Path("test.yaml"),
+                      file_status = RenameStatus.SAME,
+                      folder_status = RenameStatus.SAME,
+                  )),
+            patch("kleinanzeigen_bot.utils.dicts.save_dict"),
+            patch("kleinanzeigen_bot.utils.misc.now"),
+        ):
+            publishing_flow.persist_published_ad(
+                ad_file = "test.yaml",
+                ad_cfg = ad,
+                ad_cfg_orig = ad_cfg_orig,
+                old_ad_id = None,
+                ad_id = 12345,
+                mode = AdUpdateStrategy.REPLACE,
+                config = cfg,
+            )
+
+        assert ad_cfg_orig["price_reduction_count"] == 3
+
+    def test_skips_when_zero(self) -> None:
+        """When price_reduction_count is 0 (default), it is NOT written."""
+        ad = _make_min_ad()
+        ad.price_reduction_count = 0
+        ad_cfg_orig = self._make_ad_cfg_orig()
+        cfg = _make_config()
+
+        with (
+            patch("kleinanzeigen_bot.local_path_renaming.rename_referenced_local_image_files_after_id_change",
+                  return_value = _make_image_rename_result()),
+            patch("kleinanzeigen_bot.local_path_renaming.rename_local_ad_file_and_folder_after_id_change",
+                  return_value = _local_path_renaming.LocalPathRenameResult(
+                      ad_file = Path("test.yaml"),
+                      file_status = RenameStatus.SAME,
+                      folder_status = RenameStatus.SAME,
+                  )),
+            patch("kleinanzeigen_bot.utils.dicts.save_dict"),
+            patch("kleinanzeigen_bot.utils.misc.now"),
+        ):
+            publishing_flow.persist_published_ad(
+                ad_file = "test.yaml",
+                ad_cfg = ad,
+                ad_cfg_orig = ad_cfg_orig,
+                old_ad_id = None,
+                ad_id = 12345,
+                mode = AdUpdateStrategy.REPLACE,
+                config = cfg,
+            )
+
+        assert "price_reduction_count" not in ad_cfg_orig
+
+
+class TestPersistPublishedAdSaveRollback:
+    """Test that a save failure propagates the exception after rollback."""
+
+    def test_propagates_save_error(self) -> None:
+        """When save_dict raises, the exception is re-raised (after rollback)."""
+        ad = _make_min_ad()
+        ad_cfg_orig:dict[str, Any] = {"title": "Test Ad Title", "description": "Test description for the ad listing.", "type": "OFFER", "category": "160"}
+        cfg = _make_config()
+
+        with (
+            patch("kleinanzeigen_bot.utils.dicts.save_dict", side_effect = RuntimeError("disk full")),
+            patch("kleinanzeigen_bot.local_path_renaming.rename_referenced_local_image_files_after_id_change",
+                  return_value = _make_image_rename_result()),
+            patch("kleinanzeigen_bot.local_path_renaming.rename_local_ad_file_and_folder_after_id_change",
+                  return_value = _local_path_renaming.LocalPathRenameResult(
+                      ad_file = Path("test.yaml"),
+                      file_status = RenameStatus.SAME,
+                      folder_status = RenameStatus.SAME,
+                  )),
+            patch("kleinanzeigen_bot.utils.misc.now"),
+            pytest.raises(RuntimeError, match = "disk full"),
+        ):
+            publishing_flow.persist_published_ad(
+                ad_file = "test.yaml",
+                ad_cfg = ad,
+                ad_cfg_orig = ad_cfg_orig,
+                old_ad_id = None,
+                ad_id = 12345,
+                mode = AdUpdateStrategy.REPLACE,
+                config = cfg,
+            )
+
+
+@pytest.mark.asyncio
+async def test_publish_ad_survives_persistence_failure() -> None:
+    """When persist_published_ad raises, publish_ad logs and does not propagate."""
+    ad = _make_min_ad()
+    ad_cfg_orig:dict[str, Any] = {"title": "Test Ad Title", "description": "Test description for the ad listing.", "type": "OFFER", "category": "160"}
+    cfg = _make_config()
+    bot = KleinanzeigenBot()
+    bot.browser = MagicMock()
+    bot.browser.get = AsyncMock()
+    bot.config = cfg
+
+    with (
+        patch.object(bot, "_delete_old_ad_if_needed", new_callable = AsyncMock),
+        patch.object(bot, "web_open", new_callable = AsyncMock),
+        patch.object(bot, "_dismiss_consent_banner", new_callable = AsyncMock),
+        patch.object(bot, "_fill_ad_form", new_callable = AsyncMock),
+        patch.object(bot, "_submit_and_confirm_ad", new_callable = AsyncMock, return_value = 12345),
+        patch("kleinanzeigen_bot.publishing_flow.persist_published_ad",
+              side_effect = RuntimeError("disk full")),
+    ):
+        # Must not raise — the try/except in publish_ad swallows the error
+        await bot.publish_ad("test.yaml", ad, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)

--- a/tests/unit/test_web_scraping_pagination.py
+++ b/tests/unit/test_web_scraping_pagination.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """Tests for the navigate_paginated_ad_overview helper method."""


### PR DESCRIPTION
## ℹ️ Description

Extract post-publish persistence from `KleinanzeigenBot` into a new `publishing_flow` module, establishing the first publishing-domain extraction following the pattern used for `delete_flow`, `extend_flow`, and `download_flow`.

## 📋 Changes Summary

- **New module `publishing_flow.py`** (~140 lines) with two functions:
  - `persist_published_ad()` — public boundary: YAML field updates, content hash, timestamps, repost/price-reduction counters, save, rollback, and local path renaming
  - `\_log\_local\_path\_rename\_result()` — module-private logging helper
- **`__init__.py`**: added `publishing_flow` import, replaced `await self.\_persist\_published\_ad(...)` with `publishing\_flow.persist\_published\_ad(...)` (sync call, no await), removed both methods (~120 lines)
- Cleaned up unused imports in `__init__.py`: `AdPartial`, `replace`, `_local_path_renaming`, `_dicts`
- Translation sections moved from `__init__.py` to `publishing_flow.py` in `translations.de.yaml`

### ⚙️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

Internal refactoring only — no user-facing behavior or CLI changes.

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Post-publication persistence moved into a dedicated publishing flow to centralize ad update and rename handling.

* **Improvements**
  * Enhanced logging and handling of local file/folder renames after publication.
  * Updated persisted ad metadata after publish (IDs, content hashes, timestamps, repost and price-reduction counts).

* **Bug Fixes**
  * Publishing now catches and logs persistence failures instead of letting them propagate.

* **Tests**
  * Added unit tests for rename logging, persistence behavior, rollback on save failure, and resilience to persistence errors.

* **Chores**
  * Updated file copyright headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->