### PR TITLE
refactor: extract publishing submission flow

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -17,6 +17,7 @@ from . import ad_loading, captcha_flow, delete_flow, download_flow, extend_flow,
 from . import ad_state as _ad_state
 from . import price_reduction as _price_reduction
 from . import publishing_flow as _publishing_flow
+from . import publishing_submission as _publishing_submission
 from . import runtime_config as _runtime_config
 from ._version import __version__
 from .ad_description import get_ad_description
@@ -1148,7 +1149,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         await self._fill_ad_form(ad_file, ad_cfg, mode)
 
-        ad_id = await _publishing_flow.submit_and_confirm_ad(self, ad_file, ad_cfg, mode, captcha_config = self.config.captcha)
+        ad_id = await _publishing_submission.submit_and_confirm_ad(self, ad_file, ad_cfg, mode, captcha_config = self.config.captcha)
 
         try:
             _publishing_flow.persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode, config = self.config)

--- a/src/kleinanzeigen_bot/publishing_flow.py
+++ b/src/kleinanzeigen_bot/publishing_flow.py
@@ -1,25 +1,17 @@
 # SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-import re
-import urllib.parse as urllib_parse
 from dataclasses import replace
 from gettext import gettext as _
 from pathlib import Path
 from typing import Any
 
-from nodriver.core.connection import ProtocolException
-
-from . import captcha_flow
 from . import local_path_renaming as _local_path_renaming
 from .model.ad_model import Ad, AdPartial, AdUpdateStrategy
-from .model.config_model import CaptchaConfig, Config
+from .model.config_model import Config
 from .utils import dicts as _dicts
 from .utils import loggers as _loggers
 from .utils import misc as _misc
-from .utils.exceptions import PublishSubmissionUncertainError
-from .utils.misc import ainput
-from .utils.web_scraping_mixin import By, WebScrapingMixin
 
 LOG = _loggers.get_logger(__name__)
 
