### PR TITLE
fix: disable diagnostics timing collection by default

### DIFF
--- a/docs/config.default.yaml
+++ b/docs/config.default.yaml
@@ -356,4 +356,4 @@ diagnostics:
   output_dir:
 
   # If true, collect local timeout timing data and write it to diagnostics JSON for troubleshooting and tuning.
-  timing_collection: true
+  timing_collection: false

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -485,7 +485,7 @@
           "title": "Output Dir"
         },
         "timing_collection": {
-          "default": true,
+          "default": false,
           "description": "If true, collect local timeout timing data and write it to diagnostics JSON for troubleshooting and tuning.",
           "title": "Timing Collection",
           "type": "boolean"

--- a/src/kleinanzeigen_bot/model/config_model.py
+++ b/src/kleinanzeigen_bot/model/config_model.py
@@ -371,7 +371,7 @@ class DiagnosticsConfig(ContextualModel):
         description = "Optional output directory for diagnostics artifacts. If omitted, a safe default is used based on installation mode.",
     )
     timing_collection:bool = Field(
-        default = True,
+        default = False,
         description = "If true, collect local timeout timing data and write it to diagnostics JSON for troubleshooting and tuning.",
     )
 


### PR DESCRIPTION
## ℹ️ Description

Change the `diagnostics.timing_collection` default from `true` to `false` so that timeout timing data is only collected when a user explicitly opts in.

## 📋 Changes Summary

- `model/config_model.py`: changed `TimingCollectionConfig.timing_collection` default from `True` to `False`
- `schemas/config.schema.json`: regenerated with `"default": false`
- `docs/config.default.yaml`: regenerated with `timing_collection: false`

Existing configs that explicitly set `timing_collection: true` are unaffected.

### ⚙️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [x] 💥 Breaking change (changes default behavior — users who relied on the implicit `true` default must now explicitly enable it)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.