### PR TITLE
enh: skip runtime bootstrap for update-check command

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -238,7 +238,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     LOG.info("DONE: No configuration errors found.")
                     LOG.info("############################################")
                 case "update-check":
-                    _bootstrap_runtime()
+                    # update-check uses sensible defaults and needs no config files,
+                    # no file logging, and no browser setup — skip bootstrap entirely.
+                    self.config = Config()
                     checker = UpdateChecker(self.config, self._update_check_state_path)
                     checker.check_for_updates(skip_interval_check = True)
                 case "update-content-hash":


### PR DESCRIPTION
## ℹ️ Description

The `update-check` command was calling `_bootstrap_runtime()` which triggered config file creation (`create_default_config`), file logging setup, and browser config application. None of these are needed for a read-only GitHub release version check.

This PR skips the full bootstrap and instead uses `UpdateChecker` with sensible defaults from `Config()` and a state path resolved from the already-available workspace.

Closes #1090.

## 📋 Changes Summary

### 🚀 Enhancement

- **`src/kleinanzeigen_bot/__init__.py`** — `update-check` case: removed `_bootstrap_runtime()` call, uses `self.config = Config()` with sensible defaults, state path from already-resolved `self.workspace`.

### ⚙️ Type of Change
- [x] 🚀 New feature / Enhancement (non-breaking change which adds functionality)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.