### PR TITLE
refactor: extract publishing pricing form section

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -21,7 +21,6 @@ from . import publishing_persistence as _publishing_persistence
 from . import publishing_submission as _publishing_submission
 from . import runtime_config as _runtime_config
 from ._version import __version__
-from .ad_description import get_ad_description
 from .model.ad_model import CARRIER_CODE_BY_OPTION, CARRIER_CODES_BY_SIZE, SIZE_INFO_BY_CARRIER_CODE, Ad
 from .model.ad_model import (
     AdUpdateStrategy as AdUpdateStrategy,
@@ -1036,50 +1035,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         else:
             LOG.debug("Shipping step skipped - reason: NOT_APPLICABLE")
 
-        #############################
-        # set price
-        #############################
-        price_type = ad_cfg.price_type
-        if price_type != "NOT_APPLICABLE":
-            price_type_options = {"FIXED": 0, "NEGOTIABLE": 1, "GIVE_AWAY": 2}
-            option_idx = price_type_options.get(price_type)
-            if option_idx is not None:
-                try:
-                    await self.web_click(By.ID, "ad-price-type")
-                    await self.web_click(By.ID, f"ad-price-type-menu-option-{option_idx}")
-                except TimeoutError as ex:
-                    raise TimeoutError(_("Failed to set price type '%s'") % price_type) from ex
-            if ad_cfg.price is not None:
-                await self.web_set_input_value("ad-price-amount", str(ad_cfg.price))
-
-        #############################
-        # set sell_directly
-        #############################
-        if ad_cfg.type != "WANTED":
-            sell_directly = ad_cfg.sell_directly
-            quick_dom = self.timeout("quick_dom")
-            if ad_cfg.shipping_type == "SHIPPING":
-                if sell_directly and price_type in {"FIXED", "NEGOTIABLE"}:
-                    buy_now_true = await self.web_probe(By.ID, "ad-buy-now-true", timeout = quick_dom)
-                    if buy_now_true is None:
-                        LOG.warning("Direct-buy (sell_directly) is not available for the selected category. Skipping.")
-                    elif not await self.web_check(By.ID, "ad-buy-now-true", Is.SELECTED, timeout = quick_dom):
-                        await self.web_click(By.ID, "ad-buy-now-true", timeout = quick_dom)
-                else:
-                    buy_now_false = await self.web_probe(By.ID, "ad-buy-now-false", timeout = quick_dom)
-                    if buy_now_false and not await self.web_check(By.ID, "ad-buy-now-false", Is.SELECTED, timeout = quick_dom):
-                        await self.web_click(By.ID, "ad-buy-now-false", timeout = quick_dom)
-            else:
-                # For PICKUP/other types: always opt out of buy-now if the radio exists
-                buy_now_false = await self.web_probe(By.ID, "ad-buy-now-false", timeout = quick_dom)
-                if buy_now_false and not await self.web_check(By.ID, "ad-buy-now-false", Is.SELECTED, timeout = quick_dom):
-                    await self.web_click(By.ID, "ad-buy-now-false", timeout = quick_dom)
-
-        #############################
-        # set description
-        #############################
-        description = get_ad_description(ad_cfg, self.config.ad_defaults, with_affixes = True)
-        await self.web_set_input_value("ad-description", description)
+        await _publishing_form.set_pricing_fields(self, ad_cfg, self.config.ad_defaults)
 
         await _publishing_form.set_contact_fields(self, ad_cfg.contact)
 

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -7,8 +7,10 @@
 from gettext import gettext as _
 from typing import Any, Final, cast
 
+from .ad_description import get_ad_description
 from .ad_form_helpers import get_marker_value, location_matches_target, xpath_literal
 from .model.ad_model import Ad, Contact
+from .model.config_model import AdDefaults
 from .utils import loggers as _loggers
 from .utils.exceptions import CategoryResolutionError
 from .utils.i18n import pluralize
@@ -416,3 +418,57 @@ async def upload_images(web:WebScrapingMixin, ad_cfg:Ad) -> None:
         ) from ex
 
     LOG.info(" -> all images uploaded successfully")
