### PR TITLE
refactor: extract publishing category form section

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -16,6 +16,7 @@ from . import ad_form_helpers as _ad_form_helpers
 from . import ad_loading, captcha_flow, delete_flow, download_flow, extend_flow, published_ads
 from . import ad_state as _ad_state
 from . import price_reduction as _price_reduction
+from . import publishing_form as _publishing_form
 from . import publishing_persistence as _publishing_persistence
 from . import publishing_submission as _publishing_submission
 from . import runtime_config as _runtime_config
@@ -1003,7 +1004,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         #############################
         # set category (before title to avoid form reset clearing title)
         #############################
-        await self._set_category(ad_cfg.category, ad_file)
+        await _publishing_form.set_category(self, root_url = self.root_url, category = ad_cfg.category, ad_file = ad_file)
         await self.web_sleep()  # wait for category-dependent fields to render before setting attributes
 
         #############################
@@ -1551,99 +1552,6 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             raise TimeoutError(_("Unable to close condition dialog!")) from ex
 
         return True
-
-    async def _set_category(self, category:str | None, ad_file:str) -> None:
-        # click on something to trigger automatic category detection
-        await self.web_click(By.ID, "ad-description")
-
-        is_category_auto_selected = False
-        category_path_elem = await self.web_probe(By.ID, "ad-category-path")
-        if category_path_elem and await self._extract_visible_text(category_path_elem):
-            is_category_auto_selected = True
-
-        if category:
-            await self.web_sleep()  # workaround for https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/39
-            await self.web_click(By.XPATH, "//a[contains(., 'Kategorie')] | //button[contains(., 'Kategorie')]")
-            await self.web_find(By.XPATH, "//button[contains(., 'Weiter')]")
-
-            category_url = f"{self.root_url}/p-kategorie-aendern.html#?path={category}"
-            await self.web_open(category_url)
-            await self.web_click(By.XPATH, "//button[contains(., 'Weiter')]")
-
-            # When the configured path cannot be resolved (e.g. outdated or ambiguous),
-            # the site falls back to a React category-suggestion radio picker. Handle it
-            # by matching a path segment against one of the offered suggestions.
-            await self._resolve_category_suggestions(category)
-        else:
-            ensure(is_category_auto_selected, f"No category specified in [{ad_file}] and automatic category detection failed")
-
-    async def _resolve_category_suggestions(self, category:str) -> None:
-        """Handle Kleinanzeigen's post-redesign category-suggestion picker.
-
-        If ``fieldset#ad-category-picker`` is rendered after the category change
-        flow (because the configured path could not be resolved), try to click
-        the suggestion whose radio ``value`` matches one of the segments of
-        ``category`` (deepest first). The radio input is ``sr-only``, so clicks
-        go on the associated ``<label for="...">``.
-
-        If the picker shell is present but radios have not rendered yet, retry
-        once after a short pause and then raise ``TimeoutError`` so the caller
-        can treat it as a retryable pre-submit failure. Raises
-        ``CategoryResolutionError`` with the list of offered suggestions if none
-        of the segments match — surfaces an actionable error instead of letting
-        the submit retry loop trip the duplicate-guard.
-        """
-        picker_timeout = self.timeout("quick_dom")
-        picker = await self.web_probe(By.ID, "ad-category-picker", timeout = picker_timeout)
-        if picker is None:
-            return
-
-        radio_selector = "#ad-category-picker input[type='radio'][name='category-suggestions']"
-        radio_by_value:dict[str, Element] = {}
-        for attempt in range(2):
-            try:
-                radios = await self.web_find_all(By.CSS_SELECTOR, radio_selector, timeout = picker_timeout)
-            except TimeoutError:
-                radios = []
-
-            radio_by_value = {}
-            for radio in radios:
-                value = str(cast(Any, radio.attrs.get("value")) or "").strip()
-                if value and value not in radio_by_value:
-                    radio_by_value[value] = radio
-
-            if radio_by_value:
-                break
-
-            if attempt == 0:
-                await self.web_sleep(200, 350)
-
-        if not radio_by_value:
-            raise TimeoutError(_("Category suggestion picker element found but no radio suggestions rendered after waiting."))
-
-        # Try deepest-first segments so "73/76/sachbuecher" first probes the leaf, then 76, then 73.
-        for segment in (seg.strip() for seg in reversed(category.split("/")) if seg.strip()):
-            radio = radio_by_value.get(segment)
-            if radio is None:
-                continue
-            radio_id = str(cast(Any, radio.attrs.get("id")) or "")
-            try:
-                if radio_id:
-                    await self.web_click(
-                        By.XPATH,
-                        f"//fieldset[@id='ad-category-picker']//label[@for={_ad_form_helpers.xpath_literal(radio_id)}]",
-                        timeout = picker_timeout,
-                    )
-                else:
-                    await radio.click()
-            except TimeoutError:
-                await radio.click()
-            LOG.info("Category suggestion picker: selected value=%s (matched path segment).", segment)
-            return
-
-        offered = ", ".join(sorted(radio_by_value.keys())) or "(none)"
-        message = _("Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path.")  # noqa: E501
-        raise CategoryResolutionError(message % {"category": category, "offered": offered})
 
     @staticmethod
     def _special_attribute_candidate_priority(elem:Element) -> tuple[int, int]:

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+
+"""Publishing form sections."""
+
+from gettext import gettext as _
+from typing import Any, Final, cast
+
+from .ad_form_helpers import xpath_literal
+from .utils import loggers as _loggers
+from .utils.exceptions import CategoryResolutionError
+from .utils.misc import ensure
+from .utils.web_scraping_mixin import By, Element, WebScrapingMixin
+
+LOG:Final[_loggers.Logger] = _loggers.get_logger(__name__)
+
+
+async def set_category(web:WebScrapingMixin, *, root_url:str, category:str | None, ad_file:str) -> None:
+    # click on something to trigger automatic category detection
+    await web.web_click(By.ID, "ad-description")
+
+    is_category_auto_selected = False
+    category_path_elem = await web.web_probe(By.ID, "ad-category-path")
+    if category_path_elem and await web._extract_visible_text(category_path_elem):  # noqa: SLF001 - WebScrapingMixin category marker helper
+        is_category_auto_selected = True
+
+    if category:
+        await web.web_sleep()  # workaround for https://github.com/Second-Hand-Friends/kleinanzeigen-bot/issues/39
+        await web.web_click(By.XPATH, "//a[contains(., 'Kategorie')] | //button[contains(., 'Kategorie')]")
+        await web.web_find(By.XPATH, "//button[contains(., 'Weiter')]")
+
+        category_url = f"{root_url}/p-kategorie-aendern.html#?path={category}"
+        await web.web_open(category_url)
+        await web.web_click(By.XPATH, "//button[contains(., 'Weiter')]")
+
+        # When the configured path cannot be resolved (e.g. outdated or ambiguous),
+        # the site falls back to a React category-suggestion radio picker. Handle it
+        # by matching a path segment against one of the offered suggestions.
+        await resolve_category_suggestions(web, category)
+    else:
+        ensure(is_category_auto_selected, f"No category specified in [{ad_file}] and automatic category detection failed")
+
+
+async def resolve_category_suggestions(web:WebScrapingMixin, category:str) -> None:
+    """Handle Kleinanzeigen's post-redesign category-suggestion picker.
+
+    If ``fieldset#ad-category-picker`` is rendered after the category change
+    flow (because the configured path could not be resolved), try to click
+    the suggestion whose radio ``value`` matches one of the segments of
+    ``category`` (deepest first). The radio input is ``sr-only``, so clicks
+    go on the associated ``<label for="...">``.
+
+    If the picker shell is present but radios have not rendered yet, retry
+    once after a short pause and then raise ``TimeoutError`` so the caller
+    can treat it as a retryable pre-submit failure. Raises
+    ``CategoryResolutionError`` with the list of offered suggestions if none
+    of the segments match — surfaces an actionable error instead of letting
+    the submit retry loop trip the duplicate-guard.
+    """
+    picker_timeout = web.timeout("quick_dom")
+    picker = await web.web_probe(By.ID, "ad-category-picker", timeout = picker_timeout)
+    if picker is None:
+        return
+
+    radio_selector = "#ad-category-picker input[type='radio'][name='category-suggestions']"
+    radio_by_value:dict[str, Element] = {}
+    for attempt in range(2):
+        try:
+            radios = await web.web_find_all(By.CSS_SELECTOR, radio_selector, timeout = picker_timeout)
+        except TimeoutError:
+            radios = []
+
+        radio_by_value = {}
+        for radio in radios:
+            value = str(cast(Any, radio.attrs.get("value")) or "").strip()
+            if value and value not in radio_by_value:
+                radio_by_value[value] = radio
+
+        if radio_by_value:
+            break
+
+        if attempt == 0:
+            await web.web_sleep(200, 350)
+
+    if not radio_by_value:
+        raise TimeoutError(_("Category suggestion picker element found but no radio suggestions rendered after waiting."))
+
+    # Try deepest-first segments so "73/76/sachbuecher" first probes the leaf, then 76, then 73.
+    for segment in (seg.strip() for seg in reversed(category.split("/")) if seg.strip()):
+        radio = radio_by_value.get(segment)
+        if radio is None:
+            continue
+        radio_id = str(cast(Any, radio.attrs.get("id")) or "")
+        try:
+            if radio_id:
+                await web.web_click(
+                    By.XPATH,
+                    f"//fieldset[@id='ad-category-picker']//label[@for={xpath_literal(radio_id)}]",
+                    timeout = picker_timeout,
+                )
+            else:
+                await radio.click()
+        except TimeoutError:
+            await radio.click()
+        LOG.info("Category suggestion picker: selected value=%s (matched path segment).", segment)
+        return
+
+    offered = ", ".join(sorted(radio_by_value.keys())) or "(none)"
+    message = _("Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path.")  # noqa: E501
+    raise CategoryResolutionError(message % {"category": category, "offered": offered})

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -170,12 +170,6 @@ kleinanzeigen_bot/__init__.py:
     "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"
     "No condition radio matched values %(values)s": "Keine Zustand-Auswahl passt zu den Werten %(values)s"
 
