### PR TITLE
refactor: extract publishing shipping form section

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-import asyncio, enum, importlib, json, os, re, sys  # isort: skip
+import asyncio, enum, importlib, os, re, sys  # isort: skip
 import urllib.parse as urllib_parse
 from dataclasses import dataclass
 from gettext import gettext as _
@@ -21,12 +21,13 @@ from . import publishing_persistence as _publishing_persistence
 from . import publishing_submission as _publishing_submission
 from . import runtime_config as _runtime_config
 from ._version import __version__
-from .model.ad_model import CARRIER_CODE_BY_OPTION, CARRIER_CODES_BY_SIZE, SIZE_INFO_BY_CARRIER_CODE, Ad
+from .model.ad_model import Ad
 from .model.ad_model import (
     AdUpdateStrategy as AdUpdateStrategy,
 )
 from .model.config_model import Config  # noqa: TC001 — used at runtime, config injection
 from .published_ads import PublishedAd, ad_matches_id
+from .publishing_form import _select_button_combobox as _select_button_combobox
 from .update_checker import UpdateChecker
 from .utils import diagnostics as _diagnostics
 from .utils import loggers as _loggers
@@ -1008,32 +1009,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         #############################
         # set shipping type/options/costs
         #############################
-        shipping_type = ad_cfg.shipping_type
-        if shipping_type != "NOT_APPLICABLE":
-            if ad_cfg.type == "WANTED":
-                # WANTED ads render shipping as a special-attribute combobox dropdown,
-                # not as radio buttons.  Select by display text using the standard
-                # DOM-based web_select_button_combobox (no React fiber internals).
-                # See issue #930 for broader React fiber migration.
-                display_text = _ad_form_helpers.WANTED_SHIPPING_LABELS.get(shipping_type)
-                if display_text:
-                    try:
-                        shipping_btn = await self.web_find(
-                            By.CSS_SELECTOR,
-                            _ad_form_helpers.VERSAND_COMBOBOX_SELECTOR,
-                            timeout = self.timeout("quick_dom"),
-                        )
-                        btn_id = cast(str, shipping_btn.attrs.get("id"))
-                        if not btn_id:
-                            raise TimeoutError(_("Shipping combobox button has no id attribute"))
-                        await self.web_select_button_combobox(btn_id, display_text)
-                    except TimeoutError as ex:
-                        LOG.warning("Failed to set shipping attribute for type '%s'!", shipping_type)
-                        raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % shipping_type) from ex
-            else:
-                await self._set_shipping(ad_cfg, mode)
-        else:
-            LOG.debug("Shipping step skipped - reason: NOT_APPLICABLE")
+        await _publishing_form.set_shipping_form(self, ad_cfg, mode)
 
         await _publishing_form.set_pricing_fields(self, ad_cfg, self.config.ad_defaults)
 
@@ -1408,7 +1384,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     if associated_button_id is None:
                         raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key)
                     LOG.debug("Attribute field '%s': found associated button combobox id='%s'", special_attribute_key, associated_button_id)
-                    await self._select_button_combobox(associated_button_id, special_attribute_value_str)
+                    await _select_button_combobox(self, associated_button_id, special_attribute_value_str)
                     LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
                     continue
 
@@ -1444,7 +1420,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 elif special_attr_elem.local_name == "button" and elem_role == "combobox":
                     LOG.debug("Attribute field '%s' seems to be a button combobox (click-to-open dropdown)...", special_attribute_key)
                     ensure(elem_id, f"No id available for button combobox special attribute [{special_attribute_key}]")
-                    await self._select_button_combobox(cast(str, elem_id), special_attribute_value_str)
+                    await _select_button_combobox(self, cast(str, elem_id), special_attribute_value_str)
                 elif elem_role == "combobox" and elem_type in {"text", ""} and special_attr_elem.local_name == "input":
                     LOG.debug("Attribute field '%s' seems to be a Combobox (i.e. text input with filtering dropdown)...", special_attribute_key)
                     await self.web_select_combobox(elem_selector_type, elem_selector_value, special_attribute_value_str)
@@ -1455,248 +1431,6 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                 LOG.debug("Failed to set attribute field '%s' via known input types.", special_attribute_key)
                 raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key) from ex
             LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
