### PR TITLE
refactor: extract publishing form orchestrator

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -987,34 +987,6 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             LOG.info("DONE: (Re-)published %s", pluralize("ad", count))
         LOG.info("############################################")
 
-    async def _fill_ad_form(
-        self, ad_file:str, ad_cfg:Ad, mode:AdUpdateStrategy,
-    ) -> None:
-        """Fill the ad creation/edit form — category, attributes, shipping, price,
-        sell-directly, description, contact, and images."""
-
-        #############################
-        # set category (before title to avoid form reset clearing title)
-        #############################
-        await _publishing_form.set_category(self, root_url = self.root_url, category = ad_cfg.category, ad_file = ad_file)
-        await self.web_sleep()  # wait for category-dependent fields to render before setting attributes
-
-        #############################
-        # set special attributes
-        #############################
-        await _publishing_form.set_special_attributes(self, ad_cfg)
-
-        #############################
-        # set shipping type/options/costs
-        #############################
-        await _publishing_form.set_shipping_form(self, ad_cfg, mode)
-
-        await _publishing_form.set_pricing_fields(self, ad_cfg, self.config.ad_defaults)
-
-        await _publishing_form.set_contact_fields(self, ad_cfg.contact)
-
-        await _publishing_form.fill_image_section(self, ad_cfg)
-
     async def publish_ad(
         self, ad_file:str, ad_cfg:Ad, ad_cfg_orig:dict[str, Any], published_ads_list:list[PublishedAd], mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE
     ) -> None:
@@ -1065,7 +1037,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if ad_cfg.type == "WANTED":
             await self.web_click(By.ID, "ad-type-WANTED")
 
-        await self._fill_ad_form(ad_file, ad_cfg, mode)
+        await _publishing_form.fill_ad_form(self, ad_file, ad_cfg, mode,
+            root_url = self.root_url, ad_defaults = self.config.ad_defaults)
 
         ad_id = await _publishing_submission.submit_and_confirm_ad(self, ad_file, ad_cfg, mode, captcha_config = self.config.captcha)
 

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -1036,3 +1036,38 @@ async def set_special_attributes(web:WebScrapingMixin, ad_cfg:Ad) -> None:
             LOG.debug("Failed to set attribute field '%s' via known input types.", special_attribute_key)
             raise TimeoutError(_("Failed to set attribute '%s'") % special_attribute_key) from ex
         LOG.debug("Successfully set attribute field [%s] to [%s]...", special_attribute_key, special_attribute_value_str)
+
+
+async def fill_ad_form(
+    web:WebScrapingMixin,
+    ad_file:str,
+    ad_cfg:Ad,
+    mode:AdUpdateStrategy,
+    *,
+    root_url:str,
+    ad_defaults:AdDefaults,
+) -> None:
+    """Fill the ad creation/edit form — category, attributes, shipping, price,
+    sell-directly, description, contact, and images."""
+
+    #############################
+    # set category (before title to avoid form reset clearing title)
+    #############################
+    await set_category(web, root_url = root_url, category = ad_cfg.category, ad_file = ad_file)
+    await web.web_sleep()  # wait for category-dependent fields to render before setting attributes
+
+    #############################
+    # set special attributes
+    #############################
+    await set_special_attributes(web, ad_cfg)
+
+    #############################
+    # set shipping type/options/costs
+    #############################
+    await set_shipping_form(web, ad_cfg, mode)
+
+    await set_pricing_fields(web, ad_cfg, ad_defaults)
+
+    await set_contact_fields(web, ad_cfg.contact)
+
+    await fill_image_section(web, ad_cfg)

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2027,7 +2027,7 @@ class TestKleinanzeigenBotShippingOptions:
 class TestWantedShippingSelection:
     """Orchestration seam test for WANTED shipping delegation.
 
-    Verifies that ``publish_ad`` / ``_fill_ad_form`` delegates to
+    Verifies that ``publish_ad`` / ``fill_ad_form`` delegates to
     ``kleinanzeigen_bot.publishing_form.set_shipping_form(self, ad_cfg, mode)``
     with the expected bot/ad/mode arguments. Does not validate selector labels
     or error behavior — those are covered by ``tests/unit/test_publishing_form.py``.

--- a/tests/unit/test_publishing_persistence.py
+++ b/tests/unit/test_publishing_persistence.py
@@ -299,7 +299,7 @@ async def test_publish_ad_survives_persistence_failure() -> None:
         patch.object(bot, "_delete_old_ad_if_needed", new_callable = AsyncMock),
         patch.object(bot, "web_open", new_callable = AsyncMock),
         patch.object(bot, "_dismiss_consent_banner", new_callable = AsyncMock),
-        patch.object(bot, "_fill_ad_form", new_callable = AsyncMock),
+        patch("kleinanzeigen_bot.publishing_form.fill_ad_form", new_callable = AsyncMock),
         patch("kleinanzeigen_bot.publishing_submission.submit_and_confirm_ad", new_callable = AsyncMock, return_value = 12345),
         patch("kleinanzeigen_bot.publishing_persistence.persist_published_ad",
               side_effect = RuntimeError("disk full")),


### PR DESCRIPTION
## ℹ️ Description

Move the last form-filling remnant out of `__init__.py` into `publishing_form.py`, where all individual form section functions already live.

- `_fill_ad_form()` only delegated to the already-extracted section functions (`set_category`, `set_special_attributes`, `set_shipping_form`, `set_pricing_fields`, `set_contact_fields`, `fill_image_section`).
- Replaced with a public module-level `publishing_form.fill_ad_form()` that accepts explicit `web`, `root_url`, `ad_defaults`, `ad_file`, `ad_cfg`, and `mode` parameters.
- `publish_ad()` now calls `_publishing_form.fill_ad_form(self, ...)` instead of `self._fill_ad_form(...)`.

## 📋 Changes Summary

- Extracted `fill_ad_form()` into `publishing_form.py` as a public module-level async function
- Removed `_fill_ad_form()` method from `KleinanzeigenBot` class
- Updated call site in `publish_ad()` to pass explicit parameters
- Updated test patch target in `test_publishing_persistence.py` and docstring in `test_init.py`

### ⚙️ Type of Change
- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized ad form-filling logic for improved maintainability and code structure.

* **Tests**
  * Updated unit tests to reflect internal code reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->