### PR TITLE
fix: handle shipping select for pro accounts

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1915,6 +1915,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
     async def _set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
         short_timeout = self.timeout("quick_dom")
+
+        # PRO/commercial accounts are expected to render Versand as the legacy/native
+        # ``versand_s`` select.  In that UI the placeholder ("Bitte wählen") must be
+        # replaced directly with either "Versand möglich" or "Nur Abholung".
         shipping_select_selector = 'select[id$=".versand_s"]'
         shipping_select = await self.web_probe(By.CSS_SELECTOR, shipping_select_selector, timeout = short_timeout)
         if shipping_select is not None:
@@ -1933,6 +1937,9 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 LOG.debug(ex, exc_info = True)
                 raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % ad_cfg.shipping_type) from ex
 
+        # Private/non-commercial accounts are expected to render the newer radio-button
+        # controls and, for SHIPPING, the shipping-options dialog.  This is the fallback
+        # path when no native ``versand_s`` select is present (see #869 vs #1125).
         if ad_cfg.shipping_type == "PICKUP":
             pickup_radio = await self.web_probe(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
             if pickup_radio is None:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -61,6 +61,11 @@ _LOGGED_OUT_CTA_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CSS_SELECTOR, 'a[href*="einloggen"]'),
     (By.CSS_SELECTOR, 'a[href*="/m-einloggen"]'),
 ]
+_VERSAND_COMBOBOX_SELECTOR:Final[str] = (
+    'button[role="combobox"][id="versand"], '
+    'button[role="combobox"][id$=".versand"], '
+    'button[role="combobox"][aria-labelledby$="versand-selected-option"]'
+)
 
 colorama.just_fix_windows_console()
 
@@ -1040,15 +1045,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 # See issue #930 for broader React fiber migration.
                 display_text = _ad_form_helpers.WANTED_SHIPPING_LABELS.get(shipping_type)
                 if display_text:
-                    shipping_combobox_selector = (
-                        'button[role="combobox"][id="versand"], '
-                        'button[role="combobox"][id$=".versand"], '
-                        'button[role="combobox"][aria-labelledby$="versand-selected-option"]'
-                    )
                     try:
                         shipping_btn = await self.web_find(
                             By.CSS_SELECTOR,
-                            shipping_combobox_selector,
+                            _VERSAND_COMBOBOX_SELECTOR,
                             timeout = self.timeout("quick_dom"),
                         )
                         btn_id = cast(str, shipping_btn.attrs.get("id"))
@@ -1926,12 +1926,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # PostListingForm Astro island.  In that UI the placeholder ("Bitte wählen")
         # must be replaced directly with either "Versand möglich" (value "ja") or
         # "Nur Abholung" (value "nein").
-        shipping_combobox_selector = (
-            'button[role="combobox"][id="versand"], '
-            'button[role="combobox"][id$=".versand"], '
-            'button[role="combobox"][aria-labelledby$="versand-selected-option"]'
-        )
-        shipping_combobox = await self.web_probe(By.CSS_SELECTOR, shipping_combobox_selector, timeout = short_timeout)
+        shipping_combobox = await self.web_probe(By.CSS_SELECTOR, _VERSAND_COMBOBOX_SELECTOR, timeout = short_timeout)
         if shipping_combobox is not None:
             try:
                 btn_id = cast(str, shipping_combobox.attrs.get("id"))

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1040,10 +1040,15 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 # See issue #930 for broader React fiber migration.
                 display_text = _ad_form_helpers.WANTED_SHIPPING_LABELS.get(shipping_type)
                 if display_text:
+                    shipping_combobox_selector = (
+                        'button[role="combobox"][id="versand"], '
+                        'button[role="combobox"][id$=".versand"], '
+                        'button[role="combobox"][aria-labelledby$="versand-selected-option"]'
+                    )
                     try:
                         shipping_btn = await self.web_find(
                             By.CSS_SELECTOR,
-                            '[role="combobox"][id$=".versand"]',
+                            shipping_combobox_selector,
                             timeout = self.timeout("quick_dom"),
                         )
                         btn_id = cast(str, shipping_btn.attrs.get("id"))
@@ -1921,7 +1926,11 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         # PostListingForm Astro island.  In that UI the placeholder ("Bitte wählen")
         # must be replaced directly with either "Versand möglich" (value "ja") or
         # "Nur Abholung" (value "nein").