-
-    # TODO: Issue #930 — migrate to web_select_button_combobox (display-text-based, no React fiber)
-    async def _select_button_combobox(self, elem_id:str, value:str) -> None:
-        """Select an option from a <button role="combobox"> dropdown by its API value.
-
-        Clicks the button to open the listbox, reads the options data from the React fiber
-        (which maps API values to display labels), and clicks the matching option.
-        """
-        await self.web_click(By.ID, elem_id)
-        listbox_id = f"{elem_id}-menu"
-        await self.web_find(By.ID, listbox_id)
-        js_btn_id = json.dumps(elem_id)
-        js_listbox_id = json.dumps(listbox_id)
-        js_value = json.dumps(value)
-        ok = await self.web_execute(f"""(function() {{
-            const listbox = document.getElementById({js_listbox_id});
-            if (!listbox) return false;
-            const liOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
-            const btnEl = document.getElementById({js_btn_id});
-            if (!btnEl) return false;
-            const fiberKey = Object.keys(btnEl).find(k => k.startsWith('__reactFiber'));
-            let fiber = fiberKey ? btnEl[fiberKey] : null;
-            for (let i = 0; i < 20 && fiber; i++, fiber = fiber.return) {{
-                if (fiber.memoizedProps && fiber.memoizedProps.options) {{
-                    const optionsData = fiber.memoizedProps.options;
-                    for (let j = 0; j < optionsData.length; j++) {{
-                        if (optionsData[j].value === {js_value} && liOptions[j]) {{
-                            liOptions[j].click();
-                            return true;
-                        }}
-                    }}
-                    return false;
-                }}
-            }}
-            return false;
-        }})()""")
-        if not ok:
-            raise TimeoutError(_("Option '%(value)s' not found in button combobox '%(id)s'") % {"value": value, "id": elem_id})
-
-    async def _set_shipping(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
-        short_timeout = self.timeout("quick_dom")
-
-        # PRO/commercial accounts are expected to render Versand as a custom
-        # special-attribute dropdown (``<button role="combobox">``) from the
-        # PostListingForm Astro island.  In that UI the placeholder ("Bitte wählen")
-        # must be replaced directly with either "Versand möglich" (value "ja") or
-        # "Nur Abholung" (value "nein").
-        shipping_combobox = await self.web_probe(By.CSS_SELECTOR, _ad_form_helpers.VERSAND_COMBOBOX_SELECTOR, timeout = short_timeout)
-        if shipping_combobox is not None:
-            try:
-                btn_id = cast(str, shipping_combobox.attrs.get("id"))
-                if not btn_id:
-                    raise TimeoutError(_("Shipping combobox button has no id attribute"))
-                await self.web_select_button_combobox(btn_id, _ad_form_helpers.WANTED_SHIPPING_LABELS[ad_cfg.shipping_type], timeout = short_timeout)
-                LOG.debug("Selected shipping type via Versand combobox: %s", ad_cfg.shipping_type)
-                return
-            except KeyError as ex:
-                raise ValueError(_("Unsupported shipping_type: %s") % ad_cfg.shipping_type) from ex
-            except TimeoutError as ex:
-                LOG.debug(ex, exc_info = True)
-                raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % ad_cfg.shipping_type) from ex
-
-        # Private/non-commercial accounts are expected to render the radio-button
-        # controls and, for SHIPPING, the shipping-options dialog.  This is the
-        # fallback path when no special-attribute Versand combobox is present
-        # (see #869 vs #1125).
-        if ad_cfg.shipping_type == "PICKUP":
-            pickup_radio = await self.web_probe(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
-            if pickup_radio is None:
-                shipping_fieldset = await self.web_probe(By.ID, "ad-shipping-enabled", timeout = short_timeout)
-                if shipping_fieldset is not None:
-                    raise TimeoutError(
-                        _("Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.")
-                    )
-                # Some categories (notably books 76/77 and comics 76/77/15156) render no
-                # shipping fieldset at all — those ads are PICKUP-only by site convention.
-                LOG.debug("PICKUP: no shipping fieldset for this category; treating as already PICKUP.")
-                return
-            try:
-                if not await self.web_check(By.ID, "ad-shipping-enabled-no", Is.SELECTED, timeout = short_timeout):
-                    await self.web_click(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
-            except TimeoutError as ex:
-                LOG.debug(ex, exc_info = True)
-                raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % ad_cfg.shipping_type) from ex
-        elif ad_cfg.shipping_options:
-            # Ensure shipping is enabled before opening the dialog (may already be selected)
-            try:
-                await self.web_click(By.ID, "ad-shipping-enabled-yes", timeout = short_timeout)
-                await self.web_sleep(500, 800)
-            except TimeoutError as ex:
-                LOG.debug("Shipping enabled toggle not found before options dialog: %s", ex)
-            await self.web_click(By.ID, "ad-shipping-options")
-
-            if mode == AdUpdateStrategy.MODIFY:
-                try:
-                    # when "Andere Versandmethoden" is not available, go back and start over new
-                    await self.web_find(By.XPATH, '//button[contains(., "Andere Versandmethoden")]', timeout = short_timeout)
-                except TimeoutError:
-                    await self.web_click(By.XPATH, '//button[contains(., "Zurück")]')
-
-                    # in some categories we need to go another dialog back
-                    try:
-                        await self.web_find(By.XPATH, '//button[contains(., "Andere Versandmethoden")]', timeout = short_timeout)
-                    except TimeoutError:
-                        await self.web_click(By.XPATH, '//button[contains(., "Zurück")]')
-
-            await self.web_click(By.XPATH, '//button[contains(., "Andere Versandmethoden")]')
-            await self._set_shipping_options(ad_cfg, mode)
-        else:
-            # Ensure shipping is enabled before opening the dialog (may already be selected)
-            try:
-                await self.web_click(By.ID, "ad-shipping-enabled-yes", timeout = short_timeout)
-                await self.web_sleep(500, 800)
-            except TimeoutError as ex:
-                LOG.debug("Shipping enabled toggle not found before options dialog: %s", ex)
-
-            # no options. only costs. Set custom shipping cost
-            try:
-                await self.web_click(By.ID, "ad-shipping-options")
-            except TimeoutError as ex:
-                LOG.debug(ex, exc_info = True)
-                LOG.warning("Shipping options dialog entry not found. Legacy '.versand_s' select UI is no longer supported and requires dedicated rebuild.")
-                raise TimeoutError(_("Unable to open shipping options dialog!")) from ex
-
-            try:
-                # when "Andere Versandmethoden" is not available, then we are already on the individual page
-                await self.web_click(By.XPATH, '//button[contains(., "Andere Versandmethoden")]')
-            except TimeoutError:
-                # Dialog option not present; already on the individual shipping page.
-                pass
-
-            # only click on "Individueller Versand" when the price input is not available, otherwise it's already checked
-            # (important for mode = UPDATE)
-            individual_price_elem = await self.web_probe(By.ID, "ad-individual-shipping-price", timeout = short_timeout)
-            if individual_price_elem is None:
-                # Input not visible yet; click the individual shipping option.
-                try:
-                    await self.web_click(By.ID, "ad-individual-shipping-checkbox-control")
-                except TimeoutError as ex:
-                    LOG.debug(ex, exc_info = True)
-                    raise TimeoutError(_("Unable to select individual shipping option!")) from ex
-
-            if ad_cfg.shipping_costs is not None:
-                price_str = str(ad_cfg.shipping_costs).replace(".", ",")
-                # Native DOM setter + React-aware events: send_keys gets wiped by
-                # React re-render after the ad-individual-shipping-checkbox-control click.
-                # A re-render between web_find and web_execute inside web_set_input_value can
-                # also leave the write as a silent no-op, so verify and retry before "Fertig".
-                max_attempts = 3
-                for attempt in range(1, max_attempts + 1):
-                    try:
-                        await self.web_set_input_value("ad-individual-shipping-price", price_str)
-                        actual = await self.web_execute("document.getElementById('ad-individual-shipping-price')?.value")
-                    except TimeoutError as ex:
-                        # A re-render landing on web_find inside web_set_input_value or on the
-                        # readback web_execute can raise here; treat either as a transient
-                        # failure so the outer loop can retry instead of bailing.
-                        LOG.debug(ex, exc_info = True)
-                        if attempt >= max_attempts:
-                            raise TimeoutError(_("Unable to set shipping price!")) from ex
-                        await self.web_sleep(300, 500)
-                        continue
-                    if actual == price_str:
-                        break
-                    if attempt >= max_attempts:
-                        raise TimeoutError(_("Unable to set shipping price!"))
-                    LOG.debug("shipping price not persisted (attempt %d/%d): got %r, expected %r", attempt, max_attempts, actual, price_str)
-                    await self.web_sleep(300, 500)
-            else:
-                LOG.debug(
-                    "Shipping option 'ad-individual-shipping-checkbox-control' selected but no shipping_costs provided; "
-                    "leaving field 'ad-individual-shipping-price' unchanged."
-                )
-
-            try:
-                await self.web_click(By.XPATH, '//button[contains(., "Fertig")]')
-            except TimeoutError as ex:
-                LOG.debug(ex, exc_info = True)
-                raise TimeoutError(_("Unable to close shipping dialog!")) from ex
-
-    async def _set_shipping_options(self, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
-        if not ad_cfg.shipping_options:
-            raise ValueError(_("shipping_options must be provided"))
-
-        # Resolve user-facing config names to carrier codes
-        try:
-            wanted_carrier_codes = [CARRIER_CODE_BY_OPTION[opt] for opt in set(ad_cfg.shipping_options)]
-        except KeyError as ex:
-            raise KeyError(_("Unknown shipping option(s), please refer to the documentation/README: %s") % ad_cfg.shipping_options) from ex
-
-        # Determine the size group — all options must belong to the same group
-        size_info = {SIZE_INFO_BY_CARRIER_CODE[code] for code in wanted_carrier_codes}
-        if len(size_info) != 1:
-            raise ValueError(_("You can only specify shipping options for one package size!"))
-        ((shipping_size, shipping_radio_value),) = size_info
-        wanted_codes = set(wanted_carrier_codes)
-        all_codes_for_size = CARRIER_CODES_BY_SIZE[shipping_size]
-
-        short_timeout = self.timeout("quick_dom")
-        dialog = '//*[self::dialog or @role="dialog"]'
-
-        try:
-            # Select the size group via radio button value (e.g. "SMALL", "MEDIUM", "LARGE")
-            size_radio_xpath = f'{dialog}//input[@type="radio" and @value="{shipping_radio_value}"]'
-            shipping_size_radio = await self.web_find(By.XPATH, size_radio_xpath, timeout = short_timeout)
-            shipping_size_radio_is_checked = shipping_size_radio.attrs.get("checked") is not None
-
-            if not shipping_size_radio_is_checked:
-                LOG.debug("Selecting size '%s' (radio value=%s)", shipping_size, shipping_radio_value)
-                await self.web_click(By.XPATH, size_radio_xpath, timeout = short_timeout)
-
-            await self.web_sleep(300, 500)
-            await self.web_click(By.XPATH, f'{dialog}//button[contains(., "Weiter")]', timeout = short_timeout)
-            await self.web_sleep(500, 800)
-
-            # Toggle package checkboxes by carrier code value attribute.
-            # IMPORTANT: REPLACE intentionally uses the same state-based sync as MODIFY.
-            # Live DOM defaults after "Weiter" are not stable across size/category (issue #956),
-            # so we must read current checkbox state and reconcile with desired state.
-            LOG.debug("Using state-based shipping option sync for mode '%s'", mode)
-            LOG.debug("Processing %d packages for size '%s'", len(all_codes_for_size), shipping_size)
-
-            for carrier_code in all_codes_for_size:
-                checkbox_xpath = f'{dialog}//input[@type="checkbox" and @value="{carrier_code}"]'
-                checkbox = await self.web_find(By.XPATH, checkbox_xpath, timeout = short_timeout)
-                is_checked = checkbox.attrs.get("checked") is not None
-                should_be_checked = carrier_code in wanted_codes
-
-                LOG.debug("Carrier '%s': checked=%s, wanted=%s", carrier_code, is_checked, should_be_checked)
-
-                if is_checked != should_be_checked:
-                    LOG.debug("Toggling carrier '%s'", carrier_code)
-                    await self.web_click(By.XPATH, checkbox_xpath, timeout = short_timeout)
-        except TimeoutError as ex:
-            LOG.debug(ex, exc_info = True)
-            raise TimeoutError(_("Failed to configure shipping options in dialog!")) from ex
-
-        try:
-            # Click apply button
-            await self.web_click(By.XPATH, f'{dialog}//button[contains(., "Fertig")]', timeout = short_timeout)
-        except TimeoutError as ex:
-            raise TimeoutError(_("Unable to close shipping dialog!")) from ex
 
 #############################
 # main entry point

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -4,12 +4,26 @@
 
 """Publishing form sections."""
 
+import json
 from gettext import gettext as _
 from typing import Any, Final, cast
 
 from .ad_description import get_ad_description
-from .ad_form_helpers import get_marker_value, location_matches_target, xpath_literal
-from .model.ad_model import Ad, Contact
+from .ad_form_helpers import (
+    VERSAND_COMBOBOX_SELECTOR,
+    WANTED_SHIPPING_LABELS,
+    get_marker_value,
+    location_matches_target,
+    xpath_literal,
+)
+from .model.ad_model import (
+    CARRIER_CODE_BY_OPTION,
+    CARRIER_CODES_BY_SIZE,
+    SIZE_INFO_BY_CARRIER_CODE,
+    Ad,
+    AdUpdateStrategy,
+    Contact,
+)
 from .model.config_model import AdDefaults
 from .utils import loggers as _loggers
 from .utils.exceptions import CategoryResolutionError
@@ -472,3 +486,280 @@ async def set_pricing_fields(web:WebScrapingMixin, ad_cfg:Ad, ad_defaults:AdDefa
     #############################
     description = get_ad_description(ad_cfg, ad_defaults, with_affixes = True)
     await web.web_set_input_value("ad-description", description)
+
+
+# TODO: Issue #930 — migrate to web_select_button_combobox (display-text-based, no React fiber)
+async def _select_button_combobox(web:WebScrapingMixin, elem_id:str, value:str) -> None:
+    """Select an option from a <button role="combobox"> dropdown by its API value.
+
+    Clicks the button to open the listbox, reads the options data from the React fiber
+    (which maps API values to display labels), and clicks the matching option.
+    """
+    await web.web_click(By.ID, elem_id)
+    listbox_id = f"{elem_id}-menu"
+    await web.web_find(By.ID, listbox_id)
+    js_btn_id = json.dumps(elem_id)
+    js_listbox_id = json.dumps(listbox_id)
+    js_value = json.dumps(value)
+    ok = await web.web_execute(f"""(function() {{
+        const listbox = document.getElementById({js_listbox_id});
+        if (!listbox) return false;
+        const liOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
+        const btnEl = document.getElementById({js_btn_id});
+        if (!btnEl) return false;
+        const fiberKey = Object.keys(btnEl).find(k => k.startsWith('__reactFiber'));
+        let fiber = fiberKey ? btnEl[fiberKey] : null;
+        for (let i = 0; i < 20 && fiber; i++, fiber = fiber.return) {{
+            if (fiber.memoizedProps && fiber.memoizedProps.options) {{
+                const optionsData = fiber.memoizedProps.options;
+                for (let j = 0; j < optionsData.length; j++) {{
+                    if (optionsData[j].value === {js_value} && liOptions[j]) {{
+                        liOptions[j].click();
+                        return true;
+                    }}
+                }}
+                return false;
+            }}
+        }}
+        return false;
+    }})()""")
+    if not ok:
+        raise TimeoutError(_("Option '%(value)s' not found in button combobox '%(id)s'") % {"value": value, "id": elem_id})
+
+
+async def set_shipping_form(web:WebScrapingMixin, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
+    """Fill the shipping type/options/costs section on the ad form."""
+    shipping_type = ad_cfg.shipping_type
+    if shipping_type != "NOT_APPLICABLE":
+        if ad_cfg.type == "WANTED":
+            # WANTED ads render shipping as a special-attribute combobox dropdown,
+            # not as radio buttons.  Select by display text using the standard
+            # DOM-based web_select_button_combobox (no React fiber internals).
+            # See issue #930 for broader React fiber migration.
+            display_text = WANTED_SHIPPING_LABELS.get(shipping_type)
+            if display_text:
+                try:
+                    shipping_btn = await web.web_find(
+                        By.CSS_SELECTOR,
+                        VERSAND_COMBOBOX_SELECTOR,
+                        timeout = web.timeout("quick_dom"),
+                    )
+                    btn_id = cast(str, shipping_btn.attrs.get("id"))
+                    if not btn_id:
+                        raise TimeoutError(_("Shipping combobox button has no id attribute"))
+                    await web.web_select_button_combobox(btn_id, display_text)
+                except TimeoutError as ex:
+                    LOG.warning("Failed to set shipping attribute for type '%s'!", shipping_type)
+                    raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % shipping_type) from ex
+        else:
+            await set_shipping(web, ad_cfg, mode)
+    else:
+        LOG.debug("Shipping step skipped - reason: NOT_APPLICABLE")
+
+
+async def set_shipping(web:WebScrapingMixin, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
+    """Set shipping for non-WANTED ads (radio button or combobox flow)."""
+    short_timeout = web.timeout("quick_dom")
+
+    # PRO/commercial accounts are expected to render Versand as a custom
+    # special-attribute dropdown (``<button role="combobox">``) from the
+    # PostListingForm Astro island.  In that UI the placeholder ("Bitte wählen")
+    # must be replaced directly with either "Versand möglich" (value "ja") or
+    # "Nur Abholung" (value "nein").
+    shipping_combobox = await web.web_probe(By.CSS_SELECTOR, VERSAND_COMBOBOX_SELECTOR, timeout = short_timeout)
+    if shipping_combobox is not None:
+        try:
+            btn_id = cast(str, shipping_combobox.attrs.get("id"))
+            if not btn_id:
+                raise TimeoutError(_("Shipping combobox button has no id attribute"))
+            await web.web_select_button_combobox(btn_id, WANTED_SHIPPING_LABELS[ad_cfg.shipping_type], timeout = short_timeout)
+            LOG.debug("Selected shipping type via Versand combobox: %s", ad_cfg.shipping_type)
+            return
+        except KeyError as ex:
+            raise ValueError(_("Unsupported shipping_type: %s") % ad_cfg.shipping_type) from ex
+        except TimeoutError as ex:
+            LOG.debug(ex, exc_info = True)
+            raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % ad_cfg.shipping_type) from ex
+
+    # Private/non-commercial accounts are expected to render the radio-button
+    # controls and, for SHIPPING, the shipping-options dialog.  This is the
+    # fallback path when no special-attribute Versand combobox is present
+    # (see #869 vs #1125).
+    if ad_cfg.shipping_type == "PICKUP":
+        pickup_radio = await web.web_probe(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
+        if pickup_radio is None:
+            shipping_fieldset = await web.web_probe(By.ID, "ad-shipping-enabled", timeout = short_timeout)
+            if shipping_fieldset is not None:
+                raise TimeoutError(
+                    _("Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.")
+                )
+            # Some categories (notably books 76/77 and comics 76/77/15156) render no
+            # shipping fieldset at all — those ads are PICKUP-only by site convention.
+            LOG.debug("PICKUP: no shipping fieldset for this category; treating as already PICKUP.")
+            return
+        try:
+            if not await web.web_check(By.ID, "ad-shipping-enabled-no", Is.SELECTED, timeout = short_timeout):
+                await web.web_click(By.ID, "ad-shipping-enabled-no", timeout = short_timeout)
+        except TimeoutError as ex:
+            LOG.debug(ex, exc_info = True)
+            raise TimeoutError(_("Failed to set shipping attribute for type '%s'!") % ad_cfg.shipping_type) from ex
+    elif ad_cfg.shipping_options:
+        # Ensure shipping is enabled before opening the dialog (may already be selected)
+        try:
+            await web.web_click(By.ID, "ad-shipping-enabled-yes", timeout = short_timeout)
+            await web.web_sleep(500, 800)
+        except TimeoutError as ex:
+            LOG.debug("Shipping enabled toggle not found before options dialog: %s", ex)
+        await web.web_click(By.ID, "ad-shipping-options")
+
+        if mode == AdUpdateStrategy.MODIFY:
+            try:
+                # when "Andere Versandmethoden" is not available, go back and start over new
+                await web.web_find(By.XPATH, '//button[contains(., "Andere Versandmethoden")]', timeout = short_timeout)
+            except TimeoutError:
+                await web.web_click(By.XPATH, '//button[contains(., "Zurück")]')
+
+                # in some categories we need to go another dialog back
+                try:
+                    await web.web_find(By.XPATH, '//button[contains(., "Andere Versandmethoden")]', timeout = short_timeout)
+                except TimeoutError:
+                    await web.web_click(By.XPATH, '//button[contains(., "Zurück")]')
+
+        await web.web_click(By.XPATH, '//button[contains(., "Andere Versandmethoden")]')
+        await set_shipping_options(web, ad_cfg, mode)
+    else:
+        # Ensure shipping is enabled before opening the dialog (may already be selected)
+        try:
+            await web.web_click(By.ID, "ad-shipping-enabled-yes", timeout = short_timeout)
+            await web.web_sleep(500, 800)
+        except TimeoutError as ex:
+            LOG.debug("Shipping enabled toggle not found before options dialog: %s", ex)
+
+        # no options. only costs. Set custom shipping cost
+        try:
+            await web.web_click(By.ID, "ad-shipping-options")
+        except TimeoutError as ex:
+            LOG.debug(ex, exc_info = True)
+            LOG.warning("Shipping options dialog entry not found. Legacy '.versand_s' select UI is no longer supported and requires dedicated rebuild.")
+            raise TimeoutError(_("Unable to open shipping options dialog!")) from ex
+
+        try:
+            # when "Andere Versandmethoden" is not available, then we are already on the individual page
+            await web.web_click(By.XPATH, '//button[contains(., "Andere Versandmethoden")]')
+        except TimeoutError:
+            # Dialog option not present; already on the individual shipping page.
+            pass
+
+        # only click on "Individueller Versand" when the price input is not available, otherwise it's already checked
+        # (important for mode = UPDATE)
+        individual_price_elem = await web.web_probe(By.ID, "ad-individual-shipping-price", timeout = short_timeout)
+        if individual_price_elem is None:
+            # Input not visible yet; click the individual shipping option.
+            try:
+                await web.web_click(By.ID, "ad-individual-shipping-checkbox-control")
+            except TimeoutError as ex:
+                LOG.debug(ex, exc_info = True)
+                raise TimeoutError(_("Unable to select individual shipping option!")) from ex
+
+        if ad_cfg.shipping_costs is not None:
+            price_str = str(ad_cfg.shipping_costs).replace(".", ",")
+            # Native DOM setter + React-aware events: send_keys gets wiped by
+            # React re-render after the ad-individual-shipping-checkbox-control click.
+            # A re-render between web_find and web_execute inside web_set_input_value can
+            # also leave the write as a silent no-op, so verify and retry before "Fertig".
+            max_attempts = 3
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    await web.web_set_input_value("ad-individual-shipping-price", price_str)
+                    actual = await web.web_execute("document.getElementById('ad-individual-shipping-price')?.value")
+                except TimeoutError as ex:
+                    # A re-render landing on web_find inside web_set_input_value or on the
+                    # readback web_execute can raise here; treat either as a transient
+                    # failure so the outer loop can retry instead of bailing.
+                    LOG.debug(ex, exc_info = True)
+                    if attempt >= max_attempts:
+                        raise TimeoutError(_("Unable to set shipping price!")) from ex
+                    await web.web_sleep(300, 500)
+                    continue
+                if actual == price_str:
+                    break
+                if attempt >= max_attempts:
+                    raise TimeoutError(_("Unable to set shipping price!"))
+                LOG.debug("shipping price not persisted (attempt %d/%d): got %r, expected %r", attempt, max_attempts, actual, price_str)
+                await web.web_sleep(300, 500)
+        else:
+            LOG.debug(
+                "Shipping option 'ad-individual-shipping-checkbox-control' selected but no shipping_costs provided; "
+                "leaving field 'ad-individual-shipping-price' unchanged."
+            )
+
+        try:
+            await web.web_click(By.XPATH, '//button[contains(., "Fertig")]')
+        except TimeoutError as ex:
+            LOG.debug(ex, exc_info = True)
+            raise TimeoutError(_("Unable to close shipping dialog!")) from ex
+
+
+async def set_shipping_options(web:WebScrapingMixin, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:
+    """Configure shipping options dialog (carrier selection)."""
+    if not ad_cfg.shipping_options:
+        raise ValueError(_("shipping_options must be provided"))
+
+    # Resolve user-facing config names to carrier codes
+    try:
+        wanted_carrier_codes = [CARRIER_CODE_BY_OPTION[opt] for opt in set(ad_cfg.shipping_options)]
+    except KeyError as ex:
+        raise KeyError(_("Unknown shipping option(s), please refer to the documentation/README: %s") % ad_cfg.shipping_options) from ex
+
+    # Determine the size group — all options must belong to the same group
+    size_info = {SIZE_INFO_BY_CARRIER_CODE[code] for code in wanted_carrier_codes}
+    if len(size_info) != 1:
+        raise ValueError(_("You can only specify shipping options for one package size!"))
+    ((shipping_size, shipping_radio_value),) = size_info
+    wanted_codes = set(wanted_carrier_codes)
+    all_codes_for_size = CARRIER_CODES_BY_SIZE[shipping_size]
+
+    short_timeout = web.timeout("quick_dom")
+    dialog = '//*[self::dialog or @role="dialog"]'
+
+    try:
+        # Select the size group via radio button value (e.g. "SMALL", "MEDIUM", "LARGE")
+        size_radio_xpath = f'{dialog}//input[@type="radio" and @value="{shipping_radio_value}"]'
+        shipping_size_radio = await web.web_find(By.XPATH, size_radio_xpath, timeout = short_timeout)
+        shipping_size_radio_is_checked = shipping_size_radio.attrs.get("checked") is not None
+
+        if not shipping_size_radio_is_checked:
+            LOG.debug("Selecting size '%s' (radio value=%s)", shipping_size, shipping_radio_value)
+            await web.web_click(By.XPATH, size_radio_xpath, timeout = short_timeout)
+
+        await web.web_sleep(300, 500)
+        await web.web_click(By.XPATH, f'{dialog}//button[contains(., "Weiter")]', timeout = short_timeout)
+        await web.web_sleep(500, 800)
+
+        # Toggle package checkboxes by carrier code value attribute.
+        # IMPORTANT: REPLACE intentionally uses the same state-based sync as MODIFY.
+        # Live DOM defaults after "Weiter" are not stable across size/category (issue #956),
+        # so we must read current checkbox state and reconcile with desired state.
+        LOG.debug("Using state-based shipping option sync for mode '%s'", mode)
+        LOG.debug("Processing %d packages for size '%s'", len(all_codes_for_size), shipping_size)
+
+        for carrier_code in all_codes_for_size:
+            checkbox_xpath = f'{dialog}//input[@type="checkbox" and @value="{carrier_code}"]'
+            checkbox = await web.web_find(By.XPATH, checkbox_xpath, timeout = short_timeout)
+            is_checked = checkbox.attrs.get("checked") is not None
+            should_be_checked = carrier_code in wanted_codes
+
+            LOG.debug("Carrier '%s': checked=%s, wanted=%s", carrier_code, is_checked, should_be_checked)
+
+            if is_checked != should_be_checked:
+                LOG.debug("Toggling carrier '%s'", carrier_code)
+                await web.web_click(By.XPATH, checkbox_xpath, timeout = short_timeout)
+    except TimeoutError as ex:
+        LOG.debug(ex, exc_info = True)
+        raise TimeoutError(_("Failed to configure shipping options in dialog!")) from ex
+
+    try:
+        # Click apply button
+        await web.web_click(By.XPATH, f'{dialog}//button[contains(., "Fertig")]', timeout = short_timeout)
+    except TimeoutError as ex:
+        raise TimeoutError(_("Unable to close shipping dialog!")) from ex

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -141,9 +141,6 @@ kleinanzeigen_bot/__init__.py:
     "Post-publish persistence failed for '%s' (ad ID %s - ad is live on Kleinanzeigen but local YAML may be out of sync)": "Persistenz nach Veröffentlichung fehlgeschlagen für '%s' (Anzeigen-ID %s - Anzeige ist auf Kleinanzeigen live, aber die lokale YAML ist möglicherweise nicht synchron)"
 
   _fill_ad_form:
-    "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
-    "Shipping step skipped - reason: NOT_APPLICABLE": "Versandschritt übersprungen: Versand nicht anwendbar (Status = NOT_APPLICABLE)"
-    "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
 
   update_ads:
     "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' von [%s]..."
@@ -165,9 +162,6 @@ kleinanzeigen_bot/__init__.py:
     "Unable to select condition [%s]": "Zustand [%s] konnte nicht ausgewählt werden"
     "Failed to set attribute '%s'": "Fehler beim Setzen des Attributs '%s'"
     "No condition radio matched values %(values)s": "Keine Zustand-Auswahl passt zu den Werten %(values)s"
-
-  _select_button_combobox:
-    "Option '%(value)s' not found in button combobox '%(id)s'": "Option '%(value)s' nicht in Button-Combobox '%(id)s' gefunden"
 
   _set_special_attributes:
     "Found %i special attributes": "%i spezielle Attribute gefunden"
@@ -196,25 +190,6 @@ kleinanzeigen_bot/__init__.py:
     "DONE: No ads found to extend.": "FERTIG: Keine Anzeigen zum Verlängern gefunden."
     "Unknown command: %s": "Unbekannter Befehl: %s"
     "Timing collector flush failed: %s": "Zeitmessdaten konnten nicht gespeichert werden: %s"
-
-  _set_shipping:
-    "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
-    "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
-    "Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.": "Das Versand-Fieldset wird gerendert, aber die Abholungs-Option fehlt; die Seite wurde möglicherweise nicht vollständig geladen."
-    "Unsupported shipping_type: %s": "Nicht unterstützter shipping_type: %s"
-    ? "Shipping options dialog entry not found. Legacy '.versand_s' select UI is no longer supported and requires dedicated rebuild."
-    : "Einstieg in den Versandoptionen-Dialog nicht gefunden. Die alte '.versand_s'-Select-UI wird nicht mehr unterstützt und muss gezielt neu umgesetzt werden."
-    "Unable to open shipping options dialog!": "Versandoptionen-Dialog konnte nicht geöffnet werden!"
-    "Unable to select individual shipping option!": "Individuelle Versandoption konnte nicht ausgewählt werden!"
-    "Unable to set shipping price!": "Versandpreis konnte nicht gesetzt werden!"
-    "Unable to close shipping dialog!": "Versanddialog konnte nicht geschlossen werden!"
-
-  _set_shipping_options:
-    "Failed to configure shipping options in dialog!": "Versandoptionen konnten im Dialog nicht konfiguriert werden!"
-    "Unable to close shipping dialog!": "Versanddialog konnte nicht geschlossen werden!"
-    "shipping_options must be provided": "shipping_options müssen angegeben werden!"
-    "Unknown shipping option(s), please refer to the documentation/README: %s": "Unbekannte Versandoption(en), bitte lies die Dokumentation/das README: %s"
-    "You can only specify shipping options for one package size!": "Du kannst nur Versandoptionen für eine Paketgröße angeben!"
 
 #################################################
 kleinanzeigen_bot/published_ads.py:
@@ -281,6 +256,33 @@ kleinanzeigen_bot/publishing_form.py:
 
   check_thumbnails_uploaded:
     " -> %d of %d images processed": " -> %d von %d Bildern verarbeitet"
+
+  set_shipping_form:
+    "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
+    "Shipping step skipped - reason: NOT_APPLICABLE": "Versandschritt übersprungen: Versand nicht anwendbar (Status = NOT_APPLICABLE)"
+    "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
+
+  _select_button_combobox:
+    "Option '%(value)s' not found in button combobox '%(id)s'": "Option '%(value)s' nicht in Button-Combobox '%(id)s' gefunden"
+
+  set_shipping:
+    "Failed to set shipping attribute for type '%s'!": "Fehler beim setzen des Versandattributs für den Typ '%s'!"
+    "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
+    "Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.": "Das Versand-Fieldset wird gerendert, aber die Abholungs-Option fehlt; die Seite wurde möglicherweise nicht vollständig geladen."
+    "Unsupported shipping_type: %s": "Nicht unterstützter shipping_type: %s"
+    ? "Shipping options dialog entry not found. Legacy '.versand_s' select UI is no longer supported and requires dedicated rebuild."
+    : "Einstieg in den Versandoptionen-Dialog nicht gefunden. Die alte '.versand_s'-Select-UI wird nicht mehr unterstützt und muss gezielt neu umgesetzt werden."
+    "Unable to open shipping options dialog!": "Versandoptionen-Dialog konnte nicht geöffnet werden!"
+    "Unable to select individual shipping option!": "Individuelle Versandoption konnte nicht ausgewählt werden!"
+    "Unable to set shipping price!": "Versandpreis konnte nicht gesetzt werden!"
+    "Unable to close shipping dialog!": "Versanddialog konnte nicht geschlossen werden!"
+
+  set_shipping_options:
+    "Failed to configure shipping options in dialog!": "Versandoptionen konnten im Dialog nicht konfiguriert werden!"
+    "Unable to close shipping dialog!": "Versanddialog konnte nicht geschlossen werden!"
+    "shipping_options must be provided": "shipping_options müssen angegeben werden!"
+    "Unknown shipping option(s), please refer to the documentation/README: %s": "Unbekannte Versandoption(en), bitte lies die Dokumentation/das README: %s"
+    "You can only specify shipping options for one package size!": "Du kannst nur Versandoptionen für eine Paketgröße angeben!"
 
 #################################################
 kleinanzeigen_bot/publishing_persistence.py:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -20,7 +20,6 @@ from kleinanzeigen_bot import (
     runtime_config,
 )
 from kleinanzeigen_bot._version import __version__
-from kleinanzeigen_bot.ad_form_helpers import VERSAND_COMBOBOX_SELECTOR
 from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.model.config_model import (
     AutoPriceReductionConfig,
@@ -2114,12 +2113,12 @@ class TestKleinanzeigenBotShippingOptions:
 
         with (
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [hidden_elem, button_elem]),
-            patch.object(test_bot, "_select_button_combobox", new_callable = AsyncMock) as mock_button_combobox,
+            patch("kleinanzeigen_bot._select_button_combobox", new_callable = AsyncMock) as mock_button_combobox,
             patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
         ):
             await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
-        mock_button_combobox.assert_awaited_once_with("kleidung_herren.color", "beige")
+        mock_button_combobox.assert_awaited_once_with(test_bot, "kleidung_herren.color", "beige")
         mock_input.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -2263,9 +2262,8 @@ class TestKleinanzeigenBotShippingOptions:
                 new_callable = AsyncMock,
                 return_value = ":r8r7:",
             ) as mock_find_button,
-            patch.object(
-                test_bot,
-                "_select_button_combobox",
+            patch(
+                "kleinanzeigen_bot._select_button_combobox",
                 new_callable = AsyncMock,
             ) as mock_select_combobox,
             patch.object(test_bot, "web_input", new_callable = AsyncMock) as mock_input,
@@ -2273,7 +2271,7 @@ class TestKleinanzeigenBotShippingOptions:
             await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_find_button.assert_awaited_once_with(hidden_input_name = "attributeMap[groesse]")
-        mock_select_combobox.assert_awaited_once_with(":r8r7:", "68")
+        mock_select_combobox.assert_awaited_once_with(test_bot, ":r8r7:", "68")
         mock_input.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -2357,16 +2355,15 @@ class TestKleinanzeigenBotShippingOptions:
                 "_find_associated_button_combobox",
                 new_callable = AsyncMock,
             ) as mock_find_button,
-            patch.object(
-                test_bot,
-                "_select_button_combobox",
+            patch(
+                "kleinanzeigen_bot._select_button_combobox",
                 new_callable = AsyncMock,
             ) as mock_select_combobox,
         ):
             await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_find_button.assert_not_awaited()
-        mock_select_combobox.assert_awaited_once_with("kleidung_herren.type", "accessoires")
+        mock_select_combobox.assert_awaited_once_with(test_bot, "kleidung_herren.type", "accessoires")
 
 
 class TestConditionSelector:
@@ -2643,16 +2640,15 @@ class TestConditionFallbackToGenericHandler:
             ) as mock_set_condition,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = probe_elem),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = [button_elem]),
-            patch.object(
-                test_bot,
-                "_select_button_combobox",
+            patch(
+                "kleinanzeigen_bot._select_button_combobox",
                 new_callable = AsyncMock,
             ) as mock_select_combobox,
         ):
             await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_set_condition.assert_awaited_once_with(condition_s)
-        mock_select_combobox.assert_awaited_once_with("modellbau.condition", expected_generic_value)
+        mock_select_combobox.assert_awaited_once_with(test_bot, "modellbau.condition", expected_generic_value)
 
     @pytest.mark.asyncio
     async def test_condition_timeout_propagates_instead_of_falling_back(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
@@ -2724,12 +2720,12 @@ class TestConditionFallbackToGenericHandler:
             patch.object(test_bot, "_set_condition", new_callable = AsyncMock, return_value = False) as mock_set_condition,
             patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = probe_side_effect),
             patch.object(test_bot, "web_find_all", new_callable = AsyncMock, side_effect = find_all_side_effect),
-            patch.object(test_bot, "_select_button_combobox", new_callable = AsyncMock) as mock_select_combobox,
+            patch("kleinanzeigen_bot._select_button_combobox", new_callable = AsyncMock) as mock_select_combobox,
         ):
             await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
         mock_set_condition.assert_awaited_once_with("ok")
