### PR TITLE
fix: click Auth0 Weiter after captcha (#1120)

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -574,7 +574,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # After captcha solving, probe for a visible Weiter button
         quick_dom = self.timeout("quick_dom")
         weiter = await self.web_probe(
-            By.XPATH, "//button[contains(text(), 'Weiter')]",
+            By.XPATH, "//button[contains(., 'Weiter')]",
             timeout = quick_dom,
         )
         if weiter is not None:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -544,6 +544,46 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         return "error" not in path
 
+    async def _handle_identifier_captcha_state(self) -> None:
+        """Handle captcha on the Auth0 identifier page and click Weiter if present.
+
+        After submitting the email, a reCAPTCHA may be displayed on the
+        identifier page. If so, this waits for the user to solve it and then
+        probes for a visible Weiter button (not assumed to exist). If present,
+        it is clicked to continue to the password page.
+
+        No-op when the password page is already reached or no captcha is
+        detected, so the normal fast path is unaffected.
+        """
+        if "/u/login/password" in self._current_page_url():
+            return
+
+        captcha_elem = await self.web_probe(
+            By.CSS_SELECTOR,
+            "iframe[name^='a-'][src^='https://www.google.com/recaptcha/api2/anchor?']",
+            timeout = self.timeout("captcha_detection"),
+        )
+        if captcha_elem is None:
+            return
+
+        LOG.warning("############################################")
+        LOG.warning("# Captcha detected on Auth0 login page. Please solve it in the browser.")
+        LOG.warning("############################################")
+        await ainput(_("Press a key to continue..."))
+
+        # After captcha solving, probe for a visible Weiter button
+        quick_dom = self.timeout("quick_dom")
+        weiter = await self.web_probe(
+            By.XPATH, "//button[contains(text(), 'Weiter')]",
+            timeout = quick_dom,
+        )
+        if weiter is not None:
+            LOG.info("Auth0 Weiter button present after captcha, clicking it...")
+            await weiter.click()
+            await self.web_sleep()
+        else:
+            LOG.debug("No Weiter button after captcha — continuing to wait for password page")
+
     async def fill_login_data_and_send(self) -> None:
         """Auth0 2-step login via m-einloggen-sso.html (server-side redirect, no JS needed).
 
@@ -558,6 +598,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         LOG.debug("Auth0 Step 1: entering email...")
         await self.web_input(By.ID, "username", self.config.login.username)
         await self.web_click(By.CSS_SELECTOR, "button[type='submit']")
+
+        # Captcha-solving branch: captcha can appear on the identifier page
+        # after email submit. After solving, a visible Weiter button may need
+        # clicking to reach the password page.
+        await self._handle_identifier_captcha_state()
 
         # Step 2: wait for password page then enter password
         LOG.debug("Waiting for Auth0 password page...")

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -573,13 +573,14 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
         # After captcha solving, probe for a visible Weiter button
         quick_dom = self.timeout("quick_dom")
+        weiter_xpath = "//button[contains(., 'Weiter')]"
         weiter = await self.web_probe(
-            By.XPATH, "//button[contains(., 'Weiter')]",
+            By.XPATH, weiter_xpath,
             timeout = quick_dom,
         )
-        if weiter is not None:
+        if weiter is not None and await self.web_check(By.XPATH, weiter_xpath, Is.DISPLAYED, timeout = quick_dom):
             LOG.info("Auth0 Weiter button present after captcha, clicking it...")
-            await weiter.click()
+            await self.web_click(By.XPATH, weiter_xpath, timeout = quick_dom)
             await self.web_sleep()
         else:
             LOG.debug("No Weiter button after captcha — continuing to wait for password page")

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -98,6 +98,11 @@ kleinanzeigen_bot/__init__.py:
     "Auth0 Step 2: entering password...": "Auth0 Schritt 2: Passwort wird eingegeben..."
     "Auth0 login submitted.": "Auth0-Anmeldung abgesendet."
 
+  _handle_identifier_captcha_state:
+    "# Captcha detected on Auth0 login page. Please solve it in the browser.": "# Captcha auf der Auth0-Anmeldeseite erkannt. Bitte loesen Sie das Captcha im Browser."
+    "Auth0 Weiter button present after captcha, clicking it...": "Auth0-Weiter-Button nach Captcha vorhanden, klicke ihn..."
+    "Press a key to continue...": "Eine Taste drücken, um fortzufahren..."
+
   _check_sms_verification:
     "# Device verification message detected. Please follow the instruction displayed in the Browser.": "# Nachricht zur Geräteverifizierung erkannt. Bitte den Anweisungen im Browser folgen."
     "Press ENTER when done...": "EINGABETASTE drücken, wenn erledigt..."

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -666,6 +666,7 @@ class TestKleinanzeigenBotAuthentication:
         """Verify that login form filling works correctly."""
         with (
             patch.object(test_bot, "_wait_for_auth0_login_context", new_callable = AsyncMock) as wait_context,
+            patch.object(test_bot, "_handle_identifier_captcha_state", new_callable = AsyncMock),
             patch.object(test_bot, "_wait_for_auth0_password_step", new_callable = AsyncMock) as wait_password,
             patch.object(test_bot, "_wait_for_post_auth0_submit_transition", new_callable = AsyncMock) as wait_transition,
             patch.object(test_bot, "web_input") as mock_input,
@@ -692,6 +693,7 @@ class TestKleinanzeigenBotAuthentication:
         """Missing Auth0 password step should fail fast."""
         with (
             patch.object(test_bot, "_wait_for_auth0_login_context", new_callable = AsyncMock),
+            patch.object(test_bot, "_handle_identifier_captcha_state", new_callable = AsyncMock),
             patch.object(test_bot, "_wait_for_auth0_password_step", new_callable = AsyncMock, side_effect = AssertionError("missing password")),
             patch.object(test_bot, "web_input") as mock_input,
             patch.object(test_bot, "web_click") as mock_click,


### PR DESCRIPTION
## ℹ️ Description

Fixes issue #1120 by handling the Auth0 captcha branch after email submit. When captcha appears, the bot now probes for a visible/clickable "Weiter" button and clicks it before waiting for the password page. The normal no-captcha login flow remains unchanged.

- Link to the related issue(s): Issue #1120
- Describe the motivation and context for this change.

## 📋 Changes Summary

- Added a captcha-only Auth0 identifier handler that waits for captcha completion, probes for "Weiter" with `web_probe`, and clicks it if present.
- Kept the existing no-captcha login path unchanged.
- Updated German translations for the new log messages.
- Adjusted unit tests for the new login helper.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary. No additional docs changes were needed beyond translations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login robustness to detect optional reCAPTCHA on the email/identifier step; users are notified when a captcha appears, can provide input, and the login resumes once advanced.
* **Tests**
  * Updated unit tests to cover and control the captcha-handling behavior during the login flow, including the missing-password-step scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->