@@ -151,180 +143,3 @@ def persist_published_ad(
     # ad_file is stale at this point (pointing to the pre-rename path), but
     # no code in publish_ad() dereferences it after this line, so the drift
     # has no runtime impact.
-
-
-async def _try_recover_ad_id_from_redirect(web:WebScrapingMixin) -> int | None:
-    """Try to extract the published ad ID from page tracking data.
-
-    Used as a fallback when the confirmation page auto-redirects before
-    the URL can be polled. Checks document.referrer first, then scans
-    inline script content for the confirmation URL containing adId.
-
-    Returns:
-        The extracted ad ID, or None if no ad ID could be found.
-    """
-    # Layer 1: check document.referrer for the confirmation URL.
-    # Note: referrer reflects the most recent navigation, so a stale ID from a
-    # previous publish is not a concern — the publish flow navigates to the edit
-    # page first, resetting the referrer before the confirmation redirect occurs.
-    try:
-        referrer = str(await web.web_execute("document.referrer") or "")
-    except (TimeoutError, ProtocolException) as ex:
-        LOG.debug("document.referrer lookup failed (%s), skipping to script scan", type(ex).__name__)
-        referrer = ""
-
-    if "p-anzeige-aufgeben-bestaetigung.html?adId=" in referrer:
-        try:
-            query = urllib_parse.parse_qs(urllib_parse.urlparse(referrer).query)
-            ad_id_str = query.get("adId", [])[0]
-            ad_id = int(ad_id_str)
-            LOG.debug("Extracted ad ID %s from document.referrer fallback", ad_id)
-            return ad_id
-        except (IndexError, ValueError, TypeError):
-            LOG.debug("Failed to parse ad ID from document.referrer: %s", referrer)
-
-    # Layer 2: scan inline <script> tags for confirmation URL with adId
-    try:
-        script_content = str(await web.web_execute(
-            "[...document.querySelectorAll('script')].map(s => s.textContent).join('\\n')"
-        ) or "")
-        matches = {
-            int(match)
-            for match in re.findall(r"p-anzeige-aufgeben-bestaetigung\.html\?adId=(\d+)", script_content)
-        }
-        if len(matches) == 1:
-            ad_id = next(iter(matches))
-            LOG.debug("Extracted ad ID %s from inline script fallback", ad_id)
-            return ad_id
-        if len(matches) > 1:
-            LOG.debug("Inline script fallback was ambiguous; refusing matches: %s", sorted(matches))
-    except (TimeoutError, ProtocolException, ValueError, TypeError) as ex:
-        LOG.debug("Script content scan failed (%s): %s", type(ex).__name__, ex)
-
-    return None
-
-
-async def submit_and_confirm_ad(
-    web:WebScrapingMixin,
-    ad_file:str,
-    ad_cfg:Ad,
-    mode:AdUpdateStrategy,
-    *,
-    captcha_config:CaptchaConfig,
-) -> int:
-    """Submit the ad form, handle post-submit dialogs, wait for confirmation,
-    and extract the published ad ID.
-
-    Returns:
-        The published ad ID.
-
-    Raises:
-        PublishSubmissionUncertainError: The submission may have succeeded
-            but the ad ID could not be recovered.
-        RuntimeError: An internal invariant was violated (ad_id is None
-            despite the recovery path).
-    """
-
-    #############################
-    # wait for captcha
-    #############################
-    operation_label = {
-        AdUpdateStrategy.REPLACE: "publish",
-        AdUpdateStrategy.MODIFY: "update",
-    }.get(mode, mode.name.lower())
-    await captcha_flow.check_and_wait_for_captcha(web, captcha_config, is_login_page = False, page_context = f"{operation_label} operation")
-
-    #############################
-    # set title (right before submit to prevent React re-render clearing it)
-    #############################
-    LOG.debug("Setting title '%s' (deferred to prevent React re-render clearing it)", ad_cfg.title)
-    await web.web_set_input_value("ad-title", ad_cfg.title)
-
-    #############################
-    # submit
-    #############################
-    # Click is retryable — no submission can have occurred before this point.
-    # Edit page uses 'Änderungen speichern' or 'Anzeige speichern'; publish page uses 'Anzeige aufgeben'
-    await web.web_click(By.XPATH, "//button[contains(., 'Anzeige aufgeben') or contains(., 'Änderungen speichern') or contains(., 'Anzeige speichern')]")
-
-    # Everything after the first click is uncertain: the ad may already have been submitted.
-    ad_id:int | None = None
-    try:
-        quick_dom = web.timeout("quick_dom")
-
-        # PostListingForm v2 may show an "Effektiver verkaufen" upsell
-        # dialog after clicking submit.  Dismiss it so the actual form
-        # POST can proceed.
-        upsell_dialog = await web.web_probe(
-            By.XPATH, "//dialog[@open and contains(., 'Effektiver verkaufen')]", timeout = quick_dom
-        )
-        if upsell_dialog is not None:
-            LOG.info("Dismissing upsell dialog...")
-            await web.web_click(
-                By.XPATH, "//dialog[@open]//button[contains(., 'Ohne Hochschieben weiter')]",
-                timeout = quick_dom,
-            )
-            await web.web_sleep(500)  # let the dialog close animation finish
-
-        imprint_btn = await web.web_probe(By.ID, "imprint-guidance-submit", timeout = quick_dom)
-        if imprint_btn is not None:
-            await imprint_btn.click()
-
-        # check for no image question
-        if not ad_cfg.images:
-            image_hint_xpath = '//button[contains(., "Ohne Bild veröffentlichen")]'
-            image_hint_button = await web.web_probe(By.XPATH, image_hint_xpath, timeout = quick_dom)
-            if image_hint_button is not None:
-                await image_hint_button.click()
-
-        #############################
-        # wait for payment form if commercial account is used
-        #############################
-        payment_form = await web.web_probe(By.ID, "myftr-shppngcrt-frm", timeout = quick_dom)
-        if payment_form is not None:
-            LOG.warning("############################################")
-            LOG.warning("# Payment form detected! Please proceed with payment.")
-            LOG.warning("############################################")
-            await web.web_scroll_page_down()
-            await ainput(_("Press a key to continue..."))
-
-        confirmation_timeout = web.timeout("publishing_confirmation")
-
-        async def _check_confirmation_url() -> bool:
-            url = str(await web.web_execute("window.location.href"))
-            return "p-anzeige-aufgeben-bestaetigung.html?adId=" in url
-
-        await web.web_await(_check_confirmation_url, timeout = confirmation_timeout)
-
-        # extract the ad id from the URL's query parameter (use JS for fresh URL, not stale page url)
-        current_url = str(await web.web_execute("window.location.href"))
-        current_url_query_params = urllib_parse.parse_qs(urllib_parse.urlparse(current_url).query)
-        ad_id = int(current_url_query_params.get("adId", [])[0])
-
-    except (TimeoutError, ProtocolException, IndexError, ValueError, TypeError) as ex:
-        # The confirmation page may have auto-redirected before we could poll it,
-        # or the URL was redirected between polling and extraction (race condition).
-        # Try to recover the ad ID from tracking data on the current page.
-        LOG.debug("Confirmation URL polling or extraction failed (%s), attempting tracking data fallback...", type(ex).__name__)
-        try:
-            ad_id = await _try_recover_ad_id_from_redirect(web)
-        except Exception as fallback_ex:  # noqa: BLE001
-            LOG.debug("Tracking data fallback failed: %s", fallback_ex)
-
-        if ad_id is None:
-            raise PublishSubmissionUncertainError("submission may have succeeded before failure") from ex
-
-        LOG.warning(
-            "Confirmation page redirected too fast; extracted ad ID %s from page tracking data",
-            ad_id,
-        )
-
-    # Defensive guard: ad_id must be set by now — either from the confirmation URL
-    # (try block) or the tracking fallback (except block). The except block always
-    # either sets ad_id or raises PublishSubmissionUncertainError, making this
-    # unreachable in the current code. Guards against future regressions.
-    if ad_id is None:
-        msg = _("ad_id is unexpectedly None after confirmation flow for %s") % ad_file
-        raise RuntimeError(msg)
-
-    return ad_id

--- a/src/kleinanzeigen_bot/publishing_submission.py
+++ b/src/kleinanzeigen_bot/publishing_submission.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+import re
+import urllib.parse as urllib_parse
+from gettext import gettext as _
+
+from nodriver.core.connection import ProtocolException
+
+from . import captcha_flow
+from .model.ad_model import Ad, AdUpdateStrategy
+from .model.config_model import CaptchaConfig
+from .utils import loggers as _loggers
+from .utils.exceptions import PublishSubmissionUncertainError
+from .utils.misc import ainput
+from .utils.web_scraping_mixin import By, WebScrapingMixin
+
+LOG = _loggers.get_logger(__name__)
+
+
+async def _try_recover_ad_id_from_redirect(web:WebScrapingMixin) -> int | None:
+    """Try to extract the published ad ID from page tracking data.
+
+    Used as a fallback when the confirmation page auto-redirects before
+    the URL can be polled. Checks document.referrer first, then scans
+    inline script content for the confirmation URL containing adId.
+
+    Returns:
+        The extracted ad ID, or None if no ad ID could be found.
+    """
+    # Layer 1: check document.referrer for the confirmation URL.
+    # Note: referrer reflects the most recent navigation, so a stale ID from a
+    # previous publish is not a concern — the publish flow navigates to the edit
+    # page first, resetting the referrer before the confirmation redirect occurs.
+    try:
+        referrer = str(await web.web_execute("document.referrer") or "")
+    except (TimeoutError, ProtocolException) as ex:
+        LOG.debug("document.referrer lookup failed (%s), skipping to script scan", type(ex).__name__)
+        referrer = ""
+
+    if "p-anzeige-aufgeben-bestaetigung.html?adId=" in referrer:
+        try:
+            query = urllib_parse.parse_qs(urllib_parse.urlparse(referrer).query)
+            ad_id_str = query.get("adId", [])[0]
+            ad_id = int(ad_id_str)
+            LOG.debug("Extracted ad ID %s from document.referrer fallback", ad_id)
+            return ad_id
+        except (IndexError, ValueError, TypeError):
+            LOG.debug("Failed to parse ad ID from document.referrer: %s", referrer)
+
+    # Layer 2: scan inline <script> tags for confirmation URL with adId
+    try:
+        script_content = str(await web.web_execute(
+            "[...document.querySelectorAll('script')].map(s => s.textContent).join('\\n')"
+        ) or "")
+        matches = {
+            int(match)
+            for match in re.findall(r"p-anzeige-aufgeben-bestaetigung\.html\?adId=(\d+)", script_content)
+        }
+        if len(matches) == 1:
+            ad_id = next(iter(matches))
+            LOG.debug("Extracted ad ID %s from inline script fallback", ad_id)
+            return ad_id
+        if len(matches) > 1:
+            LOG.debug("Inline script fallback was ambiguous; refusing matches: %s", sorted(matches))
+    except (TimeoutError, ProtocolException, ValueError, TypeError) as ex:
+        LOG.debug("Script content scan failed (%s): %s", type(ex).__name__, ex)
+
+    return None
+
+
+async def submit_and_confirm_ad(
+    web:WebScrapingMixin,
+    ad_file:str,
+    ad_cfg:Ad,
+    mode:AdUpdateStrategy,
+    *,
+    captcha_config:CaptchaConfig,
+) -> int:
+    """Submit the ad form, handle post-submit dialogs, wait for confirmation,
+    and extract the published ad ID.
+
+    Returns:
+        The published ad ID.
+
+    Raises:
+        PublishSubmissionUncertainError: The submission may have succeeded
+            but the ad ID could not be recovered.
+        RuntimeError: An internal invariant was violated (ad_id is None
+            despite the recovery path).
+    """
+
+    #############################
+    # wait for captcha
+    #############################
+    operation_label = {
+        AdUpdateStrategy.REPLACE: "publish",
+        AdUpdateStrategy.MODIFY: "update",
+    }.get(mode, mode.name.lower())
+    await captcha_flow.check_and_wait_for_captcha(web, captcha_config, is_login_page = False, page_context = f"{operation_label} operation")
+
+    #############################
+    # set title (right before submit to prevent React re-render clearing it)
+    #############################
+    LOG.debug("Setting title '%s' (deferred to prevent React re-render clearing it)", ad_cfg.title)
+    await web.web_set_input_value("ad-title", ad_cfg.title)
+
+    #############################
+    # submit
+    #############################
+    # Click is retryable — no submission can have occurred before this point.
+    # Edit page uses 'Änderungen speichern' or 'Anzeige speichern'; publish page uses 'Anzeige aufgeben'
+    await web.web_click(By.XPATH, "//button[contains(., 'Anzeige aufgeben') or contains(., 'Änderungen speichern') or contains(., 'Anzeige speichern')]")
+
+    # Everything after the first click is uncertain: the ad may already have been submitted.
+    ad_id:int | None = None
+    try:
+        quick_dom = web.timeout("quick_dom")
+
+        # PostListingForm v2 may show an "Effektiver verkaufen" upsell
+        # dialog after clicking submit.  Dismiss it so the actual form
+        # POST can proceed.
+        upsell_dialog = await web.web_probe(
+            By.XPATH, "//dialog[@open and contains(., 'Effektiver verkaufen')]", timeout = quick_dom
+        )
+        if upsell_dialog is not None:
+            LOG.info("Dismissing upsell dialog...")
+            await web.web_click(
+                By.XPATH, "//dialog[@open]//button[contains(., 'Ohne Hochschieben weiter')]",
+                timeout = quick_dom,
+            )
+            await web.web_sleep(500)  # let the dialog close animation finish
+
+        imprint_btn = await web.web_probe(By.ID, "imprint-guidance-submit", timeout = quick_dom)
+        if imprint_btn is not None:
+            await imprint_btn.click()
+
+        # check for no image question
+        if not ad_cfg.images:
+            image_hint_xpath = '//button[contains(., "Ohne Bild veröffentlichen")]'
+            image_hint_button = await web.web_probe(By.XPATH, image_hint_xpath, timeout = quick_dom)
+            if image_hint_button is not None:
+                await image_hint_button.click()
+
+        #############################
+        # wait for payment form if commercial account is used
+        #############################
+        payment_form = await web.web_probe(By.ID, "myftr-shppngcrt-frm", timeout = quick_dom)
+        if payment_form is not None:
+            LOG.warning("############################################")
+            LOG.warning("# Payment form detected! Please proceed with payment.")
+            LOG.warning("############################################")
+            await web.web_scroll_page_down()
+            await ainput(_("Press a key to continue..."))
+
+        confirmation_timeout = web.timeout("publishing_confirmation")
+
+        async def _check_confirmation_url() -> bool:
+            url = str(await web.web_execute("window.location.href"))
+            return "p-anzeige-aufgeben-bestaetigung.html?adId=" in url
+
+        await web.web_await(_check_confirmation_url, timeout = confirmation_timeout)
+
+        # extract the ad id from the URL's query parameter (use JS for fresh URL, not stale page url)
+        current_url = str(await web.web_execute("window.location.href"))
+        current_url_query_params = urllib_parse.parse_qs(urllib_parse.urlparse(current_url).query)
+        ad_id = int(current_url_query_params.get("adId", [])[0])
+
+    except (TimeoutError, ProtocolException, IndexError, ValueError, TypeError) as ex:
+        # The confirmation page may have auto-redirected before we could poll it,
+        # or the URL was redirected between polling and extraction (race condition).
+        # Try to recover the ad ID from tracking data on the current page.
+        LOG.debug("Confirmation URL polling or extraction failed (%s), attempting tracking data fallback...", type(ex).__name__)
+        try:
+            ad_id = await _try_recover_ad_id_from_redirect(web)
+        except Exception as fallback_ex:  # noqa: BLE001
+            LOG.debug("Tracking data fallback failed: %s", fallback_ex)
+
+        if ad_id is None:
+            raise PublishSubmissionUncertainError("submission may have succeeded before failure") from ex
+
+        LOG.warning(
+            "Confirmation page redirected too fast; extracted ad ID %s from page tracking data",
+            ad_id,
+        )
+
+    # Defensive guard: ad_id must be set by now — either from the confirmation URL
+    # (try block) or the tracking fallback (except block). The except block always
+    # either sets ad_id or raises PublishSubmissionUncertainError, making this
+    # unreachable in the current code. Guards against future regressions.
+    if ad_id is None:
+        msg = _("ad_id is unexpectedly None after confirmation flow for %s") % ad_file
+        raise RuntimeError(msg)
+
+    return ad_id

--- a/src/kleinanzeigen_bot/publishing_submission.py
+++ b/src/kleinanzeigen_bot/publishing_submission.py
@@ -1,6 +1,13 @@
 # SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Submit, confirm, and recover published ad IDs.
+
+This module owns the browser-side publish boundary: captcha handling,
+submit click, confirmation polling, and fallback recovery when the
+confirmation page redirects too fast to inspect the URL directly.
+"""
+
 import re
 import urllib.parse as urllib_parse
 from gettext import gettext as _
@@ -18,7 +25,11 @@ from .utils.web_scraping_mixin import By, WebScrapingMixin
 LOG = _loggers.get_logger(__name__)
 
 
-async def _try_recover_ad_id_from_redirect(web:WebScrapingMixin) -> int | None:
+async def _try_recover_ad_id_from_redirect(
+    web:WebScrapingMixin,
+    *,
+    pre_submit_referrer:str | None = None,
+) -> int | None:
     """Try to extract the published ad ID from page tracking data.
 
     Used as a fallback when the confirmation page auto-redirects before
@@ -36,6 +47,10 @@ async def _try_recover_ad_id_from_redirect(web:WebScrapingMixin) -> int | None:
         referrer = str(await web.web_execute("document.referrer") or "")
     except (TimeoutError, ProtocolException) as ex:
         LOG.debug("document.referrer lookup failed (%s), skipping to script scan", type(ex).__name__)
+        referrer = ""
+
+    if pre_submit_referrer is not None and referrer == pre_submit_referrer:
+        LOG.debug("document.referrer did not change after submit; skipping referrer fallback")
         referrer = ""
 
     if "p-anzeige-aufgeben-bestaetigung.html?adId=" in referrer:
@@ -110,6 +125,7 @@ async def submit_and_confirm_ad(
     #############################
     # Click is retryable — no submission can have occurred before this point.
     # Edit page uses 'Änderungen speichern' or 'Anzeige speichern'; publish page uses 'Anzeige aufgeben'
+    pre_submit_referrer = str(await web.web_execute("document.referrer") or "")
     await web.web_click(By.XPATH, "//button[contains(., 'Anzeige aufgeben') or contains(., 'Änderungen speichern') or contains(., 'Anzeige speichern')]")
 
     # Everything after the first click is uncertain: the ad may already have been submitted.
@@ -172,7 +188,7 @@ async def submit_and_confirm_ad(
         # Try to recover the ad ID from tracking data on the current page.
         LOG.debug("Confirmation URL polling or extraction failed (%s), attempting tracking data fallback...", type(ex).__name__)
         try:
-            ad_id = await _try_recover_ad_id_from_redirect(web)
+            ad_id = await _try_recover_ad_id_from_redirect(web, pre_submit_referrer = pre_submit_referrer)
         except Exception as fallback_ex:  # noqa: BLE001
             LOG.debug("Tracking data fallback failed: %s", fallback_ex)
 

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -286,6 +286,9 @@ kleinanzeigen_bot/publishing_flow.py:
     "image(s)": "Bild(er)"
     "ad folder": "Anzeigenordner"
 
+#################################################
+kleinanzeigen_bot/publishing_submission.py:
+#################################################
   submit_and_confirm_ad:
     "############################################": "############################################"
     "Dismissing upsell dialog...": "Upsell-Dialog schließen..."

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1199,6 +1199,7 @@ class TestKleinanzeigenBotBasics:
         web_execute_side_effect:list[Any] | None = None,
         redirect_recovery_return:int | None = None,
         redirect_recovery_side_effect:BaseException | None = None,
+        mock_redirect_recovery:bool = True,
         include_success_mocks:bool = False,
     ) -> Iterator[None]:
         """Mock all post-submit publish_ad dependencies for confirmation fallback tests.
@@ -1229,9 +1230,17 @@ class TestKleinanzeigenBotBasics:
             patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = web_await_side_effect),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_submission._try_recover_ad_id_from_redirect", new_callable = AsyncMock,
-                  return_value = redirect_recovery_return, side_effect = redirect_recovery_side_effect),
         ]
+
+        if mock_redirect_recovery:
+            common_patches.append(
+                patch(
+                    "kleinanzeigen_bot.publishing_submission._try_recover_ad_id_from_redirect",
+                    new_callable = AsyncMock,
+                    return_value = redirect_recovery_return,
+                    side_effect = redirect_recovery_side_effect,
+                ),
+            )
 
         if include_success_mocks:
             common_patches.append(patch("kleinanzeigen_bot.utils.dicts.save_dict"))
@@ -1302,6 +1311,7 @@ class TestKleinanzeigenBotBasics:
                 mock_page,
                 web_await_side_effect = TimeoutError("confirmation timeout"),
                 web_execute_side_effect = [stale_confirmation_url, stale_confirmation_url, "var x = 42;"],
+                mock_redirect_recovery = False,
             ),
             patch("kleinanzeigen_bot.publishing_flow.persist_published_ad") as mock_persist,
             pytest.raises(PublishSubmissionUncertainError, match = "submission may have succeeded before failure"),

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1196,6 +1196,7 @@ class TestKleinanzeigenBotBasics:
         mock_page:MagicMock,
         *,
         web_await_side_effect:BaseException | None = None,
+        web_execute_side_effect:list[Any] | None = None,
         redirect_recovery_return:int | None = None,
         redirect_recovery_side_effect:BaseException | None = None,
         include_success_mocks:bool = False,
@@ -1222,7 +1223,7 @@ class TestKleinanzeigenBotBasics:
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
-            patch.object(test_bot, "web_execute", new_callable = AsyncMock),
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = web_execute_side_effect),
             patch.object(test_bot, "web_find", new_callable = AsyncMock),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
@@ -1283,6 +1284,32 @@ class TestKleinanzeigenBotBasics:
             await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
 
         assert ad_cfg_orig["id"] == 99887766
+
+    @pytest.mark.asyncio
+    async def test_publish_ad_ignores_stale_referrer_after_timeout(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """A stale pre-submit referrer must not recover the previous ad ID for a new publish attempt."""
+        ad_cfg, ad_cfg_orig = self._build_publish_ad_cfg(base_ad_config)
+        stale_confirmation_url = "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=99887766"
+
+        with (
+            self._mock_post_submit_dependencies(
+                test_bot,
+                mock_page,
+                web_await_side_effect = TimeoutError("confirmation timeout"),
+                web_execute_side_effect = [stale_confirmation_url, stale_confirmation_url, "var x = 42;"],
+            ),
+            patch("kleinanzeigen_bot.publishing_flow.persist_published_ad") as mock_persist,
+            pytest.raises(PublishSubmissionUncertainError, match = "submission may have succeeded before failure"),
+        ):
+            await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.MODIFY)
+
+        mock_persist.assert_not_called()
+        assert ad_cfg_orig["id"] is None
 
     @pytest.mark.asyncio
     async def test_publish_ad_confirmation_fallback_when_redirect_happens_after_url_poll(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1228,7 +1228,7 @@ class TestKleinanzeigenBotBasics:
             patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = web_await_side_effect),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_flow._try_recover_ad_id_from_redirect", new_callable = AsyncMock,
+            patch("kleinanzeigen_bot.publishing_submission._try_recover_ad_id_from_redirect", new_callable = AsyncMock,
                   return_value = redirect_recovery_return, side_effect = redirect_recovery_side_effect),
         ]
 

--- a/tests/unit/test_publishing_flow.py
+++ b/tests/unit/test_publishing_flow.py
@@ -12,6 +12,7 @@ import pytest
 from kleinanzeigen_bot import (
     KleinanzeigenBot,
     publishing_flow,
+    publishing_submission,
 )
 from kleinanzeigen_bot import (
     local_path_renaming as _local_path_renaming,
@@ -302,7 +303,7 @@ async def test_publish_ad_survives_persistence_failure() -> None:
         patch.object(bot, "web_open", new_callable = AsyncMock),
         patch.object(bot, "_dismiss_consent_banner", new_callable = AsyncMock),
         patch.object(bot, "_fill_ad_form", new_callable = AsyncMock),
-        patch("kleinanzeigen_bot.publishing_flow.submit_and_confirm_ad", new_callable = AsyncMock, return_value = 12345),
+        patch("kleinanzeigen_bot.publishing_submission.submit_and_confirm_ad", new_callable = AsyncMock, return_value = 12345),
         patch("kleinanzeigen_bot.publishing_flow.persist_published_ad",
               side_effect = RuntimeError("disk full")),
     ):
@@ -318,7 +319,7 @@ class TestTrackingFallback:
         """Ad ID should be extracted from document.referrer containing the confirmation URL."""
         referrer_url = "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=3382410263"
         with patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = referrer_url):
-            result = await publishing_flow._try_recover_ad_id_from_redirect(test_bot)
+            result = await publishing_submission._try_recover_ad_id_from_redirect(test_bot)
 
         assert result == 3382410263
 
@@ -332,7 +333,7 @@ class TestTrackingFallback:
         execute_returns = [referrer, script_content]
 
         with patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = execute_returns):
-            result = await publishing_flow._try_recover_ad_id_from_redirect(test_bot)
+            result = await publishing_submission._try_recover_ad_id_from_redirect(test_bot)
 
         assert result == 44556677
 
@@ -345,7 +346,7 @@ class TestTrackingFallback:
         ]
 
         with patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = execute_returns):
-            result = await publishing_flow._try_recover_ad_id_from_redirect(test_bot)
+            result = await publishing_submission._try_recover_ad_id_from_redirect(test_bot)
 
         assert result is None
 
@@ -359,7 +360,7 @@ class TestTrackingFallback:
         execute_returns = [referrer_value, script_content]
 
         with patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = execute_returns):
-            result = await publishing_flow._try_recover_ad_id_from_redirect(test_bot)
+            result = await publishing_submission._try_recover_ad_id_from_redirect(test_bot)
 
         assert result == 11223344
 
@@ -370,7 +371,7 @@ class TestTrackingFallback:
         execute_returns:list[object] = [TimeoutError("timed out"), script_content]
 
         with patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = execute_returns):
-            result = await publishing_flow._try_recover_ad_id_from_redirect(test_bot)
+            result = await publishing_submission._try_recover_ad_id_from_redirect(test_bot)
 
         assert result == 55556666
 
@@ -381,7 +382,7 @@ class TestTrackingFallback:
         execute_returns:list[object] = [referrer, TimeoutError("timed out")]
 
         with patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = execute_returns):
-            result = await publishing_flow._try_recover_ad_id_from_redirect(test_bot)
+            result = await publishing_submission._try_recover_ad_id_from_redirect(test_bot)
 
         assert result is None
 
@@ -404,9 +405,9 @@ class TestSubmitAndConfirmAd:
             patch.object(test_bot, "web_await", new_callable = AsyncMock),
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = confirmation_url),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_flow.ainput", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_submission.ainput", new_callable = AsyncMock),
         ):
-            result = await publishing_flow.submit_and_confirm_ad(
+            result = await publishing_submission.submit_and_confirm_ad(
                 test_bot, "test.yaml", ad, AdUpdateStrategy.REPLACE,
                 captcha_config = captcha_config,
             )
@@ -432,9 +433,9 @@ class TestSubmitAndConfirmAd:
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = confirmation_url),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_flow.ainput", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_submission.ainput", new_callable = AsyncMock),
         ):
-            result = await publishing_flow.submit_and_confirm_ad(
+            result = await publishing_submission.submit_and_confirm_ad(
                 test_bot, "test.yaml", ad, AdUpdateStrategy.REPLACE,
                 captcha_config = captcha_config,
             )
@@ -464,9 +465,9 @@ class TestSubmitAndConfirmAd:
             patch.object(test_bot, "web_await", new_callable = AsyncMock),
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = confirmation_url),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_flow.ainput", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_submission.ainput", new_callable = AsyncMock),
         ):
-            result = await publishing_flow.submit_and_confirm_ad(
+            result = await publishing_submission.submit_and_confirm_ad(
                 test_bot, "test.yaml", ad, AdUpdateStrategy.REPLACE,
                 captcha_config = captcha_config,
             )
@@ -490,9 +491,9 @@ class TestSubmitAndConfirmAd:
             patch.object(test_bot, "web_await", new_callable = AsyncMock),
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = confirmation_url),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock) as mock_scroll,
-            patch("kleinanzeigen_bot.publishing_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+            patch("kleinanzeigen_bot.publishing_submission.ainput", new_callable = AsyncMock) as mock_ainput,
         ):
-            result = await publishing_flow.submit_and_confirm_ad(
+            result = await publishing_submission.submit_and_confirm_ad(
                 test_bot, "test.yaml", ad, AdUpdateStrategy.REPLACE,
                 captcha_config = captcha_config,
             )
@@ -515,10 +516,10 @@ class TestSubmitAndConfirmAd:
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = TimeoutError("timed out")),
             patch.object(test_bot, "web_execute", new_callable = AsyncMock),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_flow._try_recover_ad_id_from_redirect", new_callable = AsyncMock, return_value = 99999),
-            patch("kleinanzeigen_bot.publishing_flow.ainput", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_submission._try_recover_ad_id_from_redirect", new_callable = AsyncMock, return_value = 99999),
+            patch("kleinanzeigen_bot.publishing_submission.ainput", new_callable = AsyncMock),
         ):
-            result = await publishing_flow.submit_and_confirm_ad(
+            result = await publishing_submission.submit_and_confirm_ad(
                 test_bot, "test.yaml", ad, AdUpdateStrategy.REPLACE,
                 captcha_config = captcha_config,
             )
@@ -539,11 +540,11 @@ class TestSubmitAndConfirmAd:
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = TimeoutError("timed out")),
             patch.object(test_bot, "web_execute", new_callable = AsyncMock),
             patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_flow._try_recover_ad_id_from_redirect", new_callable = AsyncMock, return_value = None),
-            patch("kleinanzeigen_bot.publishing_flow.ainput", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_submission._try_recover_ad_id_from_redirect", new_callable = AsyncMock, return_value = None),
+            patch("kleinanzeigen_bot.publishing_submission.ainput", new_callable = AsyncMock),
             pytest.raises(PublishSubmissionUncertainError),
         ):
-            await publishing_flow.submit_and_confirm_ad(
+            await publishing_submission.submit_and_confirm_ad(
                 test_bot, "test.yaml", ad, AdUpdateStrategy.REPLACE,
                 captcha_config = captcha_config,
             )


### PR DESCRIPTION
## ℹ️ Description
*Refactor the publishing submission/confirmation flow into a dedicated module while keeping behavior identical.*

- Link to the related issue(s): N/A
- Describe the motivation and context for this change: Reduce coupling in the publishing workflow and keep the persistence boundary separate.

## 📋 Changes Summary

- Added `src/kleinanzeigen_bot/publishing_submission.py` for captcha, submit, confirmation, and ad-id recovery.
- Removed the submission/confirmation helpers from `publishing_flow.py`, leaving persistence helpers there.
- Updated the `publish_ad()` call site and tests to use the new concrete module path.
- Moved the translated log-message entries for the extracted submission flow.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [ ] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Ad submission and confirmation logic moved into a dedicated submission module for clearer separation.

* **Bug Fixes**
  * Improved publish confirmation: better captcha handling, post-submit dialogs (upsell/payment, imprint guidance, “no image”) and avoidance of stale-referrer fallbacks.
  * Now fails loudly and avoids persisting when ad confirmation is uncertain.

* **Tests**
  * Unit tests updated to target the new submission flow and recovery/persistence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->