-        mock_select_combobox.assert_awaited_once_with("kleidung_herren.color", "beige")
+        mock_select_combobox.assert_awaited_once_with(test_bot, "kleidung_herren.color", "beige")
         warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
         assert len([message for message in warning_messages if "Special attribute 'condition_s' is not available" in message]) == 1
 
@@ -2754,636 +2750,32 @@ class TestConditionFallbackToGenericHandler:
             await getattr(test_bot, "_set_special_attributes")(ad_cfg)
 
 
-class TestShippingDialogFlow:
-    """Regression tests for shipping dialog flow using new radio selectors only."""
-
-    shipping_combobox_selector = VERSAND_COMBOBOX_SELECTOR
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("shipping_type", "expected_label"),
-        [("SHIPPING", "Versand möglich"), ("PICKUP", "Nur Abholung")],
-    )
-    async def test_shipping_uses_versand_combobox_when_rendered(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        shipping_type:str,
-        expected_label:str,
-    ) -> None:
-        """Commercial accounts may render Versand as a special-attribute combobox instead of radio buttons."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": shipping_type})
-        shipping_combobox = MagicMock()
-        shipping_combobox.attrs = {"id": "uhren.versand"}
-
-        with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = shipping_combobox) as mock_probe,
-            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock) as mock_select_combobox,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-        mock_probe.assert_awaited_once()
-        assert mock_probe.await_args is not None
-        assert mock_probe.await_args.args[:2] == (
-            By.CSS_SELECTOR,
-            self.shipping_combobox_selector,
-        )
-        mock_select_combobox.assert_awaited_once()
-        assert mock_select_combobox.await_args is not None
-        assert mock_select_combobox.await_args.args[:2] == ("uhren.versand", expected_label)
-        mock_click.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("selected", [False, True])
-    async def test_pickup_shipping_radio_selection(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        selected:bool,
-    ) -> None:
-        """PICKUP shipping should click the pickup radio only when it is not already selected."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
-
-        with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]) as mock_probe,
-            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = selected),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-        observed = [call.args[:2] for call in mock_probe.await_args_list]
-        assert (By.CSS_SELECTOR, self.shipping_combobox_selector) in observed
-        assert (By.ID, "ad-shipping-enabled-no") in observed
-        if selected:
-            mock_click.assert_not_awaited()
-        else:
-            mock_click.assert_awaited_once()
-            assert mock_click.call_args.args[:2] == (By.ID, "ad-shipping-enabled-no")
-
-    @pytest.mark.asyncio
-    async def test_pickup_shipping_raises_when_radio_lookup_times_out(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
-        """PICKUP shipping should fail fast when pickup radio selector is unavailable."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
-
-        with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]),
-            patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = TimeoutError("pickup lookup timed out")),
-            pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'PICKUP'!"),
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-    @pytest.mark.asyncio
-    async def test_pickup_shipping_skips_when_toggle_not_rendered(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """Categories without a shipping fieldset (e.g. books 76/77, comics 76/77/15156)
-        are PICKUP-only by site convention — the absence of both shipping selectors should
-        short-circuit without calling ``web_check``/``web_click``."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
-
-        with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, None, None]),
-            patch.object(test_bot, "web_check", new_callable = AsyncMock) as mock_check,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-        mock_check.assert_not_awaited()
-        mock_click.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_pickup_shipping_raises_when_fieldset_rendered_but_pickup_radio_missing(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """A rendered shipping fieldset without the pickup radio should be treated as an error."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
-
-        with (
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, None, MagicMock()]) as mock_probe,
-            patch.object(test_bot, "web_check", new_callable = AsyncMock) as mock_check,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            pytest.raises(
-                TimeoutError,
-                match = "Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.",
-            ),
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-        observed = [call.args[:2] for call in mock_probe.await_args_list]
-        assert (By.CSS_SELECTOR, self.shipping_combobox_selector) in observed
-        assert (By.ID, "ad-shipping-enabled-no") in observed
-        assert (By.ID, "ad-shipping-enabled") in observed
-        mock_check.assert_not_awaited()
-        mock_click.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_shipping_without_options_uses_radio_and_dialog(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
-        """Shipping without package options should use radio + dialog flow."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
-
-        with (
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
-            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = "4,95"),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-            click_args = [c.args for c in mock_click.await_args_list]
-            assert any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
-            assert any("Fertig" in str(a[1]) for a in click_args if len(a) >= 2)
-            mock_set_input.assert_awaited_once_with("ad-individual-shipping-price", "4,95")
-
-    @pytest.mark.asyncio
-    async def test_shipping_finish_timeout_raises(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
-        """Timeout while confirming shipping dialog should raise a clear error."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": []})
-
-        async def click_side_effect(selector_type:By, selector_value:str, **_:Any) -> None:
-            if selector_type == By.XPATH and "Fertig" in selector_value:
-                raise TimeoutError("finish timeout")
-
-        with (
-            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = click_side_effect),
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            pytest.raises(TimeoutError, match = "Unable to close shipping dialog!"),
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-    @pytest.mark.asyncio
-    async def test_shipping_without_options_does_not_toggle_checkbox_when_price_input_visible(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """When price input is already visible, individual-shipping checkbox is not toggled."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
-
-        with (
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
-            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = "4,95"),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-        click_args = [c.args for c in mock_click.await_args_list]
-        assert not any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
-        mock_set_input.assert_awaited_once_with("ad-individual-shipping-price", "4,95")
-
-    @pytest.mark.asyncio
-    async def test_shipping_price_lost_to_react_rerender_raises(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """When React re-render swallows the shipping price, the dialog must NOT be closed."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
-
-        async def set_input_side_effect(element_id:str, value:str) -> None:
-            # Simulate web_set_input_value succeeding (no TimeoutError) but
-            # the JS returning early because the element is null after re-render.
-            # The real web_set_input_value does a web_find + web_execute whose JS
-            # silently returns on `if(!el) return;`.  By mocking at this level we
-            # model the observable effect: the call completes without error, but
-            # the DOM value was never written.
-            pass
-
-        with (
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock, side_effect = set_input_side_effect),
-            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = None),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            pytest.raises(TimeoutError, match = "Unable to set shipping price!"),
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-        # Fertig must never be clicked when the price was not confirmed
-        fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
-        assert not fertig_clicks, "Fertig was clicked despite shipping price not being set"
-
-    @pytest.mark.asyncio
-    async def test_shipping_price_recovers_when_readback_matches_on_retry(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """First attempt mismatches (readback empty), second attempt succeeds — must close the dialog normally."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
-
-        with (
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
-            patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = [None, "4,95"]),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-        assert mock_set_input.await_count == 2, "expected exactly one retry after the first mismatch"
-        inter_attempt_sleeps = [c for c in mock_sleep.await_args_list if c.args == (300, 500)]
-        assert len(inter_attempt_sleeps) == 1, "expected one inter-attempt backoff sleep"
-        fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
-        assert fertig_clicks, "Fertig must be clicked once the readback confirms the price"
-
-    @pytest.mark.asyncio
-    async def test_shipping_price_retries_when_readback_raises_transiently(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """A TimeoutError from the readback web_execute must be retried, not propagated on the first occurrence."""
-        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
-
-        readback_results:list[str | Exception] = [TimeoutError("readback raced with re-render"), "4,95"]
-
-        async def readback_side_effect(*_args:Any, **_kwargs:Any) -> str | None:
-            result = readback_results.pop(0)
-            if isinstance(result, Exception):
-                raise result
-            return result
-
-        with (
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
-            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
-            patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = readback_side_effect),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-        ):
-            await getattr(test_bot, "_set_shipping")(ad_cfg)
-
-        assert mock_set_input.await_count == 2, "expected one retry after the readback raised"
-        fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
-        assert fertig_clicks, "Fertig must be clicked once a later readback confirms the price"
-
-
-class TestShippingOptionsDialog:
-    """Tests for _set_shipping_options using carrier-code-based selectors."""
-
-    @staticmethod
-    def _make_ad_with_options(base_ad_config:dict[str, Any], options:list[str]) -> Ad:
-        return Ad.model_validate(
-            base_ad_config
-            | {
-                "shipping_type": "SHIPPING",
-                "shipping_options": options,
-            }
-        )
-
-    @staticmethod
-    def _mock_checkbox(checked:bool = False) -> MagicMock:
-        """Create a mock checkbox element with optional checked attribute."""
-        el = MagicMock()
-        if checked:
-            el.attrs = {"checked": ""}
-        else:
-            el.attrs = {}
-        return el
-
-    @pytest.mark.parametrize(
-        "case",
-        [
-            # SMALL pre-checked, only unwanted carriers are toggled
-            {
-                "options": ["Hermes_Päckchen"],
-                "radio_checked": True,
-                "expected_radio_click": False,
-                "expected_clicked_carriers": ["HERMES_002", "DHL_001"],
-                "expected_not_clicked_carriers": ["HERMES_001"],
-            },
-            # LARGE not checked, radio click needed and only unwanted carriers are toggled
-            {
-                "options": ["DHL_10"],
-                "radio_checked": False,
-                "expected_radio_click": True,
-                "expected_clicked_carriers": ["HERMES_004", "DHL_004", "DHL_005"],
-                "expected_not_clicked_carriers": ["DHL_003"],
-            },
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_replace_mode_handles_radio_state(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        case:dict[str, Any],
-    ) -> None:
-        """REPLACE mode: handles both pre-checked and unchecked radio states."""
-        ad_cfg = self._make_ad_with_options(base_ad_config, case["options"])
-
-        radio_mock = self._mock_checkbox(checked = case["radio_checked"])
-
-        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if "radio" in selector_value:
-                return radio_mock
-            return self._mock_checkbox(checked = True)  # all checkboxes pre-checked
-
-        with (
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-        ):
-            await getattr(test_bot, "_set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.REPLACE)
-
-        click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
-
-        # Radio click behavior matches expectation
-        radio_clicked = any("radio" in str(a[1]) for a in click_args)
-        assert radio_clicked == case["expected_radio_click"]
-
-        # Should click Weiter and Fertig
-        assert any("Weiter" in str(a[1]) for a in click_args)
-        assert any("Fertig" in str(a[1]) for a in click_args)
-
-        # Should toggle exactly the expected carriers for this scenario
-        for carrier_code in case["expected_clicked_carriers"]:
-            assert any(carrier_code in str(a[1]) for a in click_args)
-
-        for carrier_code in case["expected_not_clicked_carriers"]:
-            assert not any(carrier_code in str(a[1]) for a in click_args)
-
-    @pytest.mark.asyncio
-    async def test_replace_mode_dom_verified_unchecked_defaults_select_wanted_carrier(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """REPLACE mode must select wanted carriers when defaults are unchecked (DOM-verified for MEDIUM/LARGE)."""
-        ad_cfg = self._make_ad_with_options(base_ad_config, ["DHL_5"])
-
-        radio_mock = self._mock_checkbox(checked = False)  # MEDIUM radio not selected yet
-
-        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if "radio" in selector_value and "MEDIUM" in selector_value:
-                return radio_mock
-            # DOM probe confirms MEDIUM defaults can be unchecked after "Weiter"
-            if "HERMES_003" in selector_value:
-                return self._mock_checkbox(checked = False)
-            if "DHL_002" in selector_value:
-                return self._mock_checkbox(checked = False)
-            return self._mock_checkbox(checked = False)
-
-        with (
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-        ):
-            await getattr(test_bot, "_set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.REPLACE)
-
-        click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
-
-        # Regression guard for issue #956: wanted DHL_002 must be selected
-        assert any("DHL_002" in str(a[1]) for a in click_args)
-        # Unwanted Hermes checkbox must remain untouched when already unchecked
-        assert not any("HERMES_003" in str(a[1]) for a in click_args)
-
-    @pytest.mark.asyncio
-    async def test_modify_mode_toggles_carriers(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """MODIFY mode: explicitly (de-)selects each carrier based on wanted set."""
-        ad_cfg = self._make_ad_with_options(base_ad_config, ["Hermes_Päckchen", "DHL_2"])
-
-        radio_mock = self._mock_checkbox(checked = True)  # SMALL already selected
-
-        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if "radio" in selector_value and "SMALL" in selector_value:
-                return radio_mock
-            # HERMES_001 checked, HERMES_002 checked, DHL_001 unchecked
-            if "HERMES_001" in selector_value:
-                return self._mock_checkbox(checked = True)
-            if "HERMES_002" in selector_value:
-                return self._mock_checkbox(checked = True)
-            if "DHL_001" in selector_value:
-                return self._mock_checkbox(checked = False)
-            return self._mock_checkbox(checked = False)
-
-        with (
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-        ):
-            await getattr(test_bot, "_set_shipping_options")(ad_cfg, mode = AdUpdateStrategy.MODIFY)
-
-        click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
-        # HERMES_002 should be deselected (was checked, not wanted)
-        assert any("HERMES_002" in str(a[1]) for a in click_args)
-        # DHL_001 should be selected (was unchecked, wanted via DHL_2 → DHL_001)
-        assert any("DHL_001" in str(a[1]) for a in click_args)
-        # HERMES_001 should NOT be clicked (was checked, wanted)
-        assert not any("HERMES_001" in str(a[1]) for a in click_args)
-
-    @pytest.mark.asyncio
-    async def test_unknown_option_raises_key_error(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """Unknown shipping option name raises KeyError with helpful message."""
-        ad_cfg = self._make_ad_with_options(base_ad_config, ["NonExistent_Option"])
-
-        with (
-            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
-            pytest.raises(KeyError, match = "Unknown shipping option"),
-        ):
-            await getattr(test_bot, "_set_shipping_options")(ad_cfg)
-
-        # Validation errors must occur before any DOM interaction
-        mock_find.assert_not_awaited()
-        mock_click.assert_not_awaited()
-        mock_sleep.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_mixed_size_options_raises_value_error(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-    ) -> None:
-        """Options from different size groups raise ValueError."""
-        ad_cfg = self._make_ad_with_options(base_ad_config, ["Hermes_Päckchen", "DHL_5"])
-
-        with (
-            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
-            pytest.raises(ValueError, match = "one package size"),
-        ):
-            await getattr(test_bot, "_set_shipping_options")(ad_cfg)
-
-        # Validation errors must occur before any DOM interaction
-        mock_find.assert_not_awaited()
-        mock_click.assert_not_awaited()
-        mock_sleep.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_timeout_in_dialog_raises(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
-        """TimeoutError during dialog interaction is re-raised with descriptive message."""
-        ad_cfg = self._make_ad_with_options(base_ad_config, ["Hermes_Päckchen"])
-
-        with (
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = TimeoutError("radio not found")),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            pytest.raises(TimeoutError, match = "Failed to configure shipping options in dialog!"),
-        ):
-            await getattr(test_bot, "_set_shipping_options")(ad_cfg)
-
-
 class TestWantedShippingSelection:
-    """Regression tests for WANTED shipping path using button-combobox dropdowns.
+    """Orchestration seam test for WANTED shipping delegation.
 
-    WANTED ads render shipping as a special-attribute combobox dropdown
-    (``<button role="combobox">``) rather than radio buttons.  These tests
-    verify that the correct CSS selector lookup and ``web_select_button_combobox``
-    dispatch happen during ``publish_ad``.
+    Verifies that ``publish_ad`` / ``_fill_ad_form`` delegates to
+    ``kleinanzeigen_bot.publishing_form.set_shipping_form(self, ad_cfg, mode)``
+    with the expected bot/ad/mode arguments. Does not validate selector labels
+    or error behavior — those are covered by ``tests/unit/test_publishing_form.py``.
     """
 
-    shipping_combobox_selector = VERSAND_COMBOBOX_SELECTOR
-
-    @contextmanager
-    def _mock_publish_dependencies(
+    @pytest.mark.asyncio
+    async def test_publish_ad_delegates_to_set_shipping_form(
         self,
         test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
         mock_page:MagicMock,
-    ) -> Iterator[tuple[AsyncMock, AsyncMock]]:
-        """Mock all publish_ad dependencies, yielding (mock_find, mock_select_btn_combo)."""
+        tmp_path:Path,
+    ) -> None:
+        """``publish_ad`` must delegate the shipping step to ``set_shipping_form``."""
         test_bot.page = mock_page
         test_bot.page.url = "https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html?adId=12345"
 
-        async def execute_side_effect(script:str) -> Any:
-            if "window.location.href" in script:
-                return test_bot.page.url
-            return None
-
-        with ExitStack() as stack:
-            mock_find = stack.enter_context(patch.object(test_bot, "web_find", new_callable = AsyncMock))
-            mock_select_btn_combo = stack.enter_context(patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock))
-            stack.enter_context(patch("kleinanzeigen_bot.ainput", new_callable = AsyncMock, return_value = ""))
-            stack.enter_context(patch.object(test_bot, "web_open", new_callable = AsyncMock))
-            stack.enter_context(patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock))
-            stack.enter_context(patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock))
-            stack.enter_context(patch("kleinanzeigen_bot.publishing_form.set_pricing_fields", new_callable = AsyncMock))
-            stack.enter_context(patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock))
-            stack.enter_context(patch.object(test_bot, "_set_shipping", new_callable = AsyncMock))
-            stack.enter_context(patch("kleinanzeigen_bot.publishing_form.set_contact_fields", new_callable = AsyncMock))
-            stack.enter_context(patch("kleinanzeigen_bot.publishing_form.fill_image_section", new_callable = AsyncMock))
-            stack.enter_context(patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock))
-            stack.enter_context(patch("kleinanzeigen_bot.captcha_flow.check_and_wait_for_captcha", new_callable = AsyncMock))
-            stack.enter_context(patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None))
-            stack.enter_context(patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []))
-            stack.enter_context(patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock))
-            stack.enter_context(patch.object(test_bot, "web_sleep", new_callable = AsyncMock))
-            stack.enter_context(patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True))
-            stack.enter_context(patch.object(test_bot, "web_execute", side_effect = execute_side_effect))
-            stack.enter_context(patch.object(test_bot, "web_check", new_callable = AsyncMock))
-            stack.enter_context(patch.object(test_bot, "web_click", new_callable = AsyncMock))
-            yield mock_find, mock_select_btn_combo
-
-    @staticmethod
-    def _build_wanted_ad(base_ad_config:dict[str, Any], shipping_type:str) -> tuple[Ad, dict[str, Any]]:
         ad_cfg = Ad.model_validate(
             base_ad_config
             | {
                 "type": "WANTED",
-                "shipping_type": shipping_type,
-                "shipping_options": [],
-                "price_type": "NOT_APPLICABLE",
-                "price": None,
-            }
-        )
-        return ad_cfg, ad_cfg.model_dump()
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("shipping_type", "expected_label"),
-        [("SHIPPING", "Versand möglich"), ("PICKUP", "Nur Abholung")],
-        ids = ["shipping", "pickup"],
-    )
-    async def test_wanted_shipping_selects_combobox_dropdown(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-        tmp_path:Path,
-        shipping_type:str,
-        expected_label:str,
-    ) -> None:
-        """WANTED ads should select shipping via button-combobox dropdown, not radios."""
-        ad_cfg, ad_cfg_orig = self._build_wanted_ad(base_ad_config, shipping_type)
-        ad_file = str(tmp_path / "ad.yaml")
-
-        combobox_btn = MagicMock()
-        combobox_btn.attrs = {"id": "babyausstattung.versand"}
-
-        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if selector_type == By.CSS_SELECTOR and selector_value == self.shipping_combobox_selector:
-                return combobox_btn
-            return MagicMock()
-
-        with self._mock_publish_dependencies(test_bot, mock_page) as (mock_find, mock_select_btn_combo):
-            mock_find.side_effect = find_side_effect
-            await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
-
-        mock_select_btn_combo.assert_awaited_once_with(
-            "babyausstattung.versand",
-            expected_label,
-        )
-
-    @pytest.mark.asyncio
-    async def test_wanted_shipping_raises_when_combobox_not_found(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-        tmp_path:Path,
-    ) -> None:
-        """WANTED shipping should fail when the combobox button cannot be found."""
-        ad_cfg, ad_cfg_orig = self._build_wanted_ad(base_ad_config, "SHIPPING")
-        ad_file = str(tmp_path / "ad.yaml")
-
-        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if selector_type == By.CSS_SELECTOR and selector_value == self.shipping_combobox_selector:
-                raise TimeoutError("combobox not found in DOM")
-            return MagicMock()
-
-        with self._mock_publish_dependencies(test_bot, mock_page) as (mock_find, _):
-            mock_find.side_effect = find_side_effect
-            with pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'SHIPPING'!"):
-                await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
-
-    @pytest.mark.asyncio
-    async def test_wanted_shipping_not_applicable_skips_combobox(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-        tmp_path:Path,
-    ) -> None:
-        """WANTED ads with NOT_APPLICABLE shipping should skip the combobox entirely."""
-        ad_cfg = Ad.model_validate(
-            base_ad_config
-            | {
-                "type": "WANTED",
-                "shipping_type": "NOT_APPLICABLE",
+                "shipping_type": "SHIPPING",
                 "shipping_options": [],
                 "price_type": "NOT_APPLICABLE",
                 "price": None,
@@ -3392,32 +2784,33 @@ class TestWantedShippingSelection:
         ad_cfg_orig = ad_cfg.model_dump()
         ad_file = str(tmp_path / "ad.yaml")
 
-        with self._mock_publish_dependencies(test_bot, mock_page) as (_, mock_select_btn_combo):
+        async def execute_side_effect(script:str) -> Any:
+            if "window.location.href" in script:
+                return test_bot.page.url
+            return None
+
+        with (
+            patch("kleinanzeigen_bot.ainput", new_callable = AsyncMock, return_value = ""),
+            patch.object(test_bot, "web_open", new_callable = AsyncMock),
+            patch.object(test_bot, "_dismiss_consent_banner", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_category", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_pricing_fields", new_callable = AsyncMock),
+            patch.object(test_bot, "_set_special_attributes", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_shipping_form", new_callable = AsyncMock) as mock_set_shipping_form,
+            patch("kleinanzeigen_bot.publishing_form.set_contact_fields", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.fill_image_section", new_callable = AsyncMock),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.captcha_flow.check_and_wait_for_captcha", new_callable = AsyncMock),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "_web_find_all_once", new_callable = AsyncMock, return_value = []),
+            patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+            patch.object(test_bot, "web_execute", side_effect = execute_side_effect),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock),
+        ):
             await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
 
-        mock_select_btn_combo.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_wanted_shipping_raises_when_combobox_has_no_id(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-        tmp_path:Path,
-    ) -> None:
-        """WANTED shipping should fail when the combobox button has no id attribute."""
-        ad_cfg, ad_cfg_orig = self._build_wanted_ad(base_ad_config, "SHIPPING")
-        ad_file = str(tmp_path / "ad.yaml")
-
-        combobox_btn = MagicMock()
-        combobox_btn.attrs = {}  # No "id" key
-
-        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
-            if selector_type == By.CSS_SELECTOR and selector_value == self.shipping_combobox_selector:
-                return combobox_btn
-            return MagicMock()
-
-        with self._mock_publish_dependencies(test_bot, mock_page) as (mock_find, _):
-            mock_find.side_effect = find_side_effect
-            with pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'SHIPPING'!"):
-                await test_bot.publish_ad(ad_file, ad_cfg, ad_cfg_orig, [], AdUpdateStrategy.REPLACE)
+        mock_set_shipping_form.assert_awaited_once_with(test_bot, ad_cfg, AdUpdateStrategy.REPLACE)

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -13,7 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kleinanzeigen_bot import KleinanzeigenBot
-from kleinanzeigen_bot.model.ad_model import Ad
+from kleinanzeigen_bot.ad_form_helpers import VERSAND_COMBOBOX_SELECTOR
+from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.publishing_form import (
     city_option_text,
     fill_image_section,
@@ -24,6 +25,9 @@ from kleinanzeigen_bot.publishing_form import (
     set_contact_fields,
     set_contact_location,
     set_pricing_fields,
+    set_shipping,
+    set_shipping_form,
+    set_shipping_options,
     upload_images,
 )
 from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError
@@ -1258,3 +1262,616 @@ class TestPricingFields:
 
         mock_desc.assert_called_once_with(ad_cfg, test_bot.config.ad_defaults, with_affixes = True)
         mock_set.assert_any_await("ad-description", "Expected description text")
+
+
+class TestShippingDialogFlow:
+    """Regression tests for shipping dialog flow using new radio selectors only."""
+
+    shipping_combobox_selector = VERSAND_COMBOBOX_SELECTOR
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("shipping_type", "expected_label"),
+        [("SHIPPING", "Versand möglich"), ("PICKUP", "Nur Abholung")],
+    )
+    async def test_shipping_uses_versand_combobox_when_rendered(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        shipping_type:str,
+        expected_label:str,
+    ) -> None:
+        """Commercial accounts may render Versand as a special-attribute combobox instead of radio buttons."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": shipping_type})
+        shipping_combobox = MagicMock()
+        shipping_combobox.attrs = {"id": "uhren.versand"}
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = shipping_combobox) as mock_probe,
+            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock) as mock_select_combobox,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        mock_probe.assert_awaited_once()
+        assert mock_probe.await_args is not None
+        assert mock_probe.await_args.args[:2] == (
+            By.CSS_SELECTOR,
+            self.shipping_combobox_selector,
+        )
+        mock_select_combobox.assert_awaited_once()
+        assert mock_select_combobox.await_args is not None
+        assert mock_select_combobox.await_args.args[:2] == ("uhren.versand", expected_label)
+        mock_click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("selected", [False, True])
+    async def test_pickup_shipping_radio_selection(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        selected:bool,
+    ) -> None:
+        """PICKUP shipping should click the pickup radio only when it is not already selected."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]) as mock_probe,
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, return_value = selected),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        observed = [call.args[:2] for call in mock_probe.await_args_list]
+        assert (By.CSS_SELECTOR, self.shipping_combobox_selector) in observed
+        assert (By.ID, "ad-shipping-enabled-no") in observed
+        if selected:
+            mock_click.assert_not_awaited()
+        else:
+            mock_click.assert_awaited_once()
+            assert mock_click.call_args.args[:2] == (By.ID, "ad-shipping-enabled-no")
+
+    @pytest.mark.asyncio
+    async def test_pickup_shipping_raises_when_radio_lookup_times_out(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        """PICKUP shipping should fail fast when pickup radio selector is unavailable."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock, side_effect = TimeoutError("pickup lookup timed out")),
+            pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'PICKUP'!"),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+    @pytest.mark.asyncio
+    async def test_pickup_shipping_skips_when_toggle_not_rendered(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Categories without a shipping fieldset (e.g. books 76/77, comics 76/77/15156)
+        are PICKUP-only by site convention — the absence of both shipping selectors should
+        short-circuit without calling ``web_check``/``web_click``."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, None, None]),
+            patch.object(test_bot, "web_check", new_callable = AsyncMock) as mock_check,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        mock_check.assert_not_awaited()
+        mock_click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pickup_shipping_raises_when_fieldset_rendered_but_pickup_radio_missing(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """A rendered shipping fieldset without the pickup radio should be treated as an error."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "PICKUP"})
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, None, MagicMock()]) as mock_probe,
+            patch.object(test_bot, "web_check", new_callable = AsyncMock) as mock_check,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            pytest.raises(
+                TimeoutError,
+                match = "Shipping fieldset is rendered, but the pickup radio is missing; page may not be fully loaded.",
+            ),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        observed = [call.args[:2] for call in mock_probe.await_args_list]
+        assert (By.CSS_SELECTOR, self.shipping_combobox_selector) in observed
+        assert (By.ID, "ad-shipping-enabled-no") in observed
+        assert (By.ID, "ad-shipping-enabled") in observed
+        mock_check.assert_not_awaited()
+        mock_click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_shipping_without_options_uses_radio_and_dialog(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        """Shipping without package options should use radio + dialog flow."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = "4,95"),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+            click_args = [c.args for c in mock_click.await_args_list]
+            assert any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
+            assert any("Fertig" in str(a[1]) for a in click_args if len(a) >= 2)
+            mock_set_input.assert_awaited_once_with("ad-individual-shipping-price", "4,95")
+
+    @pytest.mark.asyncio
+    async def test_shipping_finish_timeout_raises(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        """Timeout while confirming shipping dialog should raise a clear error."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": []})
+
+        async def click_side_effect(selector_type:By, selector_value:str, **_:Any) -> None:
+            if selector_type == By.XPATH and "Fertig" in selector_value:
+                raise TimeoutError("finish timeout")
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = click_side_effect),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            pytest.raises(TimeoutError, match = "Unable to close shipping dialog!"),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+    @pytest.mark.asyncio
+    async def test_shipping_without_options_does_not_toggle_checkbox_when_price_input_visible(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """When price input is already visible, individual-shipping checkbox is not toggled."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, side_effect = [None, MagicMock()]),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = "4,95"),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        click_args = [c.args for c in mock_click.await_args_list]
+        assert not any(len(a) >= 2 and a[0] == By.ID and a[1] == "ad-individual-shipping-checkbox-control" for a in click_args)
+        mock_set_input.assert_awaited_once_with("ad-individual-shipping-price", "4,95")
+
+    @pytest.mark.asyncio
+    async def test_shipping_price_lost_to_react_rerender_raises(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """When React re-render swallows the shipping price, the dialog must NOT be closed."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
+
+        async def set_input_side_effect(element_id:str, value:str) -> None:
+            pass
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock, side_effect = set_input_side_effect),
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            pytest.raises(TimeoutError, match = "Unable to set shipping price!"),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        # Fertig must never be clicked when the price was not confirmed
+        fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
+        assert not fertig_clicks, "Fertig was clicked despite shipping price not being set"
+
+    @pytest.mark.asyncio
+    async def test_shipping_price_recovers_when_readback_matches_on_retry(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """First attempt mismatches (readback empty), second attempt succeeds — must close the dialog normally."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = [None, "4,95"]),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        assert mock_set_input.await_count == 2, "expected exactly one retry after the first mismatch"
+        inter_attempt_sleeps = [c for c in mock_sleep.await_args_list if c.args == (300, 500)]
+        assert len(inter_attempt_sleeps) == 1, "expected one inter-attempt backoff sleep"
+        fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
+        assert fertig_clicks, "Fertig must be clicked once the readback confirms the price"
+
+    @pytest.mark.asyncio
+    async def test_shipping_price_retries_when_readback_raises_transiently(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """A TimeoutError from the readback web_execute must be retried, not propagated on the first occurrence."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
+
+        readback_results:list[str | Exception] = [TimeoutError("readback raced with re-render"), "4,95"]
+
+        async def readback_side_effect(*_args:Any, **_kwargs:Any) -> str | None:
+            result = readback_results.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock) as mock_set_input,
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = readback_side_effect),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        assert mock_set_input.await_count == 2, "expected one retry after the readback raised"
+        fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
+        assert fertig_clicks, "Fertig must be clicked once a later readback confirms the price"
+
+
+class TestShippingOptionsDialog:
+    """Tests for set_shipping_options using carrier-code-based selectors."""
+
+    @staticmethod
+    def _make_ad_with_options(base_ad_config:dict[str, Any], options:list[str]) -> Ad:
+        return Ad.model_validate(
+            base_ad_config
+            | {
+                "shipping_type": "SHIPPING",
+                "shipping_options": options,
+            }
+        )
+
+    @staticmethod
+    def _mock_checkbox(checked:bool = False) -> MagicMock:
+        """Create a mock checkbox element with optional checked attribute."""
+        el = MagicMock()
+        if checked:
+            el.attrs = {"checked": ""}
+        else:
+            el.attrs = {}
+        return el
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            # SMALL pre-checked, only unwanted carriers are toggled
+            {
+                "options": ["Hermes_Päckchen"],
+                "radio_checked": True,
+                "expected_radio_click": False,
+                "expected_clicked_carriers": ["HERMES_002", "DHL_001"],
+                "expected_not_clicked_carriers": ["HERMES_001"],
+            },
+            # LARGE not checked, radio click needed and only unwanted carriers are toggled
+            {
+                "options": ["DHL_10"],
+                "radio_checked": False,
+                "expected_radio_click": True,
+                "expected_clicked_carriers": ["HERMES_004", "DHL_004", "DHL_005"],
+                "expected_not_clicked_carriers": ["DHL_003"],
+            },
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_replace_mode_handles_radio_state(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        case:dict[str, Any],
+    ) -> None:
+        """REPLACE mode: handles both pre-checked and unchecked radio states."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, case["options"])
+
+        radio_mock = self._mock_checkbox(checked = case["radio_checked"])
+
+        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
+            if "radio" in selector_value:
+                return radio_mock
+            return self._mock_checkbox(checked = True)  # all checkboxes pre-checked
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await set_shipping_options(test_bot, ad_cfg, mode = AdUpdateStrategy.REPLACE)
+
+        click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
+
+        # Radio click behavior matches expectation
+        radio_clicked = any("radio" in str(a[1]) for a in click_args)
+        assert radio_clicked == case["expected_radio_click"]
+
+        # Should click Weiter and Fertig
+        assert any("Weiter" in str(a[1]) for a in click_args)
+        assert any("Fertig" in str(a[1]) for a in click_args)
+
+        # Should toggle exactly the expected carriers for this scenario
+        for carrier_code in case["expected_clicked_carriers"]:
+            assert any(carrier_code in str(a[1]) for a in click_args)
+
+        for carrier_code in case["expected_not_clicked_carriers"]:
+            assert not any(carrier_code in str(a[1]) for a in click_args)
+
+    @pytest.mark.asyncio
+    async def test_replace_mode_dom_verified_unchecked_defaults_select_wanted_carrier(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """REPLACE mode must select wanted carriers when defaults are unchecked (DOM-verified for MEDIUM/LARGE)."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, ["DHL_5"])
+
+        radio_mock = self._mock_checkbox(checked = False)  # MEDIUM radio not selected yet
+
+        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
+            if "radio" in selector_value and "MEDIUM" in selector_value:
+                return radio_mock
+            # DOM probe confirms MEDIUM defaults can be unchecked after "Weiter"
+            if "HERMES_003" in selector_value:
+                return self._mock_checkbox(checked = False)
+            if "DHL_002" in selector_value:
+                return self._mock_checkbox(checked = False)
+            return self._mock_checkbox(checked = False)
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await set_shipping_options(test_bot, ad_cfg, mode = AdUpdateStrategy.REPLACE)
+
+        click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
+
+        # Regression guard for issue #956: wanted DHL_002 must be selected
+        assert any("DHL_002" in str(a[1]) for a in click_args)
+        # Unwanted Hermes checkbox must remain untouched when already unchecked
+        assert not any("HERMES_003" in str(a[1]) for a in click_args)
+
+    @pytest.mark.asyncio
+    async def test_modify_mode_toggles_carriers(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """MODIFY mode: explicitly (de-)selects each carrier based on wanted set."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, ["Hermes_Päckchen", "DHL_2"])
+
+        radio_mock = self._mock_checkbox(checked = True)  # SMALL already selected
+
+        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
+            if "radio" in selector_value and "SMALL" in selector_value:
+                return radio_mock
+            # HERMES_001 checked, HERMES_002 checked, DHL_001 unchecked
+            if "HERMES_001" in selector_value:
+                return self._mock_checkbox(checked = True)
+            if "HERMES_002" in selector_value:
+                return self._mock_checkbox(checked = True)
+            if "DHL_001" in selector_value:
+                return self._mock_checkbox(checked = False)
+            return self._mock_checkbox(checked = False)
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+        ):
+            await set_shipping_options(test_bot, ad_cfg, mode = AdUpdateStrategy.MODIFY)
+
+        click_args = [(c.args[0], c.args[1]) for c in mock_click.await_args_list if len(c.args) >= 2]
+        # HERMES_002 should be deselected (was checked, not wanted)
+        assert any("HERMES_002" in str(a[1]) for a in click_args)
+        # DHL_001 should be selected (was unchecked, wanted via DHL_2 → DHL_001)
+        assert any("DHL_001" in str(a[1]) for a in click_args)
+        # HERMES_001 should NOT be clicked (was checked, wanted)
+        assert not any("HERMES_001" in str(a[1]) for a in click_args)
+
+    @pytest.mark.asyncio
+    async def test_unknown_option_raises_key_error(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Unknown shipping option name raises KeyError with helpful message."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, ["NonExistent_Option"])
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            pytest.raises(KeyError, match = "Unknown shipping option"),
+        ):
+            await set_shipping_options(test_bot, ad_cfg)
+
+        # Validation errors must occur before any DOM interaction
+        mock_find.assert_not_awaited()
+        mock_click.assert_not_awaited()
+        mock_sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_mixed_size_options_raises_value_error(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Options from different size groups raise ValueError."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, ["Hermes_Päckchen", "DHL_5"])
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            pytest.raises(ValueError, match = "one package size"),
+        ):
+            await set_shipping_options(test_bot, ad_cfg)
+
+        # Validation errors must occur before any DOM interaction
+        mock_find.assert_not_awaited()
+        mock_click.assert_not_awaited()
+        mock_sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_timeout_in_dialog_raises(self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any]) -> None:
+        """TimeoutError during dialog interaction is re-raised with descriptive message."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, ["Hermes_Päckchen"])
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = TimeoutError("radio not found")),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            pytest.raises(TimeoutError, match = "Failed to configure shipping options in dialog!"),
+        ):
+            await set_shipping_options(test_bot, ad_cfg)
+
+
+class TestWantedShippingSelection:
+    """Tests for WANTED shipping path via set_shipping_form.
+
+    WANTED ads render shipping as a special-attribute combobox dropdown
+    (``<button role="combobox">``) rather than radio buttons. These tests
+    verify ``set_shipping_form`` directly with WANTED ad configurations.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("shipping_type", "expected_label"),
+        [("SHIPPING", "Versand möglich"), ("PICKUP", "Nur Abholung")],
+        ids = ["shipping", "pickup"],
+    )
+    async def test_wanted_shipping_selects_combobox_dropdown(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        shipping_type:str,
+        expected_label:str,
+    ) -> None:
+        """WANTED ads should select shipping via button-combobox dropdown using VERSAND_COMBOBOX_SELECTOR."""
+        ad_cfg = Ad.model_validate(
+            base_ad_config
+            | {
+                "type": "WANTED",
+                "shipping_type": shipping_type,
+                "shipping_options": [],
+            }
+        )
+
+        combobox_btn = MagicMock()
+        combobox_btn.attrs = {"id": "babyausstattung.versand"}
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = combobox_btn) as mock_find,
+            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock) as mock_select_btn_combo,
+        ):
+            await set_shipping_form(test_bot, ad_cfg)
+
+        mock_find.assert_awaited_once_with(
+            By.CSS_SELECTOR,
+            VERSAND_COMBOBOX_SELECTOR,
+            timeout = test_bot.timeout("quick_dom"),
+        )
+        mock_select_btn_combo.assert_awaited_once_with(
+            "babyausstattung.versand",
+            expected_label,
+        )
+
+    @pytest.mark.asyncio
+    async def test_wanted_shipping_raises_when_combobox_not_found(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """WANTED shipping should fail with TimeoutError when the combobox button cannot be found."""
+        ad_cfg = Ad.model_validate(
+            base_ad_config
+            | {
+                "type": "WANTED",
+                "shipping_type": "SHIPPING",
+                "shipping_options": [],
+            }
+        )
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = TimeoutError("combobox not found in DOM")),
+            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock),
+            pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'SHIPPING'!"),
+        ):
+            await set_shipping_form(test_bot, ad_cfg)
+
+    @pytest.mark.asyncio
+    async def test_wanted_shipping_not_applicable_skips_combobox(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """WANTED ads with NOT_APPLICABLE shipping should skip the combobox entirely."""
+        ad_cfg = Ad.model_validate(
+            base_ad_config
+            | {
+                "type": "WANTED",
+                "shipping_type": "NOT_APPLICABLE",
+                "shipping_options": [],
+            }
+        )
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock) as mock_select_btn_combo,
+        ):
+            await set_shipping_form(test_bot, ad_cfg)
+
+        mock_find.assert_not_awaited()
+        mock_select_btn_combo.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_wanted_shipping_raises_when_combobox_has_no_id(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """WANTED shipping should fail with TimeoutError when the combobox button has no id attribute."""
+        ad_cfg = Ad.model_validate(
+            base_ad_config
+            | {
+                "type": "WANTED",
+                "shipping_type": "SHIPPING",
+                "shipping_options": [],
+            }
+        )
+
+        combobox_btn = MagicMock()
+        combobox_btn.attrs = {}  # No "id" key
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = combobox_btn),
+            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock),
+            pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'SHIPPING'!"),
+        ):
+            await set_shipping_form(test_bot, ad_cfg)

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -16,6 +16,7 @@ from kleinanzeigen_bot import KleinanzeigenBot
 from kleinanzeigen_bot.ad_form_helpers import VERSAND_COMBOBOX_SELECTOR
 from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.publishing_form import (
+    _select_button_combobox,  # noqa: PLC2701 - needed for coverage of React fiber selection
     city_option_text,
     fill_image_section,
     read_city_selection_text,
@@ -1535,6 +1536,114 @@ class TestShippingDialogFlow:
         fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
         assert fertig_clicks, "Fertig must be clicked once a later readback confirms the price"
 
+    # ------------------------------------------------------------------
+    # set_shipping commercial/pro combobox: error paths
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_shipping_versand_combobox_no_id(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Commercial combobox with no id attribute should raise TimeoutError."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING"})
+        shipping_combobox = MagicMock()
+        shipping_combobox.attrs = {}  # No "id" key
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = shipping_combobox),
+            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock),
+            pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'SHIPPING'!"),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+    @pytest.mark.asyncio
+    async def test_shipping_versand_combobox_unsupported_type(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Commercial combobox with unsupported shipping_type should raise ValueError.
+
+        Bypasses Pydantic validation by patching the attribute at runtime because
+        the model only permits SHIPPING/PICKUP/NOT_APPLICABLE.
+        """
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING"})
+        shipping_combobox = MagicMock()
+        shipping_combobox.attrs = {"id": "uhren.versand"}
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = shipping_combobox),
+            patch.object(test_bot, "web_select_button_combobox", new_callable = AsyncMock),
+            patch.object(ad_cfg, "shipping_type", "INVALID_TYPE"),
+            pytest.raises(ValueError, match = "Unsupported shipping_type: INVALID_TYPE"),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+    @pytest.mark.asyncio
+    async def test_shipping_versand_combobox_select_timeout(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Timeout from web_select_button_combobox should be re-raised with descriptive message."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING"})
+        shipping_combobox = MagicMock()
+        shipping_combobox.attrs = {"id": "uhren.versand"}
+
+        with (
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = shipping_combobox),
+            patch.object(
+                test_bot, "web_select_button_combobox", new_callable = AsyncMock, side_effect = TimeoutError("combobox selection failed")
+            ),
+            pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'SHIPPING'!"),
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+    # ------------------------------------------------------------------
+    # individual shipping-cost retry: web_set_input_value transient TimeoutError
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_shipping_price_recovers_after_set_input_timeout(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """A TimeoutError from web_set_input_value must be retried and recover on a subsequent attempt.
+
+        Flow: attempt1 (set_input TimeoutError → retry), attempt2 (set_input ok,
+        readback None → retry), attempt3 (set_input ok, readback matches → done).
+        """
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": [], "shipping_costs": 4.95})
+
+        set_input_attempts = 0
+
+        async def set_input_side_effect(element_id:str, value:str) -> None:
+            nonlocal set_input_attempts
+            set_input_attempts += 1
+            if set_input_attempts == 1:
+                raise TimeoutError("set_input raced with re-render")
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = None),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = MagicMock()),
+            patch.object(test_bot, "web_set_input_value", new_callable = AsyncMock, side_effect = set_input_side_effect) as mock_set_input,
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, side_effect = [None, "4,95"]),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+        ):
+            await set_shipping(test_bot, ad_cfg)
+
+        # attempt1 raised (caught), attempt2 set_input ok but readback=None (retry),
+        # attempt3 set_input ok and readback="4,95" (done) → 3 calls total
+        assert mock_set_input.await_count == 3, "expected 2 retries: one after set_input TimeoutError, one after mismatched readback"
+        inter_attempt_sleeps = [c for c in mock_sleep.await_args_list if c.args == (300, 500)]
+        assert len(inter_attempt_sleeps) == 2, "expected two inter-attempt backoff sleeps"
+        fertig_clicks = [c for c in mock_click.await_args_list if c.args and len(c.args) >= 2 and "Fertig" in str(c.args[1])]
+        assert fertig_clicks, "Fertig must be clicked once the retry succeeds"
+
 
 class TestShippingOptionsDialog:
     """Tests for set_shipping_options using carrier-code-based selectors."""
@@ -1751,6 +1860,60 @@ class TestShippingOptionsDialog:
         ):
             await set_shipping_options(test_bot, ad_cfg)
 
+    # ------------------------------------------------------------------
+    # set_shipping_options: pre-DOM validation and close failure
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_shipping_options_missing_raises_value_error(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Empty shipping_options should raise ValueError before any DOM interaction."""
+        ad_cfg = Ad.model_validate(base_ad_config | {"shipping_type": "SHIPPING", "shipping_options": []})
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            pytest.raises(ValueError, match = "shipping_options must be provided"),
+        ):
+            await set_shipping_options(test_bot, ad_cfg)
+
+        mock_find.assert_not_awaited()
+        mock_click.assert_not_awaited()
+        mock_sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_shipping_options_close_timeout_raises(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """Timeout on the final Fertig click should raise TimeoutError."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, ["Hermes_Päckchen"])
+
+        async def click_side_effect(selector_type:By, selector_value:str, **_:Any) -> None:
+            if selector_type == By.XPATH and "Fertig" in selector_value:
+                raise TimeoutError("Fertig click timeout")
+
+        radio_mock = MagicMock()
+        radio_mock.attrs = {"checked": ""}
+        checkbox_mock = MagicMock()
+        checkbox_mock.attrs = {"checked": ""}
+
+        async def find_side_effect(selector_type:By, selector_value:str, **_:Any) -> MagicMock:
+            return radio_mock if "radio" in selector_value else checkbox_mock
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = find_side_effect),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = click_side_effect),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            pytest.raises(TimeoutError, match = "Unable to close shipping dialog!"),
+        ):
+            await set_shipping_options(test_bot, ad_cfg)
+
 
 class TestWantedShippingSelection:
     """Tests for WANTED shipping path via set_shipping_form.
@@ -1876,3 +2039,55 @@ class TestWantedShippingSelection:
             pytest.raises(TimeoutError, match = "Failed to set shipping attribute for type 'SHIPPING'!"),
         ):
             await set_shipping_form(test_bot, ad_cfg)