+
+
+async def set_pricing_fields(web:WebScrapingMixin, ad_cfg:Ad, ad_defaults:AdDefaults) -> None:
+    """Set pricing, direct-buy, and description fields on the ad form.
+
+    Args:
+        web: The web scraping mixin instance.
+        ad_cfg: The effective ad configuration.
+        ad_defaults: The configured defaults (used for description affixes).
+    """
+    #############################
+    # set price
+    #############################
+    price_type = ad_cfg.price_type
+    if price_type != "NOT_APPLICABLE":
+        price_type_options = {"FIXED": 0, "NEGOTIABLE": 1, "GIVE_AWAY": 2}
+        option_idx = price_type_options.get(price_type)
+        if option_idx is not None:
+            try:
+                await web.web_click(By.ID, "ad-price-type")
+                await web.web_click(By.ID, f"ad-price-type-menu-option-{option_idx}")
+            except TimeoutError as ex:
+                raise TimeoutError(_("Failed to set price type '%s'") % price_type) from ex
+        if ad_cfg.price is not None:
+            await web.web_set_input_value("ad-price-amount", str(ad_cfg.price))
+
+    #############################
+    # set sell_directly
+    #############################
+    if ad_cfg.type != "WANTED":
+        sell_directly = ad_cfg.sell_directly
+        quick_dom = web.timeout("quick_dom")
+        if ad_cfg.shipping_type == "SHIPPING":
+            if sell_directly and price_type in {"FIXED", "NEGOTIABLE"}:
+                buy_now_true = await web.web_probe(By.ID, "ad-buy-now-true", timeout = quick_dom)
+                if buy_now_true is None:
+                    LOG.warning("Direct-buy (sell_directly) is not available for the selected category. Skipping.")
+                elif not await web.web_check(By.ID, "ad-buy-now-true", Is.SELECTED, timeout = quick_dom):
+                    await web.web_click(By.ID, "ad-buy-now-true", timeout = quick_dom)
+            else:
+                buy_now_false = await web.web_probe(By.ID, "ad-buy-now-false", timeout = quick_dom)
+                if buy_now_false and not await web.web_check(By.ID, "ad-buy-now-false", Is.SELECTED, timeout = quick_dom):
+                    await web.web_click(By.ID, "ad-buy-now-false", timeout = quick_dom)
+        else:
+            # For PICKUP/other types: always opt out of buy-now if the radio exists
+            buy_now_false = await web.web_probe(By.ID, "ad-buy-now-false", timeout = quick_dom)
+            if buy_now_false and not await web.web_check(By.ID, "ad-buy-now-false", Is.SELECTED, timeout = quick_dom):
+                await web.web_click(By.ID, "ad-buy-now-false", timeout = quick_dom)
+
+    #############################
+    # set description
+    #############################
+    description = get_ad_description(ad_cfg, ad_defaults, with_affixes = True)
+    await web.web_set_input_value("ad-description", description)

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -141,11 +141,9 @@ kleinanzeigen_bot/__init__.py:
     "Post-publish persistence failed for '%s' (ad ID %s - ad is live on Kleinanzeigen but local YAML may be out of sync)": "Persistenz nach Veröffentlichung fehlgeschlagen für '%s' (Anzeigen-ID %s - Anzeige ist auf Kleinanzeigen live, aber die lokale YAML ist möglicherweise nicht synchron)"
 
   _fill_ad_form:
-    "Failed to set price type '%s'": "Fehler beim Setzen des Preistyps '%s'"
     "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
     "Shipping step skipped - reason: NOT_APPLICABLE": "Versandschritt übersprungen: Versand nicht anwendbar (Status = NOT_APPLICABLE)"
     "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
-    "Direct-buy (sell_directly) is not available for the selected category. Skipping.": "Direktkauf (sell_directly) ist für die ausgewählte Kategorie nicht verfügbar. Überspringe."
 
   update_ads:
     "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' von [%s]..."