-        shipping_combobox_selector = 'button[role="combobox"][id="versand"], button[role="combobox"][id$=".versand"]'
+        shipping_combobox_selector = (
+            'button[role="combobox"][id="versand"], '
+            'button[role="combobox"][id$=".versand"], '
+            'button[role="combobox"][aria-labelledby$="versand-selected-option"]'
+        )
         shipping_combobox = await self.web_probe(By.CSS_SELECTOR, shipping_combobox_selector, timeout = short_timeout)
         if shipping_combobox is not None:
             try:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1916,20 +1916,20 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
     async def _set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
         short_timeout = self.timeout("quick_dom")
 
-        # PRO/commercial accounts are expected to render Versand as the legacy/native
-        # ``versand_s`` select.  In that UI the placeholder ("Bitte wählen") must be
-        # replaced directly with either "Versand möglich" or "Nur Abholung".
-        shipping_select_selector = 'select[id$=".versand_s"]'
-        shipping_select = await self.web_probe(By.CSS_SELECTOR, shipping_select_selector, timeout = short_timeout)
-        if shipping_select is not None:
+        # PRO/commercial accounts are expected to render Versand as a custom
+        # special-attribute dropdown (``<button role="combobox">``) from the
+        # PostListingForm Astro island.  In that UI the placeholder ("Bitte wählen")
+        # must be replaced directly with either "Versand möglich" (value "ja") or
+        # "Nur Abholung" (value "nein").
+        shipping_combobox_selector = 'button[role="combobox"][id="versand"], button[role="combobox"][id$=".versand"]'
+        shipping_combobox = await self.web_probe(By.CSS_SELECTOR, shipping_combobox_selector, timeout = short_timeout)
+        if shipping_combobox is not None:
             try:
-                await self.web_select(
-                    By.CSS_SELECTOR,
-                    shipping_select_selector,
-                    _ad_form_helpers.WANTED_SHIPPING_LABELS[ad_cfg.shipping_type],
-                    timeout = short_timeout,
-                )
-                LOG.debug("Selected shipping type via native versand_s select: %s", ad_cfg.shipping_type)
+                btn_id = cast(str, shipping_combobox.attrs.get("id"))
+                if not btn_id:
+                    raise TimeoutError(_("Shipping combobox button has no id attribute"))
+                await self.web_select_button_combobox(btn_id, _ad_form_helpers.WANTED_SHIPPING_LABELS[ad_cfg.shipping_type], timeout = short_timeout)
+                LOG.debug("Selected shipping type via Versand combobox: %s", ad_cfg.shipping_type)
                 return
             except KeyError as ex:
                 raise ValueError(_("Unsupported shipping_type: %s") % ad_cfg.shipping_type) from ex
@@ -1937,9 +1937,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 LOG.debug(ex, exc_info = True)
                 raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % ad_cfg.shipping_type) from ex
 
