### PR TITLE
fix: correct republication timing and content hash computation

### DIFF
--- a/src/kleinanzeigen_bot/ad_loading.py
+++ b/src/kleinanzeigen_bot/ad_loading.py
@@ -125,7 +125,7 @@ def check_ad_republication(
         now = _misc.now()
 
     ad_age = now - last_updated_on
-    if ad_age.days <= ad_cfg.republication_interval:
+    if ad_age.days < ad_cfg.republication_interval:
         LOG.info(
             " -> SKIPPED: ad [%s] was last published %d days ago. republication is only required every %s days",
             ad_file_relative,
@@ -360,10 +360,10 @@ def update_content_hashes(ads:list[tuple[str, Ad, dict[str, Any]]]) -> int:
 
     for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ads, start = 1):
         LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ads), ad_cfg.title, ad_file)
-        ad_cfg.update_content_hash()
-        if ad_cfg.content_hash != ad_cfg_orig["content_hash"]:
+        current_hash = AdPartial.model_validate(ad_cfg_orig).update_content_hash().content_hash
+        if current_hash != ad_cfg_orig.get("content_hash"):
             changed += 1
-            ad_cfg_orig["content_hash"] = ad_cfg.content_hash
+            ad_cfg_orig["content_hash"] = current_hash
             _dicts.save_dict(ad_file, ad_cfg_orig)
 
     LOG.info("############################################")

--- a/tests/unit/test_ad_loading.py
+++ b/tests/unit/test_ad_loading.py
@@ -21,7 +21,7 @@ from kleinanzeigen_bot.ad_loading import (
     resolve_ad_images,
     update_content_hashes,
 )
-from kleinanzeigen_bot.model.ad_model import Ad
+from kleinanzeigen_bot.model.ad_model import Ad, AdPartial
 from kleinanzeigen_bot.model.config_model import (
     Config,
 )
@@ -290,10 +290,9 @@ class TestUpdateContentHashes:
             _build_ad(base_ad_config, None, "Unchanged Ad 2"),
         ]
 
-        # Pre-compute hashes so two match and one differs
-        for _ad_file, ad_cfg, ad_cfg_orig in ads:
-            ad_cfg.update_content_hash()
-            ad_cfg_orig["content_hash"] = ad_cfg.content_hash
+        # Pre-compute hashes from the raw config dict (matching the production code path)
+        for _ad_file, _ad_cfg, ad_cfg_orig in ads:
+            ad_cfg_orig["content_hash"] = AdPartial.model_validate(ad_cfg_orig).update_content_hash().content_hash
 
         # Make the middle ad's original hash differ
         ads[1][2]["content_hash"] = "deliberately_wrong_hash"


### PR DESCRIPTION
## ℹ️ Description

Two small bug fixes affecting ad lifecycle correctness, both in `ad_loading.py`.

- Fix off-by-one republication comparison (#1099): ads are now eligible for republication exactly when their age reaches the configured interval, instead of one day late.
- Fix content hash divergence (#1100): `update-content-hash` now computes hashes from the raw ad config (matching `check_ad_changed`), preventing spurious "ad changed" detection on every publish.

## 📋 Changes Summary

### 🐞 Bug fixes

1. **#1099** — `check_ad_republication`: changed `<=` to `<` so ads are due at `ad_age.days == republication_interval` rather than one day later.
2. **#1100** — `update_content_hashes`: switched from `ad_cfg.update_content_hash()` (hydrated Ad model) to `AdPartial.model_validate(ad_cfg_orig).update_content_hash()` (raw config dict), matching `check_ad_changed`. Also uses `.get()` to handle legacy ad files without a `content_hash` key.

### 🧪 Tests

Updated `test_counter_progression` to pre-compute hashes using the same `AdPartial` path as production code.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted ad republication timing logic—ads at the republication interval boundary are now correctly treated as not yet due for republication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->