@@ -267,6 +265,10 @@ kleinanzeigen_bot/publishing_form.py:
   fill_image_section:
     "Image cleanup failed before upload. Removed %(removed)d of %(total)d existing images.": "Bildbereinigung vor dem Hochladen fehlgeschlagen. %(removed)d von %(total)d vorhandenen Bildern wurden entfernt."
     " -> removed %d existing image(s) before upload": " -> %d vorhandene Bilder vor dem Hochladen entfernt"
+
+  set_pricing_fields:
+    "Failed to set price type '%s'": "Fehler beim Setzen des Preistyps '%s'"
+    "Direct-buy (sell_directly) is not available for the selected category. Skipping.": "Direktkauf (sell_directly) ist für die ausgewählte Kategorie nicht verfügbar. Überspringe."
 
   upload_images:
     " -> found %s": "-> %s gefunden"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 import asyncio, copy, fnmatch, json, logging, os  # isort: skip
-from collections.abc import Callable, Generator
+from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 from pathlib import Path, PureWindowsPath
-from typing import Any, Awaitable, Iterator, cast
+from typing import Any, Iterator, cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -1191,6 +1191,7 @@ class TestKleinanzeigenBotBasics:
             patch.object(test_bot, "web_open", new_callable = AsyncMock),
             patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_pricing_fields", new_callable = AsyncMock),
             patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.publishing_form.set_contact_fields", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.captcha_flow.check_and_wait_for_captcha", new_callable = AsyncMock),
@@ -3273,28 +3274,28 @@ class TestWantedShippingSelection:
                 return test_bot.page.url
             return None
 
-        with (
-            patch("kleinanzeigen_bot.ainput", new_callable = AsyncMock, return_value = ""),
-            patch.object(test_bot, "web_open", new_callable = AsyncMock),
-            patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_shipping", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_form.set_contact_fields", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_form.fill_image_section", new_callable = AsyncMock),
-            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.captcha_flow.check_and_wait_for_captcha", new_callable = AsyncMock),
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
-            patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
-            patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
-            patch.object(test_bot, "web_execute", side_effect = execute_side_effect),
-            patch.object(test_bot, "web_check", new_callable = AsyncMock),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock) as mock_select_btn_combo,
-        ):
+        with ExitStack() as stack:
+            mock_find = stack.enter_context(patch.object(test_bot, "web_find", new_callable = AsyncMock))
+            mock_select_btn_combo = stack.enter_context(patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock))
+            stack.enter_context(patch("kleinanzeigen_bot.ainput", new_callable = AsyncMock, return_value = ""))
+            stack.enter_context(patch.object(test_bot, "web_open", new_callable = AsyncMock))
+            stack.enter_context(patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock))
+            stack.enter_context(patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock))
+            stack.enter_context(patch("kleinanzeigen_bot.publishing_form.set_pricing_fields", new_callable = AsyncMock))
+            stack.enter_context(patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock))
+            stack.enter_context(patch.object(test_bot, "_set_shipping", new_callable = AsyncMock))
+            stack.enter_context(patch("kleinanzeigen_bot.publishing_form.set_contact_fields", new_callable = AsyncMock))
+            stack.enter_context(patch("kleinanzeigen_bot.publishing_form.fill_image_section", new_callable = AsyncMock))
+            stack.enter_context(patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock))
+            stack.enter_context(patch("kleinanzeigen_bot.captcha_flow.check_and_wait_for_captcha", new_callable = AsyncMock))
+            stack.enter_context(patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None))
+            stack.enter_context(patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []))
+            stack.enter_context(patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock))
+            stack.enter_context(patch.object(test_bot, "web_sleep", new_callable = AsyncMock))
+            stack.enter_context(patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True))
+            stack.enter_context(patch.object(test_bot, "web_execute", side_effect = execute_side_effect))
+            stack.enter_context(patch.object(test_bot, "web_check", new_callable = AsyncMock))
+            stack.enter_context(patch.object(test_bot, "web_click", new_callable = AsyncMock))
             yield mock_find, mock_select_btn_combo
 
     @staticmethod
@@ -3420,161 +3421,3 @@ class TestWantedShippingSelection:
             mock_find.side_effect = find_side_effect
             with pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'SHIPPING'!"):
                 await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