-        # Private/non-commercial accounts are expected to render the newer radio-button
-        # controls and, for SHIPPING, the shipping-options dialog.  This is the fallback
-        # path when no native ``versand_s`` select is present (see #869 vs #1125).
+        # Private/non-commercial accounts are expected to render the radio-button
+        # controls and, for SHIPPING, the shipping-options dialog.  This is the
+        # fallback path when no special-attribute Versand combobox is present
+        # (see #869 vs #1125).
         if ad_cfg.shipping_type == "PICKUP":
             pickup_radio = await self.web_probe(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
             if pickup_radio is None:

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1915,6 +1915,24 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
 
     async def _set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
         short_timeout = self.timeout("quick_dom")
+        shipping_select_selector = 'select[id$=".versand_s"]'
+        shipping_select = await self.web_probe(By.CSS_SELECTOR, shipping_select_selector, timeout = short_timeout)
+        if shipping_select is not None:
+            try:
+                await self.web_select(
+                    By.CSS_SELECTOR,
+                    shipping_select_selector,
+                    _ad_form_helpers.WANTED_SHIPPING_LABELS[ad_cfg.shipping_type],
+                    timeout = short_timeout,
+                )
+                LOG.debug("Selected shipping type via native versand_s select: %s", ad_cfg.shipping_type)
+                return
+            except KeyError as ex:
+                raise ValueError(_("Unsupported shipping_type: %s") % ad_cfg.shipping_type) from ex
+            except TimeoutError as ex:
+                LOG.debug(ex, exc_info = True)
+                raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % ad_cfg.shipping_type) from ex
+
         if ad_cfg.shipping_type == "PICKUP":
             pickup_radio = await self.web_probe(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
             if pickup_radio is None:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -241,6 +241,7 @@ kleinanzeigen_bot/__init__.py:
   _set_shipping:
     "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
     "Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.": "Das Versand-Fieldset wird gerendert, aber die Abholungs-Option fehlt; die Seite wurde möglicherweise nicht vollständig geladen."
+    "Unsupported shipping_type: %s": "Nicht unterstützter shipping_type: %s"
     ? "Shipping options dialog entry not found. Legacy '.versand_s' select UI is no longer supported and requires dedicated rebuild."
     : "Einstieg in den Versandoptionen-Dialog nicht gefunden. Die alte '.versand_s'-Select-UI wird nicht mehr unterstützt und muss gezielt neu umgesetzt werden."
     "Unable to open shipping options dialog!": "Versandoptionen-Dialog konnte nicht geöffnet werden!"

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -240,6 +240,7 @@ kleinanzeigen_bot/__init__.py:
 
   _set_shipping:
     "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
+    "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
     "Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.": "Das Versand-Fieldset wird gerendert, aber die Abholungs-Option fehlt; die Seite wurde möglicherweise nicht vollständig geladen."
     "Unsupported shipping_type: %s": "Nicht unterstützter shipping_type: %s"
     ? "Shipping options dialog entry not found. Legacy '.versand_s' select UI is no longer supported and requires dedicated rebuild."

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -11,8 +11,8 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 from nodriver.core.connection import ProtocolException
 
-import kleinanzeigen_bot
 from kleinanzeigen_bot import (
+    _VERSAND_COMBOBOX_SELECTOR,  # noqa: PLC2701 - keep tests aligned with production selector
     LOG,
     SUBMISSION_MAX_RETRIES,
     KleinanzeigenBot,
@@ -3086,7 +3086,7 @@ class TestCategorySuggestionPicker:
 class TestShippingDialogFlow:
     """Regression tests for shipping dialog flow using new radio selectors only."""
 
-    shipping_combobox_selector = kleinanzeigen_bot._VERSAND_COMBOBOX_SELECTOR  # noqa: SLF001 - keep tests aligned with production selector
+    shipping_combobox_selector = _VERSAND_COMBOBOX_SELECTOR
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -3586,7 +3586,7 @@ class TestWantedShippingSelection:
     dispatch happen during ``publish_ad``.
     """
 
-    shipping_combobox_selector = kleinanzeigen_bot._VERSAND_COMBOBOX_SELECTOR  # noqa: SLF001 - keep tests aligned with production selector
+    shipping_combobox_selector = _VERSAND_COMBOBOX_SELECTOR
 
     @contextmanager
     def _mock_publish_dependencies(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3090,27 +3090,33 @@ class TestShippingDialogFlow:
         ("shipping_type", "expected_label"),
         [("SHIPPING", "Versand möglich"), ("PICKUP", "Nur Abholung")],
     )
-    async def test_shipping_uses_native_versand_select_when_rendered(
+    async def test_shipping_uses_versand_combobox_when_rendered(
         self,
         test_bot:KleinanzeigenBot,
         base_ad_config:dict[str, Any],
         shipping_type:str,
         expected_label:str,
     ) -> None:
-        """Commercial accounts may render Versand as a native select instead of radio buttons."""
+        """Commercial accounts may render Versand as a special-attribute combobox instead of radio buttons."""
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": shipping_type})
+        shipping_combobox = MagicMock()
+        shipping_combobox.attrs = {"id": "uhren.versand"}
 
         with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()) as mock_probe,
-            patch.object(test_bot, "web_select", new_callable = AsyncMock) as mock_select,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = shipping_combobox) as mock_probe,
+            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock) as mock_select_combobox,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
             await getattr(test_bot, "_set_shipping")(ad_cfg)
 
-        mock_probe.assert_awaited_once_with(By.CSS_SELECTOR, 'select[id$=".versand_s"]', timeout = test_bot.timeout("quick_dom"))
-        mock_select.assert_awaited_once_with(
+        mock_probe.assert_awaited_once()
+        assert mock_probe.await_args is not None
+        assert mock_probe.await_args.args[:2] == (
             By.CSS_SELECTOR,
-            'select[id$=".versand_s"]',
+            'button[role="combobox"][id="versand"], button[role="combobox"][id$=".versand"]',
+        )
+        mock_select_combobox.assert_awaited_once_with(
+            "uhren.versand",
             expected_label,
             timeout = test_bot.timeout("quick_dom"),
         )
@@ -3135,7 +3141,7 @@ class TestShippingDialogFlow:
             await getattr(test_bot, "_set_shipping")(ad_cfg)
 
         assert [call.args[:2] for call in mock_probe.await_args_list] == [
-            (By.CSS_SELECTOR, 'select[id$=".versand_s"]'),
+            (By.CSS_SELECTOR, 'button[role="combobox"][id="versand"], button[role="combobox"][id$=".versand"]'),
             (By.ID, "ad-shipping-enabled-no"),
         ]
         if selected:
@@ -3199,7 +3205,7 @@ class TestShippingDialogFlow:
 
         assert mock_probe.await_count == 3
         assert [call.args[:2] for call in mock_probe.await_args_list] == [
-            (By.CSS_SELECTOR, 'select[id$=".versand_s"]'),
+            (By.CSS_SELECTOR, 'button[role="combobox"][id="versand"], button[role="combobox"][id$=".versand"]'),
             (By.ID, "ad-shipping-enabled-no"),
             (By.ID, "ad-shipping-enabled"),
         ]

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3086,7 +3086,7 @@ class TestCategorySuggestionPicker:
 class TestShippingDialogFlow:
     """Regression tests for shipping dialog flow using new radio selectors only."""
 
-    shipping_combobox_selector = _VERSAND_COMBOBOX_SELECTOR
+    shipping_combobox_selector = _VERSAND_COMBOBOX_SELECTOR  # noqa: SLF001 - intentional single source of truth for selector tests
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -3586,7 +3586,7 @@ class TestWantedShippingSelection:
     dispatch happen during ``publish_ad``.
     """
 
-    shipping_combobox_selector = _VERSAND_COMBOBOX_SELECTOR
+    shipping_combobox_selector = _VERSAND_COMBOBOX_SELECTOR  # noqa: SLF001 - intentional single source of truth for selector tests
 
     @contextmanager
     def _mock_publish_dependencies(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3085,6 +3085,12 @@ class TestCategorySuggestionPicker:
 class TestShippingDialogFlow:
     """Regression tests for shipping dialog flow using new radio selectors only."""
 
+    shipping_combobox_selector = (
+        'button[role="combobox"][id="versand"], '
+        'button[role="combobox"][id$=".versand"], '
+        'button[role="combobox"][aria-labelledby$="versand-selected-option"]'
+    )
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("shipping_type", "expected_label"),
@@ -3113,13 +3119,11 @@ class TestShippingDialogFlow:
         assert mock_probe.await_args is not None
         assert mock_probe.await_args.args[:2] == (
             By.CSS_SELECTOR,
-            'button[role="combobox"][id="versand"], button[role="combobox"][id$=".versand"]',
+            self.shipping_combobox_selector,
         )
-        mock_select_combobox.assert_awaited_once_with(
-            "uhren.versand",
-            expected_label,
-            timeout = test_bot.timeout("quick_dom"),
-        )
+        mock_select_combobox.assert_awaited_once()
+        assert mock_select_combobox.await_args is not None
+        assert mock_select_combobox.await_args.args[:2] == ("uhren.versand", expected_label)
         mock_click.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -3140,10 +3144,9 @@ class TestShippingDialogFlow:
         ):
             await getattr(test_bot, "_set_shipping")(ad_cfg)
 
-        assert [call.args[:2] for call in mock_probe.await_args_list] == [
-            (By.CSS_SELECTOR, 'button[role="combobox"][id="versand"], button[role="combobox"][id$=".versand"]'),
-            (By.ID, "ad-shipping-enabled-no"),
-        ]
+        observed = [call.args[:2] for call in mock_probe.await_args_list]
+        assert (By.CSS_SELECTOR, self.shipping_combobox_selector) in observed
+        assert (By.ID, "ad-shipping-enabled-no") in observed
         if selected:
             mock_click.assert_not_awaited()
         else:
@@ -3203,12 +3206,10 @@ class TestShippingDialogFlow:
         ):
             await getattr(test_bot, "_set_shipping")(ad_cfg)
 
-        assert mock_probe.await_count == 3
-        assert [call.args[:2] for call in mock_probe.await_args_list] == [
-            (By.CSS_SELECTOR, 'button[role="combobox"][id="versand"], button[role="combobox"][id$=".versand"]'),
-            (By.ID, "ad-shipping-enabled-no"),
-            (By.ID, "ad-shipping-enabled"),
-        ]
+        observed = [call.args[:2] for call in mock_probe.await_args_list]
+        assert (By.CSS_SELECTOR, self.shipping_combobox_selector) in observed
+        assert (By.ID, "ad-shipping-enabled-no") in observed
+        assert (By.ID, "ad-shipping-enabled") in observed
         mock_check.assert_not_awaited()
         mock_click.assert_not_awaited()
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 from nodriver.core.connection import ProtocolException
 
+import kleinanzeigen_bot
 from kleinanzeigen_bot import (
     LOG,
     SUBMISSION_MAX_RETRIES,
@@ -3085,11 +3086,7 @@ class TestCategorySuggestionPicker:
 class TestShippingDialogFlow:
     """Regression tests for shipping dialog flow using new radio selectors only."""
 
-    shipping_combobox_selector = (
-        'button[role="combobox"][id="versand"], '
-        'button[role="combobox"][id$=".versand"], '
-        'button[role="combobox"][aria-labelledby$="versand-selected-option"]'
-    )
+    shipping_combobox_selector = kleinanzeigen_bot._VERSAND_COMBOBOX_SELECTOR  # noqa: SLF001 - keep tests aligned with production selector
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -3589,6 +3586,8 @@ class TestWantedShippingSelection:
     dispatch happen during ``publish_ad``.
     """
 
+    shipping_combobox_selector = kleinanzeigen_bot._VERSAND_COMBOBOX_SELECTOR  # noqa: SLF001 - keep tests aligned with production selector
+
     @contextmanager
     def _mock_publish_dependencies(
         self,
@@ -3665,7 +3664,7 @@ class TestWantedShippingSelection:
         combobox_btn.attrs = {"id": "babyausstattung.versand"}
 
         async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if selector_type == By.CSS_SELECTOR and selector_value == '[role="combobox"][id$=".versand"]':
+            if selector_type == By.CSS_SELECTOR and selector_value == self.shipping_combobox_selector:
                 return combobox_btn
             return MagicMock()
 
@@ -3691,7 +3690,7 @@ class TestWantedShippingSelection:
         ad_file = str(tmp_path / "ad.yaml")
 
         async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if selector_type == By.CSS_SELECTOR and selector_value == '[role="combobox"][id$=".versand"]':
+            if selector_type == By.CSS_SELECTOR and selector_value == self.shipping_combobox_selector:
                 raise TimeoutError("combobox not found in DOM")
             return MagicMock()
 
@@ -3743,7 +3742,7 @@ class TestWantedShippingSelection:
         combobox_btn.attrs = {}  # No "id" key
 
         async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if selector_type == By.CSS_SELECTOR and selector_value == '[role="combobox"][id$=".versand"]':
+            if selector_type == By.CSS_SELECTOR and selector_value == self.shipping_combobox_selector:
                 return combobox_btn
             return MagicMock()
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -3086,6 +3086,37 @@ class TestShippingDialogFlow:
     """Regression tests for shipping dialog flow using new radio selectors only."""
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("shipping_type", "expected_label"),
+        [("SHIPPING", "Versand möglich"), ("PICKUP", "Nur Abholung")],
+    )
+    async def test_shipping_uses_native_versand_select_when_rendered(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        shipping_type:str,
+        expected_label:str,
+    ) -> None:
+        """Commercial accounts may render Versand as a native select instead of radio buttons."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": shipping_type})
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()) as mock_probe,
+            patch.object(test_bot, "web_select", new_callable = AsyncMock) as mock_select,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await getattr(test_bot, "_set_shipping")(ad_cfg)
+
+        mock_probe.assert_awaited_once_with(By.CSS_SELECTOR, 'select[id$=".versand_s"]', timeout = test_bot.timeout("quick_dom"))
+        mock_select.assert_awaited_once_with(
+            By.CSS_SELECTOR,
+            'select[id$=".versand_s"]',
+            expected_label,
+            timeout = test_bot.timeout("quick_dom"),
+        )
+        mock_click.assert_not_awaited()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("selected", [False, True])
     async def test_pickup_shipping_radio_selection(
         self,
@@ -3097,14 +3128,16 @@ class TestShippingDialogFlow:
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
 
         with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()) as mock_probe,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]) as mock_probe,
             patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = selected),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
             await getattr(test_bot, "_set_shipping")(ad_cfg)
 