-  _resolve_category_suggestions:
-    ? "Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path."
-    : "Kategorievorschlag-Auswahl wurde angezeigt, aber kein Segment des konfigurierten Pfades '%(category)s' passte zu den angebotenen Vorschlägen [%(offered)s]. Aktualisieren Sie 'category' auf eine angebotene ID oder einen gültigen vollständigen Pfad."
-    "Category suggestion picker: selected value=%s (matched path segment).": "Kategorievorschlag-Auswahl: Wert=%s ausgewählt (passendes Pfad-Segment)."
-    "Category suggestion picker element found but no radio suggestions rendered after waiting.": "Kategorievorschlag-Auswahl gefunden, aber auch nach dem Warten wurden keine Radio-Vorschläge gerendert."
-
   _set_contact_fields:
     "Could not set contact street.": "Kontaktstraße konnte nicht gesetzt werden."
     "Could not set contact name.": "Kontaktname konnte nicht gesetzt werden."
@@ -274,6 +268,15 @@ kleinanzeigen_bot/published_ads.py:
     "No ads found on page %s, stopping pagination": "Keine Anzeigen auf Seite %s gefunden, beende Paginierung"
     "Invalid 'next' page value in paging info: %s, stopping pagination": "Ungültiger 'next'-Seitenwert in Paginierungsinfo: %s, beende Paginierung"
     "Invalid 'pageNum' in paging info: %s, stopping pagination": "Ungültiger 'pageNum'-Wert in Paginierungsinfo: %s, beende Paginierung"