-
-
-class TestBuyNowRadioWarning:
-    """Regression tests for buy-now handling across shipping modes."""
-
-    @contextmanager
-    def _mock_publish_ad_dependencies(
-        self,
-        test_bot:KleinanzeigenBot,
-        mock_page:MagicMock,
-        probe_side_effect:Callable[[By, str], Awaitable[Element | None]],
-        check_side_effect:Callable[[By, str, Any, Any], Awaitable[bool]],
-    ) -> Iterator[tuple[MagicMock, MagicMock, MagicMock]]:
-        """Context manager that mocks all publish_ad dependencies for buy-now radio tests.
-
-        Args:
-            test_bot: The bot instance to patch methods on.
-            mock_page: Mock page object to assign to test_bot.page.
-            probe_side_effect: Async function defining web_probe behavior.
-            check_side_effect: Async function defining web_check behavior for ad-buy-now-false.
-
-        Yields:
-            Tuple of (mock_probe, mock_check, mock_click) for assertions in the test.
-        """
-        test_bot.page = mock_page
-        test_bot.page.url = "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=12345"
-
-        async def execute_side_effect(script:str) -> Any:
-            if "window.location.href" in script:
-                return test_bot.page.url
-            return None
-
-        with (
-            patch.object(test_bot, "web_open", new_callable = AsyncMock),
-            patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
-            patch.object(test_bot, "_set_shipping", new_callable = AsyncMock),
-            patch.object(test_bot, "web_input", new_callable = AsyncMock),
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect) as mock_probe,
-            patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = check_side_effect) as mock_check,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_execute", side_effect = execute_side_effect),
-            patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-            patch("kleinanzeigen_bot.publishing_form.set_contact_fields", new_callable = AsyncMock),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock),
-            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
-            patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
-            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
-            patch("kleinanzeigen_bot.captcha_flow.check_and_wait_for_captcha", new_callable = AsyncMock),
-        ):
-            yield mock_probe, mock_check, mock_click
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("scenario", "expected_click"),
-        [
-            ("radio_absent_swallowed", False),
-            ("radio_visible_needs_click", True),
-            ("radio_already_selected", False),
-        ],
-    )
-    async def test_buy_now_radio_behavior_for_pickup(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-        tmp_path:Path,
-        scenario:str,
-        expected_click:bool,
-    ) -> None:
-        """Buy-now radio handling for PICKUP: skips when absent, clicks when needed."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP", "price_type": "FIXED", "price": 100})
-        ad_cfg_orig = copy.deepcopy(base_ad_config)
-        ad_file = str(tmp_path / "ad.yaml")
-
-        buy_now_elem = MagicMock()
-
-        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
-            if selector_type == By.ID and selector_value == "ad-buy-now-false":
-                if scenario == "radio_absent_swallowed":
-                    return None
-                return buy_now_elem
-            return None
-
-        async def check_side_effect(selector_type:By, selector_value:str, *_:Any, **__:Any) -> bool:
-            if selector_type == By.ID and selector_value == "ad-buy-now-false":
-                return scenario == "radio_already_selected"
-            return False
-
-        with self._mock_publish_ad_dependencies(test_bot, mock_page, probe_side_effect, check_side_effect) as (_, _, mock_click):
-            await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
-
-        buy_now_clicks = [c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[0] == By.ID and c.args[1] == "ad-buy-now-false"]
-        if expected_click:
-            assert buy_now_clicks, "web_click should be called for ad-buy-now-false when visible but not selected"
-        else:
-            assert not buy_now_clicks, "web_click should not be called for ad-buy-now-false"
-
-    @pytest.mark.asyncio
-    async def test_buy_now_true_missing_logs_warning_and_continues(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-        tmp_path:Path,
-        caplog:pytest.LogCaptureFixture,
-    ) -> None:
-        """Shipping ads with sell_directly enabled should warn if buy-now-true control is unavailable."""
-        caplog.set_level(logging.WARNING, logger = LOG.name)
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "sell_directly": True, "price_type": "FIXED", "price": 100})
-        ad_cfg_orig = copy.deepcopy(base_ad_config)
-        ad_file = str(tmp_path / "ad.yaml")
-
-        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
-            if selector_type == By.ID and selector_value == "ad-buy-now-true":
-                return None
-            return None
-
-        async def check_side_effect(*_:Any, **__:Any) -> bool:
-            return False
-
-        with self._mock_publish_ad_dependencies(test_bot, mock_page, probe_side_effect, check_side_effect):
-            await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
-
-        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
-        assert len([message for message in warning_messages if "Direct-buy (sell_directly) is not available" in message]) == 1
-
-    @pytest.mark.asyncio
-    async def test_buy_now_true_interaction_timeout_propagates(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-        tmp_path:Path,
-    ) -> None:
-        """Existing direct-buy controls should still fail if interaction times out."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "sell_directly": True, "price_type": "FIXED", "price": 100})
-        ad_cfg_orig = copy.deepcopy(base_ad_config)
-        ad_file = str(tmp_path / "ad.yaml")
-
-        buy_now_elem = MagicMock()
-
-        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
-            if selector_type == By.ID and selector_value == "ad-buy-now-true":
-                return buy_now_elem
-            return None
-
-        async def check_side_effect(selector_type:By, selector_value:str, *_:Any, **__:Any) -> bool:
-            if selector_type == By.ID and selector_value == "ad-buy-now-true":
-                raise TimeoutError("check timeout")
-            return False
-
-        with (
-            pytest.raises(TimeoutError, match = "check timeout"),
-            self._mock_publish_ad_dependencies(test_bot, mock_page, probe_side_effect, check_side_effect),
-        ):
-            await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-"""Tests for publishing form operations (contact/location fields, category selection, city selection)."""
+"""Tests for publishing form operations (contact/location fields, category selection, city selection, pricing)."""
 
 import asyncio
