### PR TITLE
fix: close submit uncertainty gap, surface silent TOCTOU race, and translate remaining TimeoutError messages

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1521,7 +1521,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 if condition_radio is not None:
                     break
             if condition_radio is None:
-                raise TimeoutError(f"No condition radio matched values {candidate_values}")
+                raise TimeoutError(_("No condition radio matched values %(values)s") % {"values": candidate_values})
             condition_radio_id = str(condition_radio.attrs.get("id") or "")
             if condition_radio_id:
                 try:

--- a/src/kleinanzeigen_bot/publishing_flow.py
+++ b/src/kleinanzeigen_bot/publishing_flow.py
@@ -247,25 +247,24 @@ async def submit_and_confirm_ad(
     # Edit page uses 'Änderungen speichern' or 'Anzeige speichern'; publish page uses 'Anzeige aufgeben'
     await web.web_click(By.XPATH, "//button[contains(., 'Anzeige aufgeben') or contains(., 'Änderungen speichern') or contains(., 'Anzeige speichern')]")
 
-    # PostListingForm v2 may show an "Effektiver verkaufen" upsell
-    # dialog after clicking submit.  Dismiss it so the actual form
-    # POST can proceed.
-    quick_dom = web.timeout("quick_dom")
-    upsell_dialog = await web.web_probe(
-        By.XPATH, "//dialog[@open and contains(., 'Effektiver verkaufen')]", timeout = quick_dom
-    )
-    if upsell_dialog is not None:
-        LOG.info("Dismissing upsell dialog...")
-        await web.web_click(
-            By.XPATH, "//dialog[@open]//button[contains(., 'Ohne Hochschieben weiter')]",
-            timeout = quick_dom,
-        )
-        await web.web_sleep(500)  # let the dialog close animation finish
-
     # Everything after the first click is uncertain: the ad may already have been submitted.
     ad_id:int | None = None
     try:
         quick_dom = web.timeout("quick_dom")
+
+        # PostListingForm v2 may show an "Effektiver verkaufen" upsell
+        # dialog after clicking submit.  Dismiss it so the actual form
+        # POST can proceed.
+        upsell_dialog = await web.web_probe(
+            By.XPATH, "//dialog[@open and contains(., 'Effektiver verkaufen')]", timeout = quick_dom
+        )
+        if upsell_dialog is not None:
+            LOG.info("Dismissing upsell dialog...")
+            await web.web_click(
+                By.XPATH, "//dialog[@open]//button[contains(., 'Ohne Hochschieben weiter')]",
+                timeout = quick_dom,
+            )
+            await web.web_sleep(500)  # let the dialog close animation finish
 
         imprint_btn = await web.web_probe(By.ID, "imprint-guidance-submit", timeout = quick_dom)
         if imprint_btn is not None:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -163,6 +163,7 @@ kleinanzeigen_bot/__init__.py:
     "Unable to close condition dialog!": "Kann den Dialog für Artikelzustand nicht schließen!"
     "Unable to select condition [%s]": "Zustand [%s] konnte nicht ausgewählt werden"
     "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"
+    "No condition radio matched values %(values)s": "Keine Zustand-Auswahl passt zu den Werten %(values)s"
 
   _resolve_category_suggestions:
     ? "Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path."
@@ -714,8 +715,14 @@ kleinanzeigen_bot/utils/web_scraping_mixin.py:
     "Last page reached (next button is disabled).": "Letzte Seite erreicht (Weiter-Button ist deaktiviert)."
     "No pagination controls found. Assuming last page.": "Keine Paginierungssteuerung gefunden. Es wird von der letzten Seite ausgegangen."
 
+  web_set_input_value:
+    "web_set_input_value: element '%(id)s' not found in DOM (TOCTOU race)": "web_set_input_value: Element '%(id)s' nicht im DOM gefunden (TOCTOU Race)"
+
   _record_timing:
     "Timing collector failed for key=%s operation=%s: %s": "Zeitmessung fehlgeschlagen für key=%s operation=%s: %s"
+
+  _run_with_timeout_retries:
+    "%(desc)s failed without executing operation": "%(desc)s fehlgeschlagen ohne dass die Operation ausgeführt wurde"
 
   _allocate_selector_group_budgets:
     "selector_count must be > 0": "selector_count muss > 0 sein"

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -257,7 +257,7 @@ class WebScrapingMixin:  # noqa: PLR0904
                     raise
                 LOG.debug("Retrying %s after TimeoutError (attempt %d/%d, timeout %.1fs)", description, attempt + 1, attempts, effective_timeout)
 
-        raise TimeoutError(f"{description} failed without executing operation")
+        raise TimeoutError(_("%(desc)s failed without executing operation") % {"desc": description})
 
     @staticmethod
     def _allocate_selector_group_budgets(total_timeout:float, selector_count:int) -> list[float]:
@@ -1011,10 +1011,10 @@ class WebScrapingMixin:  # noqa: PLR0904
         await self.web_find(By.ID, element_id)  # raises TimeoutError if element is absent
         js_element_id = json.dumps(element_id)
         js_value = json.dumps(value)
-        await self.web_execute(
+        result = await self.web_execute(
             f"(function(id,v){{"
             "var el=document.getElementById(id);"
-            "if(!el)return;"
+            "if(!el)return false;"
             "var tag=el.tagName.toLowerCase();"
             "var proto=tag==='textarea'?window.HTMLTextAreaElement:window.HTMLInputElement;"
             "var setter=Object.getOwnPropertyDescriptor(proto.prototype,'value').set;"
@@ -1023,6 +1023,10 @@ class WebScrapingMixin:  # noqa: PLR0904
             "el.dispatchEvent(new Event('change',{bubbles:true}));"
             f"}})({js_element_id},{js_value})"
         )
+        if result is False:
+            raise TimeoutError(
+                _("web_set_input_value: element '%(id)s' not found in DOM (TOCTOU race)") % {"id": element_id}
+            )
 
     def _convert_remote_object_value(self, data:Any) -> Any:
         """

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -2813,3 +2813,29 @@ class TestWebSelectButtonCombobox:
         web_scraper.web_click.assert_awaited_once()
         web_scraper.web_find.assert_awaited_once()
         web_scraper.web_sleep.assert_not_awaited()
+
+
+class TestWebSetInputValue:
+    """Direct unit tests for the web_set_input_value method (including TOCTOU race)."""
+
+    @pytest.mark.asyncio
+    async def test_sets_value_when_element_present(self, web_scraper:WebScrapingMixin) -> None:
+        """Happy path: web_find succeeds and JS returns non-False (no TOCTOU race)."""
+        web_scraper.web_find = AsyncMock()  # type: ignore[method-assign]
+        page = cast(Any, web_scraper).page
+        page.evaluate = AsyncMock(return_value = None)  # JS IIFE returns undefined → None in Python
+
+        await web_scraper.web_set_input_value("ad-title", "Hello World")
+
+        web_scraper.web_find.assert_awaited_once()
+        page.evaluate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_timeout_error_on_toctou_race(self, web_scraper:WebScrapingMixin) -> None:
+        """Error path: web_find succeeds but element disappears before JS runs — raise TimeoutError."""
+        web_scraper.web_find = AsyncMock()  # type: ignore[method-assign]
+        page = cast(Any, web_scraper).page
+        page.evaluate = AsyncMock(return_value = False)  # JS returns false (element gone)
+
+        with pytest.raises(TimeoutError, match = "TOCTOU"):
+            await web_scraper.web_set_input_value("ad-title", "Hello World")


### PR DESCRIPTION
## ℹ️ Description

Three bug fixes affecting browser automation correctness and i18n completeness:

- **#1110**: Move upsell dialog dismiss inside the post-submit try/except block so timeouts during upsell interaction are treated as uncertain submission rather than retryable errors, preventing duplicate listings.
- **#1112**: Change `web_set_input_value` to detect TOCTOU races (element disappearing between `web_find` and JS execution). The JS now returns `false` on missing element, and the Python side raises `TimeoutError` so callers see a clear failure instead of proceeding with stale field data. **Approach**: sentinel return (not JS throw) because nodriver returns `ExceptionDetails` silently rather than raising Python exceptions.
- Translate two remaining untranslated `TimeoutError` messages in `__init__.py:_set_condition` and `web_scraping_mixin.py:_run_with_timeout_retries`.

## 📋 Changes Summary

| File | Change |
|---|---|
| `publishing_flow.py` | Move upsell dismiss inside `try` block (#1110) |
| `web_scraping_mixin.py` | Sentinel + `TimeoutError` for TOCTOU race (#1112); translate guard-clause message |
| `__init__.py` | Translate `No condition radio matched values` message |
| `translations.de.yaml` | Add German translations for all 3 new messages |

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and localized error messages for timeouts and form interactions.
  * Better handling of element race conditions to reduce submission failures.

* **Refactor**
  * Reworked ad submission confirmation flow to unify exception handling and make upsell dismissal more robust.

* **Tests**
  * Added tests covering input-setting behavior and TOCTOU race handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->