+
+#################################################
+kleinanzeigen_bot/publishing_form.py:
+#################################################
+  resolve_category_suggestions:
+    ? "Category suggestion picker shown, but no segment of configured path '%(category)s' matched the offered suggestions [%(offered)s]. Update the ad's 'category' to an offered ID or a valid full path."
+    : "Kategorievorschlag-Auswahl wurde angezeigt, aber kein Segment des konfigurierten Pfades '%(category)s' passte zu den angebotenen Vorschlägen [%(offered)s]. Aktualisieren Sie 'category' auf eine angebotene ID oder einen gültigen vollständigen Pfad."
+    "Category suggestion picker: selected value=%s (matched path segment).": "Kategorievorschlag-Auswahl: Wert=%s ausgewählt (passendes Pfad-Segment)."
+    "Category suggestion picker element found but no radio suggestions rendered after waiting.": "Kategorievorschlag-Auswahl gefunden, aber auch nach dem Warten wurden keine Radio-Vorschläge gerendert."
 
 #################################################
 kleinanzeigen_bot/publishing_persistence.py:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -28,6 +28,7 @@ from kleinanzeigen_bot.model.config_model import (
     DiagnosticsConfig,
     PublishingConfig,
 )
+from kleinanzeigen_bot.publishing_form import resolve_category_suggestions, set_category
 from kleinanzeigen_bot.utils import xdg_paths
 from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError, PublishSubmissionUncertainError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
@@ -1149,7 +1150,7 @@ class TestKleinanzeigenBotBasics:
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock) as web_open_mock,
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_category", new_callable = AsyncMock, side_effect = TimeoutError("image upload timeout")),
+            patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock, side_effect = TimeoutError("image upload timeout")),
             pytest.raises(TimeoutError, match = "image upload timeout"),
         ):
             await test_bot.publish_ad("ad.yaml", ad_cfg, ad_cfg_orig, [], mode)