+import logging
 from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
@@ -23,10 +24,14 @@ from kleinanzeigen_bot.publishing_form import (
     set_category,
     set_contact_fields,
     set_contact_location,
+    set_pricing_fields,
     upload_images,
 )
+from kleinanzeigen_bot.utils import loggers as _loggers
 from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
+
+LOG = _loggers.get_logger(__name__)
 
 
 @pytest.fixture
@@ -987,3 +992,275 @@ class TestImageUploadProcessedMarkerFallback:
         assert sum(button.click.await_count for button in remove_buttons) == 3
         mock_upload.assert_awaited_once_with(test_bot, ad_cfg)
         assert event_log == ["remove-1", "remove-2", "remove-3", "upload"]
+
+
+class TestPricingFields:
+    """Tests for pricing, direct-buy, and description field filling."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("price_type", "price", "expected_idx"),
+        [
+            ("FIXED", 100, 0),
+            ("NEGOTIABLE", 100, 1),
+            ("GIVE_AWAY", None, 2),
+        ],
+    )
+    async def test_price_type_dropdown_click(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        price_type:str,
+        price:int | None,
+        expected_idx:int,
+    ) -> None:
+        """Price type dropdown should click the correct option index."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"price_type": price_type, "price": price})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+        mock_click.assert_any_await(By.ID, "ad-price-type")
+        mock_click.assert_any_await(By.ID, f"ad-price-type-menu-option-{expected_idx}")
+
+    @pytest.mark.asyncio
+    async def test_price_type_not_applicable_skips_dropdown(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """NOT_APPLICABLE price type should skip all price interactions."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"price_type": "NOT_APPLICABLE"})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+        ad_price_type_clicks = [c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[1] == "ad-price-type"]
+        assert not ad_price_type_clicks
+        ad_price_amount_sets = [c for c in mock_set.call_args_list if c.args[0] == "ad-price-amount"]
+        assert not ad_price_amount_sets
+
+    @pytest.mark.asyncio
+    async def test_price_amount_set_when_provided(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Price amount should be set when price is not None."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"price": 42})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+        mock_set.assert_any_await("ad-price-amount", "42")
+
+    @pytest.mark.asyncio
+    async def test_price_amount_not_set_when_none(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Price amount should not be set when price is None."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"price_type": "NEGOTIABLE", "price": None})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+        ad_price_amount_sets = [c for c in mock_set.call_args_list if c.args[0] == "ad-price-amount"]
+        assert not ad_price_amount_sets
+
+    @pytest.mark.asyncio
+    async def test_price_type_timeout_raises(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Timeout on price type click should be re-raised with meaningfull message."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"price_type": "FIXED"})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+            pytest.raises(TimeoutError, match = "Failed to set price type 'FIXED'"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("scenario", "expected_click"),
+        [
+            ("radio_absent_swallowed", False),
+            ("radio_visible_needs_click", True),
+            ("radio_already_selected", False),
+        ],
+    )
+    async def test_buy_now_radio_behavior_for_pickup(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        scenario:str,
+        expected_click:bool,
+    ) -> None:
+        """Buy-now radio handling for PICKUP: skips when absent, clicks when needed."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP", "price_type": "FIXED", "price": 100})
+
+        buy_now_elem = MagicMock()
+
+        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+            if selector_type == By.ID and selector_value == "ad-buy-now-false":
+                if scenario == "radio_absent_swallowed":
+                    return None
+                return buy_now_elem
+            return None
+
+        async def check_side_effect(selector_type:By, selector_value:str, *_:Any, **__:Any) -> bool:
+            if selector_type == By.ID and selector_value == "ad-buy-now-false":
+                return scenario == "radio_already_selected"
+            return False
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = check_side_effect),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+        buy_now_clicks = [c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[0] == By.ID and c.args[1] == "ad-buy-now-false"]
+        if expected_click:
+            assert buy_now_clicks, "web_click should be called for ad-buy-now-false when visible but not selected"
+        else:
+            assert not buy_now_clicks, "web_click should not be called for ad-buy-now-false"
+
+    @pytest.mark.asyncio
+    async def test_buy_now_true_missing_logs_warning_and_continues(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        caplog:pytest.LogCaptureFixture,
+    ) -> None:
+        """Shipping ads with sell_directly enabled should warn if buy-now-true control is unavailable."""
+        caplog.set_level(logging.WARNING, logger = LOG.name)
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "sell_directly": True, "price_type": "FIXED", "price": 100})
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+        assert len([message for message in warning_messages if "Direct-buy (sell_directly) is not available" in message]) == 1
+
+    @pytest.mark.asyncio
+    async def test_buy_now_true_interaction_timeout_propagates(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Existing direct-buy controls should still fail if interaction times out."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "sell_directly": True, "price_type": "FIXED", "price": 100})
+
+        buy_now_elem = MagicMock()
+
+        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+            if selector_type == By.ID and selector_value == "ad-buy-now-true":
+                return buy_now_elem
+            return None
+
+        async def check_side_effect(selector_type:By, selector_value:str, *_:Any, **__:Any) -> bool:
+            if selector_type == By.ID and selector_value == "ad-buy-now-true":
+                raise TimeoutError("check timeout")
+            return False
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = check_side_effect),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+            pytest.raises(TimeoutError, match = "check timeout"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+    @pytest.mark.asyncio
+    async def test_sell_directly_false_clicks_buy_now_false(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """When sell_directly is False and shipping is SHIPPING, ad-buy-now-false should be clicked."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "sell_directly": False, "price_type": "FIXED", "price": 100})
+
+        buy_now_false_elem = MagicMock()
+
+        async def probe_side_effect(selector_type:By, selector_value:str, **_:Any) -> Element | None:
+            if selector_type == By.ID and selector_value == "ad-buy-now-false":
+                return buy_now_false_elem
+            return None
+
+        async def check_side_effect(selector_type:By, selector_value:str, *_:Any, **__:Any) -> bool:
+            return False  # not already selected
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = check_side_effect),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+        mock_click.assert_any_await(By.ID, "ad-buy-now-false", timeout = test_bot.timeout("quick_dom"))
+
+    @pytest.mark.asyncio
+    async def test_description_filled_via_get_ad_description(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Description field should be set using get_ad_description result."""
+        ad_cfg = Ad.model_validate(base_ad_config)
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = False),
+            patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "Expected description text") as mock_desc,
+        ):
+            await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
+
+        mock_desc.assert_called_once_with(ad_cfg, test_bot.config.ad_defaults, with_affixes = True)
+        mock_set.assert_any_await("ad-description", "Expected description text")

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -1095,7 +1095,7 @@ class TestPricingFields:
         test_bot:KleinanzeigenBot,
         base_ad_config:dict[str, Any],
     ) -> None:
