### PR TITLE
fix: use canonical title for owned ad downloads

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -572,7 +572,25 @@ class AdExtractor(WebScrapingMixin):
         """
         return await self.web_text(By.ID, "viewad-title")
 
-    async def _extract_ad_page_info(self, directory:str, ad_id:int, ad_file_stem:str, *, active_override:bool | None = None) -> AdPartial:
+    async def _resolve_download_title(self, ad_id:int) -> str:
+        """Return the canonical title for a downloaded ad."""
+        cached_ad = self.published_ads_by_id.get(ad_id)
+        if cached_ad is not None:
+            title = cached_ad.get("title")
+            if isinstance(title, str) and title.strip():
+                return title.strip()
+
+        return await self._extract_title_from_ad_page()
+
+    async def _extract_ad_page_info(
+        self,
+        directory:str,
+        ad_id:int,
+        ad_file_stem:str,
+        title:str,
+        *,
+        active_override:bool | None = None,
+    ) -> AdPartial:
         """
         Extracts ad information and downloads images to the specified directory.
         NOTE: Requires that the driver session currently is on the ad page.
@@ -580,13 +598,11 @@ class AdExtractor(WebScrapingMixin):
         :param directory: the directory to download images to
         :param ad_id: the ad ID
         :param ad_file_stem: the rendered filename stem shared by the ad config and images
+        :param title: the resolved ad title
         :param active_override: optional override for ad activity state
         :return: an AdPartial object containing the ad information
         """
         info:dict[str, Any] = {"active": active_override if active_override is not None else True}
-
-        # Extract title first (needed for directory creation)
-        title = await self._extract_title_from_ad_page()
 
         # Get BelenConf data which contains accurate ad_type information
         belen_conf = await self.web_execute("window.BelenConf")
@@ -667,8 +683,8 @@ class AdExtractor(WebScrapingMixin):
         :param active_override: optional override for ad activity state
         :return: AdPartial with staging/final directory information and rendered ad file stem
         """
-        title = await self._extract_title_from_ad_page()
-        LOG.info('Extracting title from ad %s: "%s"', ad_id, title)
+        title = await self._resolve_download_title(ad_id)
+        LOG.info('Resolved title for ad %s: "%s"', ad_id, title)
 
         # Determine the final directory path
         ad_file_stem = self._render_download_ad_file_stem(ad_id, title)
@@ -706,7 +722,7 @@ class AdExtractor(WebScrapingMixin):
         LOG.info("Downloading ad to: %s", final_dir)
 
         try:
-            ad_cfg = await self._extract_ad_page_info(str(staging_dir), ad_id, ad_file_stem, active_override = active_override)
+            ad_cfg = await self._extract_ad_page_info(str(staging_dir), ad_id, ad_file_stem, title, active_override = active_override)
         except Exception:
             if await files.exists(staging_dir):
                 try:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -497,7 +497,7 @@ kleinanzeigen_bot/extract.py:
     "A popup appeared!": "Ein Popup ist erschienen!"
 
   _extract_ad_page_info_with_directory_handling:
