### PR TITLE
fix: apply after_delete policy when title-mode delete returns all-404 with id=None

### DIFF
--- a/src/kleinanzeigen_bot/delete_flow.py
+++ b/src/kleinanzeigen_bot/delete_flow.py
@@ -4,7 +4,7 @@
 """Ad deletion browser workflow."""
 
 from gettext import gettext as _
-from typing import Any, Final, Literal
+from typing import Any, Final, Literal, NamedTuple
 
 from . import ad_state as _ad_state
 from . import published_ads
@@ -15,6 +15,20 @@ from .utils import loggers as _loggers
 from .utils.i18n import pluralize
 from .utils.misc import ensure
 from .utils.web_scraping_mixin import By, WebScrapingMixin
+
+
+class DeleteResult(NamedTuple):
+    """Outcome of a delete_ad call.
+
+    :param deleted: True if at least one server response was 200.
+    :param attempted: True if HTTP DELETE requests were actually sent
+        (Phase B ran), regardless of server response codes.
+        Always True when ``deleted`` is True.
+    """
+
+    deleted:bool
+    attempted:bool
+
 
 LOG:_loggers.Logger = _loggers.get_logger(__name__)
 
@@ -36,21 +50,11 @@ async def delete_ads(
         count += 1
         LOG.info("Processing %s/%s: '%s' from [%s]...", count, len(ad_cfgs), ad_cfg.title, ad_file)
 
-        # Record pre-delete id to detect whether delete_ad attempted a deletion.
-        # delete_ad clears ad_cfg.id when targets were found (Phase B ran),
-        # and preserves it on no-match early return.
-        id_before = ad_cfg.id
-        deleted = await delete_ad(web, root_url, ad_cfg, published_ads_list, delete_old_ads_by_title = delete_old_ads_by_title)
-        if deleted:
+        result = await delete_ad(web, root_url, ad_cfg, published_ads_list, delete_old_ads_by_title = delete_old_ads_by_title)
+        if result.deleted:
             deleted_count += 1
 
-        # Apply after_delete policy only when a delete was actually attempted.
-        # Detection: True return (some 200), or id changed from non-None to None (all 404).
-        # When id was already None before the call, only True return is reliable;
-        # a False return could be no-match or title-match all-404, both treated as no cleanup.
-        delete_attempted = deleted or (id_before is not None and ad_cfg.id is None)
-
-        if delete_attempted and after_delete != "NONE":
+        if result.attempted and after_delete != "NONE":
             if _ad_state.apply_after_delete_policy(ad_cfg, ad_cfg_orig, mode = after_delete):
                 _dicts.save_dict(ad_file, ad_cfg_orig)
         await web.web_sleep()
@@ -67,12 +71,12 @@ async def delete_ad(
     published_ads_list:list[PublishedAd],
     *,
     delete_old_ads_by_title:bool,
-) -> bool:
+) -> DeleteResult:
     """Delete an ad from the server.
 
     Returns:
-        True if at least one delete request returned 200 (confirmed deleted).
-        False if no matching ads were found or all returned 404 (already gone).
+        :class:`DeleteResult` with ``deleted`` (at least one 200) and
+        ``attempted`` (HTTP DELETE requests were actually sent).
 
     Side effects:
         Clears ``ad_cfg.id`` whenever a delete was attempted, regardless of
@@ -105,7 +109,7 @@ async def delete_ad(
     # Early return if nothing to delete — skip page open, CSRF fetch, and sleep
     if not ids_to_delete:
         LOG.info(" -> SKIPPED: no published ad matched '%s' for deletion", ad_cfg.title)
-        return False
+        return DeleteResult(deleted = False, attempted = False)
 
     # Phase B: Open manage-ads page, fetch CSRF token, execute deletions
     await web.web_open(f"{root_url}/m-meine-anzeigen.html")
@@ -133,4 +137,4 @@ async def delete_ad(
     # Clear ad_cfg.id whenever a delete was attempted — the old ID is stale
     # regardless of whether the server returned 200 (deleted) or 404 (already gone).
     ad_cfg.id = None
-    return deleted
+    return DeleteResult(deleted = deleted, attempted = True)

--- a/tests/unit/test_delete_flow.py
+++ b/tests/unit/test_delete_flow.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from kleinanzeigen_bot import KleinanzeigenBot, delete_flow
+from kleinanzeigen_bot.delete_flow import DeleteResult
 from kleinanzeigen_bot.model.ad_model import Ad
 
 
@@ -88,7 +89,7 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result is True
+        assert result == (True, True)
         assert ad_cfg.id is None
 
     @pytest.mark.asyncio
@@ -112,7 +113,7 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = False,
             )
 
-        assert result is True
+        assert result == (True, True)
         assert ad_cfg.id is None
 
     @pytest.mark.asyncio
@@ -138,7 +139,7 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result is False
+        assert result == (False, False)
         assert ad_cfg.id == 99999  # Preserved — no deletion attempted
         mock_web_open.assert_not_called()
         mock_web_find.assert_not_called()
@@ -169,7 +170,7 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = False,
             )
 
-        assert result is False
+        assert result == (False, True)
         assert ad_cfg.id is None  # Cleared because delete was attempted
 
     @pytest.mark.asyncio
@@ -193,7 +194,7 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result is False
+        assert result == (False, False)
         mock_web_open.assert_not_called()  # No valid IDs → no page open
 
     @pytest.mark.asyncio
@@ -217,7 +218,7 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = False,
             )
 
-        assert result is True
+        assert result == (True, True)
         assert ad_cfg.id is None
         mock_request.assert_called_once()
         assert "ids=0" in mock_request.call_args[1]["url"]
@@ -252,7 +253,7 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result is True
+        assert result == (True, True)
         assert ad_cfg.id is None
         assert mock_request.call_count == 3
 
@@ -277,7 +278,7 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result is True
+        assert result == (True, True)
         assert ad_cfg.id is None
         mock_request.assert_called_once()  # Deduplicated — only one request
 
@@ -328,9 +329,9 @@ class TestDeleteAdsAfterDeletePolicy:
 
         async def fake_delete(
             _web:Any, _root_url:str, ad:Ad, _published:list[dict[str, Any]], **__:Any
-        ) -> bool:
+        ) -> DeleteResult:
             ad.id = None  # Phase B ran and cleared the id
-            return False  # but all responses were 404
+            return DeleteResult(deleted = False, attempted = True)  # all responses were 404 but deletion was attempted
 
         with (
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = []),
@@ -359,7 +360,7 @@ class TestDeleteAdsAfterDeletePolicy:
 
         with (
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = []),
-            patch("kleinanzeigen_bot.delete_flow.delete_ad", new_callable = AsyncMock, return_value = False),
+            patch("kleinanzeigen_bot.delete_flow.delete_ad", new_callable = AsyncMock, return_value = DeleteResult(deleted = False, attempted = False)),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.utils.dicts.save_dict") as mock_save,
         ):
@@ -390,7 +391,9 @@ class TestDeleteAdsAfterDeletePolicy:
 
         with (
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = []),
-            patch("kleinanzeigen_bot.delete_flow.delete_ad", new_callable = AsyncMock, return_value = True) as mock_delete_ad,
+            patch("kleinanzeigen_bot.delete_flow.delete_ad",
+                  new_callable = AsyncMock,
+                  return_value = DeleteResult(deleted = True, attempted = True)) as mock_delete_ad,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.utils.dicts.save_dict") as mock_save,
         ):
@@ -405,3 +408,34 @@ class TestDeleteAdsAfterDeletePolicy:
         mock_save.assert_not_called()
         # delete_ad called twice (once per ad)
         assert mock_delete_ad.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cleanup_on_title_match_all_404_with_id_none(
+        self, test_bot:KleinanzeigenBot, minimal_ad_config:dict[str, Any], tmp_path:Path,
+    ) -> None:
+        """Regression test for #1103: after_delete policy applied when title-mode delete
+        returns all-404 and ad_cfg.id was already None."""
+        test_bot.config.deleting.after_delete = "RESET"
+        minimal_ad_config["id"] = None
+        ad_file, ad_cfg, ad_cfg_orig = self._make_ad(minimal_ad_config, tmp_path)
+        ad_cfg.id = None  # Simulate id was never assigned
+
+        mock_delete = AsyncMock(return_value = DeleteResult(deleted = False, attempted = True))
+
+        with (
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = []),
+            patch("kleinanzeigen_bot.delete_flow.delete_ad", new = mock_delete),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.utils.dicts.save_dict") as mock_save,
+        ):
+            await delete_flow.delete_ads(
+                web = test_bot, root_url = test_bot.root_url,
+                after_delete = test_bot.config.deleting.after_delete,
+                delete_old_ads_by_title = True,
+                ad_cfgs = [(ad_file, ad_cfg, ad_cfg_orig)],
+            )
+
+        # Policy must be applied: deletion was attempted
+        assert ad_cfg.repost_count == 0
+        assert "id" not in ad_cfg_orig
+        mock_save.assert_called_once()

--- a/tests/unit/test_delete_flow.py
+++ b/tests/unit/test_delete_flow.py
@@ -89,7 +89,8 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result == (True, True)
+        assert isinstance(result, DeleteResult)
+        assert result == DeleteResult(deleted = True, attempted = True)
         assert ad_cfg.id is None
 
     @pytest.mark.asyncio
@@ -113,7 +114,8 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = False,
             )
 
-        assert result == (True, True)
+        assert isinstance(result, DeleteResult)
+        assert result == DeleteResult(deleted = True, attempted = True)
         assert ad_cfg.id is None
 
     @pytest.mark.asyncio
@@ -139,7 +141,8 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result == (False, False)
+        assert isinstance(result, DeleteResult)
+        assert result == DeleteResult(deleted = False, attempted = False)
         assert ad_cfg.id == 99999  # Preserved — no deletion attempted
         mock_web_open.assert_not_called()
         mock_web_find.assert_not_called()
@@ -170,7 +173,8 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = False,
             )
 
-        assert result == (False, True)
+        assert isinstance(result, DeleteResult)
+        assert result == DeleteResult(deleted = False, attempted = True)
         assert ad_cfg.id is None  # Cleared because delete was attempted
 
     @pytest.mark.asyncio
@@ -194,7 +198,8 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result == (False, False)
+        assert isinstance(result, DeleteResult)
+        assert result == DeleteResult(deleted = False, attempted = False)
         mock_web_open.assert_not_called()  # No valid IDs → no page open
 
     @pytest.mark.asyncio
@@ -218,7 +223,8 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = False,
             )
 
-        assert result == (True, True)
+        assert isinstance(result, DeleteResult)
+        assert result == DeleteResult(deleted = True, attempted = True)
         assert ad_cfg.id is None
         mock_request.assert_called_once()
         assert "ids=0" in mock_request.call_args[1]["url"]
@@ -253,7 +259,8 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result == (True, True)
+        assert isinstance(result, DeleteResult)
+        assert result == DeleteResult(deleted = True, attempted = True)
         assert ad_cfg.id is None
         assert mock_request.call_count == 3
 
@@ -278,7 +285,8 @@ class TestKleinanzeigenBotAdDeletion:
                 delete_old_ads_by_title = True,
             )
 
-        assert result == (True, True)
+        assert isinstance(result, DeleteResult)
+        assert result == DeleteResult(deleted = True, attempted = True)
         assert ad_cfg.id is None
         mock_request.assert_called_once()  # Deduplicated — only one request
 


### PR DESCRIPTION
## ℹ️ Description

When `delete_old_ads_by_title=True` and `ad_cfg.id=None` and all remote DELETE requests return 404, the `after_delete` policy (DISABLE/RESET) was silently skipped because the orchestrator's `id_before`/`id_after` heuristic could not distinguish "not attempted" from "attempted but all 404."

This PR replaces the heuristic with an explicit `DeleteResult` NamedTuple returned from `delete_ad()`, communicating whether HTTP DELETE requests were actually sent (`attempted`) separately from whether any returned 200 (`deleted`).

Closes #1103.

## 📋 Changes Summary

### 🐞 Bug fix

- **`delete_flow.py`** — New `DeleteResult(deleted, attempted)` NamedTuple replaces the `bool` return from `delete_ad()`. The orchestrator now uses `result.attempted` directly to decide whether to apply `after_delete` policy.
- Removed the fragile `id_before`/`ad_cfg.id`-based heuristic entirely.

### 🧪 Tests

- Updated all 9 existing `delete_ad()` tests for the new tuple return type
- Updated 3 orchestrator tests (`delete_ads`) for the new `DeleteResult` API
- Added regression test `test_cleanup_on_title_match_all_404_with_id_none` — `ad_cfg.id=None`, title-match, all responses 404, `after_delete=RESET` is applied

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion tracking to distinguish attempted vs successful deletions, ensuring cleanup policies run correctly across edge cases.

* **Tests**
  * Updated unit tests to reflect the new deletion outcomes and added a regression test to verify cleanup behavior when title-mode deletions all fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->