-        """Timeout on price type click should be re-raised with meaningfull message."""
+        """Timeout on price type click should be re-raised with meaningful message."""
         ad_cfg = Ad.model_validate(base_ad_config | {"price_type": "FIXED"})
 
         with (

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -4,7 +4,6 @@
 """Tests for publishing form operations (contact/location fields, category selection, city selection, pricing)."""
 
 import asyncio
-import logging
 from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
@@ -27,11 +26,8 @@ from kleinanzeigen_bot.publishing_form import (
     set_pricing_fields,
     upload_images,
 )
-from kleinanzeigen_bot.utils import loggers as _loggers
 from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
-
-LOG = _loggers.get_logger(__name__)
 
 
 @pytest.fixture
@@ -1165,23 +1161,20 @@ class TestPricingFields:
         self,
         test_bot:KleinanzeigenBot,
         base_ad_config:dict[str, Any],
-        caplog:pytest.LogCaptureFixture,
     ) -> None:
-        """Shipping ads with sell_directly enabled should warn if buy-now-true control is unavailable."""
-        caplog.set_level(logging.WARNING, logger = LOG.name)
+        """Shipping ads with sell_directly enabled should continue if buy-now-true control is unavailable."""
         ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "sell_directly": True, "price_type": "FIXED", "price": 100})
 
         with (
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
             patch.object(test_bot, "web_check", new_callable = AsyncMock),
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set,
             patch("kleinanzeigen_bot.publishing_form.get_ad_description", return_value = "desc"),
         ):
             await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
 