-        mock_probe.assert_awaited_once()
-        assert mock_probe.call_args.args[:2] == (By.ID, "ad-shipping-enabled-no")
+        assert [call.args[:2] for call in mock_probe.await_args_list] == [
+            (By.CSS_SELECTOR, 'select[id$=".versand_s"]'),
+            (By.ID, "ad-shipping-enabled-no"),
+        ]
         if selected:
             mock_click.assert_not_awaited()
         else:
@@ -3117,7 +3150,7 @@ class TestShippingDialogFlow:
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
 
         with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]),
             patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = TimeoutError("pickup lookup timed out")),
             pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'PICKUP'!"),
         ):
@@ -3135,7 +3168,7 @@ class TestShippingDialogFlow:
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
 
         with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, None]),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, None, None]),
             patch.object(test_bot, "web_check", new_callable = AsyncMock) as mock_check,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
@@ -3154,7 +3187,7 @@ class TestShippingDialogFlow:
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
 
         with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]) as mock_probe,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, None, MagicMock()]) as mock_probe,
             patch.object(test_bot, "web_check", new_callable = AsyncMock) as mock_check,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             pytest.raises(
@@ -3164,8 +3197,9 @@ class TestShippingDialogFlow:
         ):
             await getattr(test_bot, "_set_shipping")(ad_cfg)
 