-    "Extracting title from ad %s: \"%s\"": "Extrahiere Titel aus Anzeige %s: \"%s\""
+    "Resolved title for ad %s: \"%s\"": "Ermittelter Titel für Anzeige %s: \"%s\""
     "Removing stale staging directory: %s": "Entferne veraltetes Staging-Verzeichnis: %s"
     "Could not remove stale staging directory %s: %s": "Konnte veraltetes Staging-Verzeichnis %s nicht entfernen: %s"
     "Could not remove stale staging directory %s. Aborting extraction to avoid using a dirty staging directory.": "Konnte veraltetes Staging-Verzeichnis %s nicht entfernen. Extraktion wird abgebrochen, um kein verunreinigtes Staging-Verzeichnis zu verwenden."

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -876,8 +876,7 @@ class TestAdExtractorContent:
                 test_extractor,
                 web_text = AsyncMock(
                     side_effect = [
-                        "Test Title",  # Title (wrapper's initial extraction)
-                        "Test Title",  # Title (core extraction's call)
+                        "Test Title",  # Title extraction
                         web_description_with_affixes,  # Description with affixes (as it appears on web)
                         "03.02.2025",  # Creation date
                     ]
@@ -911,8 +910,7 @@ class TestAdExtractorContent:
                 test_extractor,
                 web_text = AsyncMock(
                     side_effect = [
-                        "Test Title",  # Title (wrapper's initial extraction)
-                        "Test Title",  # Title (core extraction's call)
+                        "Test Title",  # Title extraction
                         TimeoutError("Timeout"),  # Description times out
                         "03.02.2025",  # Date succeeds (not reached)
                     ]
@@ -947,8 +945,7 @@ class TestAdExtractorContent:
             test_extractor,
             web_text = AsyncMock(
                 side_effect = [
-                    "Test Title",  # Title (wrapper's initial extraction)
-                    "Test Title",  # Title (core extraction's call)
+                    "Test Title",  # Title extraction
                     raw_description,  # Description without affixes
                     "03.02.2025",  # Creation date
                 ]
@@ -995,12 +992,63 @@ class TestAdExtractorContent:
             ),
             patch.object(test_extractor, "web_probe", new_callable = AsyncMock, return_value = None),
         ):
-            mock_web_text.side_effect = ["Test Title", "Test Title", "Description text", "03.02.2025"]
+            mock_web_text.side_effect = ["Test Title", "Description text", "03.02.2025"]
             ad_cfg, _staging_dir, _final_dir, _ad_file_stem = await test_extractor._extract_ad_page_info_with_directory_handling(base_dir, 12345)
 
         mock_web_text.assert_any_await(By.CSS_SELECTOR, extract_module.DOWNLOAD_CREATION_DATE_SELECTOR)
         assert ad_cfg.created_on is not None
         assert ad_cfg.created_on.isoformat().startswith("2025-02-03")
+
+    @pytest.mark.asyncio
+    async def test_resolve_download_title_prefers_published_metadata(self, test_extractor:extract_module.AdExtractor) -> None:
+        """Use the clean manage-ads title for owned ads instead of the page title."""
+        test_extractor.published_ads_by_id = {12345: {"id": 12345, "title": " Clean API Title "}}
+
+        with patch.object(test_extractor, "_extract_title_from_ad_page", new_callable = AsyncMock) as mock_extract_title:
+            title = await test_extractor._resolve_download_title(12345)
+
+        assert title == "Clean API Title"
+        mock_extract_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolve_download_title_falls_back_to_page_title(self, test_extractor:extract_module.AdExtractor) -> None:
+        """Keep manual page extraction unchanged when manage-ads metadata is missing."""
+        test_extractor.published_ads_by_id = {12345: {"id": 12345, "title": "   "}}
+
+        with patch.object(test_extractor, "_extract_title_from_ad_page", new_callable = AsyncMock, return_value = "Page Title"):
+            title = await test_extractor._resolve_download_title(12345)
+
+        assert title == "Page Title"
+
+    @pytest.mark.asyncio
+    async def test_directory_handling_uses_published_title_for_names_and_ad_info(
+        self,
+        test_extractor:extract_module.AdExtractor,
+        tmp_path:Path,
+    ) -> None:
+        """Use the canonical manage-ads title consistently for paths and persisted ad info."""
+        base_dir = tmp_path / "downloaded-ads"
+        base_dir.mkdir()
+        title = "Beistelltisch aus Holz mit Glaseinsatz und Korb – 67 × 67 × 48 cm"
+        test_extractor.published_ads_by_id = {3421140610: {"id": 3421140610, "title": title}}
+        test_extractor.config.download.ad_file_name_template = "ad_{id}_{title}"
+
+        ad_cfg = _create_test_ad_partial(title = title)
+
+        with (
+            patch.object(test_extractor, "_extract_title_from_ad_page", new_callable = AsyncMock) as mock_extract_title,
+            patch.object(test_extractor, "_extract_ad_page_info", new_callable = AsyncMock, return_value = ad_cfg) as mock_extract_info,
+        ):
+            _cfg, staging_dir, final_dir, ad_file_stem = await test_extractor._extract_ad_page_info_with_directory_handling(
+                base_dir,
+                3421140610,
+            )
+
+        assert ad_file_stem == "ad_3421140610_Beistelltisch aus Holz mit Glaseinsatz und Korb – 67 × 67 × 48 cm"
+        assert staging_dir == base_dir / f".tmp-{ad_file_stem}"
+        assert final_dir == base_dir / f"ad_3421140610_{title}"
+        mock_extract_title.assert_not_called()
+        mock_extract_info.assert_awaited_once_with(str(staging_dir), 3421140610, ad_file_stem, title, active_override = None)
 
     @pytest.mark.asyncio
     async def test_extract_sell_directly_data_hit_true(self, test_extractor:extract_module.AdExtractor) -> None:
@@ -1647,7 +1695,6 @@ class TestAdExtractorDownload:
                 new_callable = AsyncMock,
                 side_effect = [
                     "Test Title",  # Title extraction
-                    "Test Title",  # Second title call for full extraction
                     "Description text",  # Description
                     "03.02.2025",  # Creation date
                 ],
@@ -1712,7 +1759,6 @@ class TestAdExtractorDownload:
                 new_callable = AsyncMock,
                 side_effect = [
                     "Test Title",  # Title extraction
-                    "Test Title",  # Second title call for full extraction
                     "Description text",  # Description
                     "03.02.2025",  # Creation date
                 ],
@@ -1780,7 +1826,6 @@ class TestAdExtractorDownload:
                 new_callable = AsyncMock,
                 side_effect = [
                     "Test Title",  # Title extraction
-                    "Test Title",  # Second title call for full extraction
                     "Description text",  # Description
                     "03.02.2025",  # Creation date
                 ],
@@ -1845,7 +1890,6 @@ class TestAdExtractorDownload:
                 new_callable = AsyncMock,
                 side_effect = [
                     title_with_umlauts,  # Title extraction
-                    title_with_umlauts,  # Second title call for full extraction
                     "Description text",  # Description
                     "03.02.2025",  # Creation date
                 ],

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -1037,18 +1037,18 @@ class TestAdExtractorContent:
 
         with (
             patch.object(test_extractor, "_extract_title_from_ad_page", new_callable = AsyncMock) as mock_extract_title,
-            patch.object(test_extractor, "_extract_ad_page_info", new_callable = AsyncMock, return_value = ad_cfg) as mock_extract_info,
+            patch.object(test_extractor, "_extract_ad_page_info", new_callable = AsyncMock, return_value = ad_cfg),
         ):
-            _cfg, staging_dir, final_dir, ad_file_stem = await test_extractor._extract_ad_page_info_with_directory_handling(
+            cfg, staging_dir, final_dir, ad_file_stem = await test_extractor._extract_ad_page_info_with_directory_handling(
                 base_dir,
                 3421140610,
             )
 
+        assert cfg.title == title
         assert ad_file_stem == "ad_3421140610_Beistelltisch aus Holz mit Glaseinsatz und Korb – 67 × 67 × 48 cm"
         assert staging_dir == base_dir / f".tmp-{ad_file_stem}"
         assert final_dir == base_dir / f"ad_3421140610_{title}"
         mock_extract_title.assert_not_called()
-        mock_extract_info.assert_awaited_once_with(str(staging_dir), 3421140610, ad_file_stem, title, active_override = None)
 
     @pytest.mark.asyncio
     async def test_extract_sell_directly_data_hit_true(self, test_extractor:extract_module.AdExtractor) -> None:


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #1119
- Fixes owned-ad downloads where the public/detail page title may include UI status decoration that makes the title exceed the semantic 65-character title limit.

## 📋 Changes Summary

- Resolve download titles once via manage-ads metadata when available.
- Reuse the resolved title for folder naming, file stems, and persisted ad config data.
- Keep manual page title extraction as the fallback without stripping or truncation.
- Add regression coverage for canonical metadata titles and fallback extraction.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (pdm run test).
- [x] I have formatted the code (pdm run format).
- [x] I have verified that linting passes (pdm run lint).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced ad title resolution to prioritize cached published metadata when available, with fallback to page extraction for improved reliability.
  * Improved directory handling to consistently use the resolved ad title for naming and saved info templates.
* **Bug Fixes**
  * Corrected title/metadata extraction flow to avoid redundant title reads and ensure creation dates are reliably sourced from the expected page elements.
* **Tests**
  * Updated and added unit test coverage for title resolution, directory behaviors, and extraction call ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->