@@ -1190,7 +1191,7 @@ class TestKleinanzeigenBotBasics:
         common_patches:list[Any] = [
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_category", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock),
             patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
             patch.object(test_bot, "_set_contact_fields", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.captcha_flow.check_and_wait_for_captcha", new_callable = AsyncMock),
@@ -2905,7 +2906,7 @@ class TestCategoryProbeBehavior:
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
         ):
-            await getattr(test_bot, "_set_category")("185/249", "data/my_ads/ad.yaml")
+            await set_category(test_bot, root_url = test_bot.root_url, category = "185/249", ad_file = "data/my_ads/ad.yaml")
 
         mock_probe.assert_any_await(By.ID, "ad-category-path")
 
@@ -2917,7 +2918,7 @@ class TestCategoryProbeBehavior:
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             pytest.raises(AssertionError, match = "No category specified"),
         ):
-            await getattr(test_bot, "_set_category")(None, "data/my_ads/ad.yaml")
+            await set_category(test_bot, root_url = test_bot.root_url, category = None, ad_file = "data/my_ads/ad.yaml")
 
 
 class TestCategorySuggestionPicker:
@@ -2953,7 +2954,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock) as mock_find_all,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_resolve_category_suggestions")("73/76/sachbuecher")
+            await resolve_category_suggestions(test_bot, "73/76/sachbuecher")
 
         mock_find_all.assert_not_awaited()
         mock_click.assert_not_awaited()
@@ -2968,7 +2969,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             pytest.raises(TimeoutError, match = "Category suggestion picker element found but no radio suggestions rendered after waiting."),
         ):
-            await getattr(test_bot, "_resolve_category_suggestions")("73/76/sachbuecher")
+            await resolve_category_suggestions(test_bot, "73/76/sachbuecher")
 
         assert mock_find_all.await_count == 2
         mock_sleep.assert_awaited_once()
@@ -2988,7 +2989,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_resolve_category_suggestions")("73/77")
+            await resolve_category_suggestions(test_bot, "73/77")
 
         mock_click.assert_awaited_once()
         selector_type, selector_value = mock_click.call_args.args[:2]
@@ -3011,7 +3012,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             pytest.raises(CategoryResolutionError, match = r"Category suggestion picker shown.*offered") as exc_info,
         ):
-            await getattr(test_bot, "_resolve_category_suggestions")("999/888")
+            await resolve_category_suggestions(test_bot, "999/888")
 
         mock_click.assert_not_awaited()
         error_message = str(exc_info.value)
@@ -3031,7 +3032,7 @@ class TestCategorySuggestionPicker:
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = radios),
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
         ):
-            await getattr(test_bot, "_resolve_category_suggestions")("76/77")
+            await resolve_category_suggestions(test_bot, "76/77")
 
         mock_click.assert_awaited_once()
         assert "label[@for='id-for-77']" in mock_click.call_args.args[1]
@@ -3561,7 +3562,7 @@ class TestWantedShippingSelection:
             patch("kleinanzeigen_bot.ainput", new_callable = AsyncMock, return_value = ""),
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_category", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock),
             patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
             patch.object(test_bot, "_set_shipping", new_callable = AsyncMock),
             patch.object(test_bot, "_set_contact_fields", new_callable = AsyncMock),
@@ -3739,7 +3740,7 @@ class TestBuyNowRadioWarning:
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_category", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock),
             patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
             patch.object(test_bot, "_set_shipping", new_callable = AsyncMock),
             patch.object(test_bot, "web_input", new_callable = AsyncMock),
@@ -4216,7 +4217,7 @@ class TestImageCleanupInPublishAd:
         with (
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_category", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock),
             patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
             patch.object(test_bot, "_set_shipping", new_callable = AsyncMock),
             patch.object(test_bot, "web_input", new_callable = AsyncMock),


### PR DESCRIPTION
## ℹ️ Description
- Link to the related issue(s): N/A
- Extracts the publishing category form section from the monolithic bot class into a focused publishing form module while preserving category selection and suggestion fallback behavior.

## 📋 Changes Summary
- Move category selection and category suggestion fallback into `src/kleinanzeigen_bot/publishing_form.py`.
- Update publish form orchestration to call the extracted category function through a narrow web/root_url boundary.
- Update unit tests and German translation ownership for the new module path.
- No dependencies, configuration changes, or additional requirements introduced.

### ⚙️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured category selection logic for improved maintainability and code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->