-        assert mock_probe.await_count == 2
+        assert mock_probe.await_count == 3
         assert [call.args[:2] for call in mock_probe.await_args_list] == [
+            (By.CSS_SELECTOR, 'select[id$=".versand_s"]'),
             (By.ID, "ad-shipping-enabled-no"),
             (By.ID, "ad-shipping-enabled"),
         ]
@@ -3221,7 +3255,7 @@ class TestShippingDialogFlow:
 
         with (
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]),
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
             patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = "4,95"),


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #1125
- Fixes PRO/commercial account publishing where the Versand field is rendered as a custom `button[role="combobox"]` dropdown by the PostListingForm Astro island, not as a native `versand_s` `<select>` and not as the private-account radio-button UI.
- Uses the confirmed PRO DOM model from the issue comments/screenshots: category-prefixed IDs such as `kunst.versand` / `uhren.versand`, placeholder `Bitte wählen`, and options `Versand möglich` (`ja`) / `Nur Abholung` (`nein`).

## 📋 Changes Summary

- Detect the custom Versand combobox before falling back to the private radio/dialog shipping flow.
- Locate the combobox by the confirmed category-prefixed id shape and by the selected-option label relationship (`aria-labelledby$="versand-selected-option"`) so the lookup is not tied to one category prefix.
- Select `Versand möglich` for `shipping_type: SHIPPING` and `Nur Abholung` for `shipping_type: PICKUP` by visible option text via `web_select_button_combobox()`.
- Apply the same safer Versand combobox selector to the existing WANTED-ad shipping combobox path.
- Keep the private/non-commercial radio-button and shipping-options-dialog path as the fallback when the custom combobox is absent.
- Add regression coverage for the PRO combobox path and relax existing shipping-flow assertions so they check behavior instead of exact probe ordering/timeout plumbing.
- Add the German translation for the combobox error message.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the WANTED shipping flow to detect and use native “Versand” dropdown controls when available, selecting the correct shipping option directly.
* **Bug Fixes**
  * Added clearer errors for unsupported shipping types and standardized timeout behavior when native selection fails; continues to fall back to the existing radio/dialog approach when the control is missing.
* **Tests**
  * Expanded unit tests to cover the native Versand combobox route, including selector coverage and updated probe/call-order expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->