+
+
+class TestSelectButtonCombobox:
+    """Tests for _select_button_combobox (React fiber combobox selection).
+
+    ``_select_button_combobox`` is the internal helper used for special-attribute
+    comboboxes where the option list is embedded in the React fiber tree. It clicks
+    the button to open the menu, waits for the listbox, then executes JS to find
+    and click the matching option by value.
+    """
+
+    @pytest.mark.asyncio
+    async def test_select_button_combobox_success(
+        self,
+        test_bot:KleinanzeigenBot,
+    ) -> None:
+        """Successful selection: clicks button, waits for listbox, executes JS, returns True."""
+        elem_id = "my-combobox-id"
+        option_value = "option_value"
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = True) as mock_execute,
+        ):
+            await _select_button_combobox(test_bot, elem_id, option_value)
+
+        mock_click.assert_awaited_once_with(By.ID, elem_id)
+        mock_find.assert_awaited_once_with(By.ID, f"{elem_id}-menu")
+        mock_execute.assert_awaited_once()
+        assert mock_execute.await_args is not None
+        js = str(mock_execute.await_args.args[0])
+        assert "my-combobox-id" in js
+        assert "my-combobox-id-menu" in js
+        assert "option_value" in js
+
+    @pytest.mark.asyncio
+    async def test_select_button_combobox_js_returns_false(
+        self,
+        test_bot:KleinanzeigenBot,
+    ) -> None:
+        """When the JS fiber walk returns False, TimeoutError is raised."""
+        elem_id = "my-combobox-id"
+        option_value = "missing_option"
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "web_find", new_callable = AsyncMock),
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = False),
+            pytest.raises(TimeoutError, match = "not found in button combobox"),
+        ):
+            await _select_button_combobox(test_bot, elem_id, option_value)

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -1792,10 +1792,11 @@ class TestWantedShippingSelection:
         ):
             await set_shipping_form(test_bot, ad_cfg)
 