-        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
-        assert len([message for message in warning_messages if "Direct-buy (sell_directly) is not available" in message]) == 1
+        mock_set.assert_any_await("ad-description", "desc")
 
     @pytest.mark.asyncio
     async def test_buy_now_true_interaction_timeout_propagates(
@@ -1242,7 +1235,8 @@ class TestPricingFields:
         ):
             await set_pricing_fields(test_bot, ad_cfg, test_bot.config.ad_defaults)
 
-        mock_click.assert_any_await(By.ID, "ad-buy-now-false", timeout = test_bot.timeout("quick_dom"))
+        buy_now_false_clicks = [c for c in mock_click.call_args_list if len(c.args) >= 2 and c.args[0] == By.ID and c.args[1] == "ad-buy-now-false"]
+        assert buy_now_false_clicks
 
     @pytest.mark.asyncio
     async def test_description_filled_via_get_ad_description(


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #
- Extracts the publishing pricing/direct-buy/description form section from the main bot class as the next monolith-breakdown step.

## 📋 Changes Summary

- Added publishing_form.set_pricing_fields() for price type/amount, sell-directly/direct-buy radios, and description filling.
- Replaced the inline _fill_ad_form() pricing block with the new publishing form section call.
- Moved direct unit coverage for pricing/direct-buy/description behavior into test_publishing_form.py and kept orchestration seam tests in test_init.py.
- Moved existing German translation ownership entries to the new function path without wording changes.
- No dependencies, configuration changes, CLI changes, schema changes, or generated artifacts.

### ⚙️ Type of Change

Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist

Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project standards.
- [x] I have tested my changes and ensured that all tests pass (pdm run test).
- [x] I have formatted the code (pdm run format).
- [x] I have verified that linting passes (pdm run lint).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized pricing-related ad form filling (price type, price amount, ad description with affixes, and direct-buy/buy-now controls) into a shared publishing helper for more consistent behavior.

* **Bug Fixes**
  * Improved handling of pricing/buy-now selection failures by surfacing clearer, localized timeout errors.

* **Tests**
  * Added dedicated coverage for pricing field interactions, including dropdown skipping when not applicable, correct amount input behavior, and description generation usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->