-        mock_find.assert_awaited_once_with(
+        mock_find.assert_awaited_once()
+        assert mock_find.await_args is not None
+        assert mock_find.await_args.args == (
             By.CSS_SELECTOR,
             VERSAND_COMBOBOX_SELECTOR,
-            timeout = test_bot.timeout("quick_dom"),
         )
         mock_select_btn_combo.assert_awaited_once_with(
             "babyausstattung.versand",


### PR DESCRIPTION
## ℹ️ Description
- Extracts the publishing shipping form workflow from `KleinanzeigenBot` into `publishing_form.py`.
- Keeps runtime behavior, selectors, waits, messages, and browser interactions unchanged while moving translation ownership.

## 📋 Changes Summary
- Move WANTED shipping handling, shipping radio/dialog handling, shipping option toggling, and the private React-fiber button-combobox helper into `publishing_form.py`.
- Update `__init__.py` to delegate shipping form work and keep only orchestration/seam responsibilities.
- Move direct shipping behavior tests to `tests/unit/test_publishing_form.py`; keep a shipping orchestration seam test in `tests/unit/test_init.py`.
- Move German translation entries for shipping messages to the `publishing_form.py` translation section.

### ⚙️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Refactor**
  * Improved publishing ad shipping form handling by routing wanted vs non-wanted ads to the correct UI flow.
  * Enhanced Versand (shipping) combobox selection for wanted ads to ensure the right option is chosen.
  * Strengthened the shipping dialog flow for pickup vs shipping-with-options, including more reliable shipping price confirmation and retry behavior.

* **Tests**
  * Expanded unit tests covering shipping dialog interactions, carrier/option selection, wanted-shipping combobox behavior, and timeout/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->