### PR TITLE
refactor: extract publishing workflow

### DIFF
--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -9,15 +9,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Literal, Sequence, cast
 
 import certifi, colorama  # isort: skip
-from nodriver.core.connection import ProtocolException
-from ruamel.yaml import YAML
-
-from . import ad_loading, captcha_flow, delete_flow, download_flow, extend_flow, published_ads
+from . import ad_loading, captcha_flow, delete_flow, download_flow, extend_flow
 from . import ad_state as _ad_state
 from . import price_reduction as _price_reduction
-from . import publishing_form as _publishing_form
-from . import publishing_persistence as _publishing_persistence
-from . import publishing_submission as _publishing_submission
+from . import publishing_workflow as _publishing_workflow
 from . import runtime_config as _runtime_config
 from ._version import __version__
 from .model.ad_model import Ad
@@ -25,15 +20,13 @@ from .model.ad_model import (
     AdUpdateStrategy as AdUpdateStrategy,
 )
 from .model.config_model import Config  # noqa: TC001 — used at runtime, config injection
-from .published_ads import PublishedAd, ad_matches_id
+from .published_ads import PublishedAd
 from .update_checker import UpdateChecker
 from .utils import diagnostics as _diagnostics
 from .utils import loggers as _loggers
 from .utils import misc as _misc
 from .utils import xdg_paths as _xdg_paths
-from .utils.exceptions import CategoryResolutionError, PublishSubmissionUncertainError
 from .utils.files import abspath
-from .utils.i18n import pluralize
 from .utils.misc import ainput, is_frozen
 from .utils.web_scraping_mixin import By, Is, WebScrapingMixin
 
@@ -45,7 +38,6 @@ if TYPE_CHECKING:
 LOG:Final[_loggers.Logger] = _loggers.get_logger(__name__)
 LOG.setLevel(_loggers.INFO)
 
-SUBMISSION_MAX_RETRIES:Final[int] = 3
 _LOGIN_DETECTION_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CLASS_NAME, "mr-medium"),
     (By.ID, "user-email"),
@@ -879,8 +871,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         return False
 
     async def _check_publishing_result(self) -> bool:
-        # Check for success messages
-        return await self.web_check(By.ID, "checking-done", Is.DISPLAYED) or await self.web_check(By.ID, "not-completed", Is.DISPLAYED)
+        return await _publishing_workflow.check_publishing_result(self)
 
     async def _delete_old_ad_if_needed(
         self, ad_cfg:Ad, published_ads_list:list[PublishedAd],
@@ -894,98 +885,23 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         In ``AFTER_PUBLISH`` mode, title-based deletion is always disabled to
         avoid accidentally removing the newly published ad.
         """
-        if self.keep_old_ads:
-            return
-        if self.config.publishing.delete_old_ads != timing:
-            return
-        delete_old_ads_by_title = (
-            self.config.publishing.delete_old_ads_by_title
-            if timing == "BEFORE_PUBLISH" else False
-        )
-        await delete_flow.delete_ad(
-            web = self, root_url = self.root_url,
-            ad_cfg = ad_cfg,
-            published_ads_list = published_ads_list,
-            delete_old_ads_by_title = delete_old_ads_by_title,
+        await _publishing_workflow.delete_old_ad_if_needed(
+            self, ad_cfg, published_ads_list,
+            timing = timing,
+            keep_old_ads = self.keep_old_ads,
+            config = self.config,
+            root_url = self.root_url,
         )
 
     async def publish_ads(self, ad_cfgs:list[tuple[str, Ad, dict[str, Any]]]) -> None:
-        count = 0
-        failed_count = 0
-        max_retries = SUBMISSION_MAX_RETRIES
-
-        published_ads_list = await published_ads.fetch_published_ads(self, self.root_url)
-
-        for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ad_cfgs, start = 1):
-            LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ad_cfgs), ad_cfg.title, ad_file)
-
-            if any(ad_matches_id(x, ad_cfg.id) and x.get("state") == "paused" for x in published_ads_list):
-                LOG.info("Skipping because ad is reserved")
-                continue
-
-            count += 1
-            success = False
-            baseline_price = ad_cfg.price
-            baseline_price_reduction_count = ad_cfg.price_reduction_count
-
-            for attempt in range(1, max_retries + 1):
-                try:
-                    # publish_ad mutates pricing fields before submit; reset them so retries
-                    # remain idempotent for a single eligible reduction cycle.
-                    ad_cfg.price = baseline_price
-                    ad_cfg.price_reduction_count = baseline_price_reduction_count
-                    await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads_list, AdUpdateStrategy.REPLACE)
-                    success = True
-                    break  # Publish succeeded, exit retry loop
-                except asyncio.CancelledError:
-                    raise  # Respect task cancellation
-                except CategoryResolutionError as ex:
-                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
-                    LOG.error("Category resolution failed for '%s': %s. Skipping ad (configuration error, no retry).", ad_cfg.title, ex)
-                    failed_count += 1
-                    break
-                except PublishSubmissionUncertainError as ex:
-                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
-                    LOG.warning(
-                        "Attempt %s/%s for '%s' reached submit boundary but failed: %s. Not retrying to prevent duplicate listings.",
-                        attempt,
-                        max_retries,
-                        ad_cfg.title,
-                        ex,
-                    )
-                    LOG.warning("Manual recovery required for '%s'. Check 'Meine Anzeigen' to confirm whether the ad was posted.", ad_cfg.title)
-                    LOG.warning(
-                        "If posted, sync local state with 'kleinanzeigen-bot download --ads=new' or 'kleinanzeigen-bot download --ads=<id>'; "
-                        "otherwise rerun publish for this ad."
-                    )
-                    failed_count += 1
-                    break
-                except (TimeoutError, ProtocolException) as ex:
-                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
-                    if attempt >= max_retries:
-                        LOG.error("All %s attempts failed for '%s': %s. Skipping ad.", max_retries, ad_cfg.title, ex)
-                        failed_count += 1
-                        break
-
-                    LOG.warning("Attempt %s/%s failed for '%s': %s. Retrying...", attempt, max_retries, ad_cfg.title, ex)
-                    await self.web_sleep(2_000)  # Wait before retry
-
-            # Check publishing result separately (no retry - ad is already submitted)
-            if success:
-                try:
-                    publish_timeout = self.timeout("publishing_result")
-                    await self.web_await(self._check_publishing_result, timeout = publish_timeout)
-                except TimeoutError:
-                    LOG.warning(" -> Could not confirm publishing for '%s', but ad may be online", ad_cfg.title)
-
-                await self._delete_old_ad_if_needed(ad_cfg, published_ads_list, timing = "AFTER_PUBLISH")
-
-        LOG.info("############################################")
-        if failed_count > 0:
-            LOG.info("DONE: (Re-)published %s (%s failed after retries)", pluralize("ad", count - failed_count), failed_count)
-        else:
-            LOG.info("DONE: (Re-)published %s", pluralize("ad", count))
-        LOG.info("############################################")
+        await _publishing_workflow.publish_ads(
+            self, ad_cfgs,
+            root_url = self.root_url,
+            config = self.config,
+            keep_old_ads = self.keep_old_ads,
+            capture_diagnostics = self._capture_publish_error_diagnostics_if_enabled,
+            config_file_path = self.config_file_path,
+        )
 
     async def publish_ad(
         self, ad_file:str, ad_cfg:Ad, ad_cfg_orig:dict[str, Any], published_ads_list:list[PublishedAd], mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE
@@ -1004,51 +920,13 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         Returns:
             None
         """
-        old_ad_id = ad_cfg.id
-
-        if mode == AdUpdateStrategy.REPLACE:
-            await self._delete_old_ad_if_needed(ad_cfg, published_ads_list, timing = "BEFORE_PUBLISH")
-
-            # Apply auto price reduction in REPLACE mode (republish flow)
-            _price_reduction.apply_auto_price_reduction(
-                ad_cfg, ad_cfg_orig, _ad_state.relative_ad_path(
-                    ad_file, self.config_file_path), mode = AdUpdateStrategy.REPLACE)
-
-            LOG.info("Publishing ad '%s'...", ad_cfg.title)
-            await self.web_open(f"{self.root_url}/p-anzeige-aufgeben-schritt2.html", reload_if_already_open = True)
-        else:
-            # Always run restore-first when enabled so previously applied reductions
-            # are restored even when on_update is false.  The evaluator handles
-            # the on_update guard internally (returns early without advancing).
-            if ad_cfg.auto_price_reduction and ad_cfg.auto_price_reduction.enabled:
-                _price_reduction.apply_auto_price_reduction(
-                    ad_cfg, ad_cfg_orig, _ad_state.relative_ad_path(
-                        ad_file, self.config_file_path), mode = AdUpdateStrategy.MODIFY)
-
-            LOG.info("Updating ad '%s'...", ad_cfg.title)
-            await self.web_open(f"{self.root_url}/p-anzeige-bearbeiten.html?adId={ad_cfg.id}", reload_if_already_open = True)
-
-        await self._dismiss_consent_banner()
-
-        if _loggers.is_debug(LOG):
-            LOG.debug(" -> effective ad meta:")
-            YAML().dump(ad_cfg.model_dump(), sys.stdout)
-
-        if ad_cfg.type == "WANTED":
-            await self.web_click(By.ID, "ad-type-WANTED")
-
-        await _publishing_form.fill_ad_form(self, ad_file, ad_cfg, mode,
-            root_url = self.root_url, ad_defaults = self.config.ad_defaults)
-
-        ad_id = await _publishing_submission.submit_and_confirm_ad(self, ad_file, ad_cfg, mode, captcha_config = self.config.captcha)
-
-        try:
-            _publishing_persistence.persist_published_ad(ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode, config = self.config)
-        except Exception:
-            LOG.error(  # noqa: G201 — must use .error(exc_info=True) for translation lookup to resolve publish_ad
-                "Post-publish persistence failed for '%s' (ad ID %s - ad is live on Kleinanzeigen but local YAML may be out of sync)",
-                ad_cfg.title, ad_id, exc_info = True,
-            )
+        await _publishing_workflow.publish_ad(
+            self, ad_file, ad_cfg, ad_cfg_orig, published_ads_list, mode,
+            root_url = self.root_url,
+            config = self.config,
+            keep_old_ads = self.keep_old_ads,
+            config_file_path = self.config_file_path,
+        )
 
     async def update_ads(self, ad_cfgs:list[tuple[str, Ad, dict[str, Any]]]) -> None:
         """
@@ -1062,79 +940,14 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         Returns:
             None
         """
-        count = 0
-        failed_count = 0
-        max_retries = SUBMISSION_MAX_RETRIES
-
-        published_ads_list = await published_ads.fetch_published_ads(self, self.root_url)
-
-        for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ad_cfgs, start = 1):
-            LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ad_cfgs), ad_cfg.title, ad_file)
-
-            ad = next((published_ad for published_ad in published_ads_list if ad_matches_id(published_ad, ad_cfg.id)), None)
-
-            if not ad:
-                LOG.warning(" -> SKIPPED: ad '%s' (ID: %s) not found in published ads", ad_cfg.title, ad_cfg.id)
-                continue
-
-            if ad["state"] == "paused":
-                LOG.info("Skipping because ad is reserved")
-                continue
-
-            count += 1
-            success = False
-            baseline_price = ad_cfg.price
-            baseline_price_reduction_count = ad_cfg.price_reduction_count
-
-            for attempt in range(1, max_retries + 1):
-                try:
-                    ad_cfg.price = baseline_price
-                    ad_cfg.price_reduction_count = baseline_price_reduction_count
-                    await self.publish_ad(ad_file, ad_cfg, ad_cfg_orig, published_ads_list, AdUpdateStrategy.MODIFY)
-                    success = True
-                    break
-                except asyncio.CancelledError:
-                    raise
-                except PublishSubmissionUncertainError as ex:
-                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
-                    LOG.warning(
-                        "Attempt %s/%s for '%s' reached submit boundary but failed: %s. Not retrying to prevent duplicate modifications.",
-                        attempt,
-                        max_retries,
-                        ad_cfg.title,
-                        ex,
-                    )
-                    LOG.warning("Manual recovery required for '%s'. Check 'Meine Anzeigen' to confirm whether the update was applied.", ad_cfg.title)
-                    failed_count += 1
-                    break
-                except CategoryResolutionError as ex:
-                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
-                    LOG.error("Category resolution failed for '%s': %s. Skipping ad (configuration error, no retry).", ad_cfg.title, ex)
-                    failed_count += 1
-                    break
-                except (TimeoutError, ProtocolException) as ex:
-                    await self._capture_publish_error_diagnostics_if_enabled(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
-                    if attempt >= max_retries:
-                        LOG.error("All %s attempts failed for '%s': %s. Skipping ad.", max_retries, ad_cfg.title, ex)
-                        failed_count += 1
-                        break
-
-                    LOG.warning("Attempt %s/%s failed for '%s': %s. Retrying...", attempt, max_retries, ad_cfg.title, ex)
-                    await self.web_sleep(2_000)
-
-            if success:
-                try:
-                    publish_timeout = self.timeout("publishing_result")
-                    await self.web_await(self._check_publishing_result, timeout = publish_timeout)
-                except TimeoutError:
-                    LOG.warning(" -> Could not confirm update for '%s', but changes may be online", ad_cfg.title)
-
-        LOG.info("############################################")
-        if failed_count > 0:
-            LOG.info("DONE: updated %s (%s failed after retries)", pluralize("ad", count - failed_count), failed_count)
-        else:
-            LOG.info("DONE: updated %s", pluralize("ad", count))
-        LOG.info("############################################")
+        await _publishing_workflow.update_ads(
+            self, ad_cfgs,
+            root_url = self.root_url,
+            config = self.config,
+            keep_old_ads = self.keep_old_ads,
+            capture_diagnostics = self._capture_publish_error_diagnostics_if_enabled,
+            config_file_path = self.config_file_path,
+        )
 
 #############################
 # main entry point

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -1051,6 +1051,12 @@ async def fill_ad_form(
     sell-directly, description, contact, and images."""
 
     #############################
+    # set ad type (WANTED ads need to select the wanted-ad radio before form sections render)
+    #############################
+    if ad_cfg.type == "WANTED":
+        await web.web_click(By.ID, "ad-type-WANTED")
+
+    #############################
     # set category (before title to avoid form reset clearing title)
     #############################
     await set_category(web, root_url = root_url, category = ad_cfg.category, ad_file = ad_file)

--- a/src/kleinanzeigen_bot/publishing_workflow.py
+++ b/src/kleinanzeigen_bot/publishing_workflow.py
@@ -1,0 +1,444 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Orchestration for publishing and updating ads.
+
+This module owns publish/update orchestration prelude and sequencing,
+retry/uncertainty policy, delete-before/after-publish wiring, and the
+post-submit publishing result check.
+
+Does **not** own: form section details (:mod:`publishing_form`),
+captcha mechanics (:mod:`captcha_flow`), submit/confirm/ad-id recovery
+(:mod:`publishing_submission`), or YAML mutation/local path renaming
+(:mod:`publishing_persistence`).
+"""
+
+import asyncio
+import sys
+from collections.abc import Awaitable, Callable
+from typing import Any, Final
+
+from nodriver.core.connection import ProtocolException
+from ruamel.yaml import YAML
+
+from . import ad_state as _ad_state
+from . import delete_flow, published_ads
+from . import price_reduction as _price_reduction
+from . import publishing_form as _publishing_form
+from . import publishing_persistence as _publishing_persistence
+from . import publishing_submission as _publishing_submission
+from .model.ad_model import Ad, AdUpdateStrategy
+from .model.config_model import Config
+from .published_ads import PublishedAd, ad_matches_id
+from .utils import loggers as _loggers
+from .utils.exceptions import CategoryResolutionError, PublishSubmissionUncertainError
+from .utils.i18n import pluralize
+from .utils.web_scraping_mixin import By, Is, WebScrapingMixin
+
+LOG = _loggers.get_logger(__name__)
+
+SUBMISSION_MAX_RETRIES:Final[int] = 3
+
+
+async def check_publishing_result(web:WebScrapingMixin) -> bool:
+    """Check for publishing success messages (checking-done or not-completed)."""
+    return await web.web_check(By.ID, "checking-done", Is.DISPLAYED) or await web.web_check(By.ID, "not-completed", Is.DISPLAYED)
+
+
+async def delete_old_ad_if_needed(  # noqa: SLF001 — accessed by bot seam via publishing_workflow.delete_old_ad_if_needed
+    web:WebScrapingMixin,
+    ad_cfg:Ad,
+    published_ads_list:list[PublishedAd],
+    *,
+    timing:str,
+    keep_old_ads:bool,
+    config:Config,
+    root_url:str,
+) -> None:
+    """Delete an old ad before or after (re-)publishing, depending on config.
+
+    Skips deletion when *keep_old_ads* is True or when the configured
+    ``delete_old_ads`` timing does not match *timing*.
+
+    In ``AFTER_PUBLISH`` mode, title-based deletion is always disabled to
+    avoid accidentally removing the newly published ad.
+    """
+    if keep_old_ads:
+        return
+    if config.publishing.delete_old_ads != timing:
+        return
+    delete_old_ads_by_title = (
+        config.publishing.delete_old_ads_by_title
+        if timing == "BEFORE_PUBLISH" else False
+    )
+    await delete_flow.delete_ad(
+        web = web, root_url = root_url,
+        ad_cfg = ad_cfg,
+        published_ads_list = published_ads_list,
+        delete_old_ads_by_title = delete_old_ads_by_title,
+    )
+
+
+async def publish_ad(
+    web:WebScrapingMixin,
+    ad_file:str,
+    ad_cfg:Ad,
+    ad_cfg_orig:dict[str, Any],
+    published_ads_list:list[PublishedAd],
+    mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE,
+    *,
+    root_url:str,
+    config:Config,
+    keep_old_ads:bool,
+    config_file_path:str,
+) -> None:
+    """Publish or update an ad on Kleinanzeigen.
+
+    Args:
+        web: A WebScrapingMixin instance for browser interactions.
+        ad_file: Path to the ad configuration YAML file.
+        ad_cfg: The effective ad configuration with default values applied.
+        ad_cfg_orig: The original ad config as present in the YAML file.
+        published_ads_list: List of published ads from the API, used for
+            deduplication and old ad deletion.
+        mode: The ad editing strategy. REPLACE creates a new ad (full
+            republish), MODIFY updates an existing ad in-place.
+        root_url: Base Kleinanzeigen URL.
+        config: Full application config.
+        keep_old_ads: If True, skip old-ad deletion.
+        config_file_path: Path to the config file (for relative path
+            resolution).
+    """
+    old_ad_id = ad_cfg.id
+
+    if mode == AdUpdateStrategy.REPLACE:
+        await delete_old_ad_if_needed(
+            web, ad_cfg, published_ads_list,
+            timing = "BEFORE_PUBLISH",
+            keep_old_ads = keep_old_ads,
+            config = config,
+            root_url = root_url,
+        )
+
+        # Apply auto price reduction in REPLACE mode (republish flow)
+        _price_reduction.apply_auto_price_reduction(
+            ad_cfg, ad_cfg_orig,
+            _ad_state.relative_ad_path(ad_file, config_file_path),
+            mode = AdUpdateStrategy.REPLACE,
+        )
+
+        LOG.info("Publishing ad '%s'...", ad_cfg.title)
+        await web.web_open(f"{root_url}/p-anzeige-aufgeben-schritt2.html", reload_if_already_open = True)
+    else:
+        # Always run restore-first when enabled so previously applied reductions
+        # are restored even when on_update is false.  The evaluator handles
+        # the on_update guard internally (returns early without advancing).
+        if ad_cfg.auto_price_reduction and ad_cfg.auto_price_reduction.enabled:
+            _price_reduction.apply_auto_price_reduction(
+                ad_cfg, ad_cfg_orig,
+                _ad_state.relative_ad_path(ad_file, config_file_path),
+                mode = AdUpdateStrategy.MODIFY,
+            )
+
+        LOG.info("Updating ad '%s'...", ad_cfg.title)
+        await web.web_open(f"{root_url}/p-anzeige-bearbeiten.html?adId={ad_cfg.id}", reload_if_already_open = True)
+
+    await web._dismiss_consent_banner()  # noqa: SLF001 — called on WebScrapingMixin from same package
+
+    if _loggers.is_debug(LOG):
+        LOG.debug(" -> effective ad meta:")
+        YAML().dump(ad_cfg.model_dump(), sys.stdout)
+
+    await _publishing_form.fill_ad_form(
+        web, ad_file, ad_cfg, mode,
+        root_url = root_url, ad_defaults = config.ad_defaults,
+    )
+
+    ad_id = await _publishing_submission.submit_and_confirm_ad(
+        web, ad_file, ad_cfg, mode,
+        captcha_config = config.captcha,
+    )
+
+    try:
+        _publishing_persistence.persist_published_ad(
+            ad_file, ad_cfg, ad_cfg_orig, old_ad_id, ad_id, mode,
+            config = config,
+        )
+    except Exception:
+        LOG.error(  # noqa: G201 — must use .error(exc_info=True) for translation lookup
+            "Post-publish persistence failed for '%s' (ad ID %s - ad is live on "
+            "Kleinanzeigen but local YAML may be out of sync)",
+            ad_cfg.title, ad_id, exc_info = True,
+        )
+
+
+async def publish_ads(
+    web:WebScrapingMixin,
+    ad_cfgs:list[tuple[str, Ad, dict[str, Any]]],
+    *,
+    root_url:str,
+    config:Config,
+    keep_old_ads:bool,
+    capture_diagnostics:Callable[..., Awaitable[None]] | None = None,
+    config_file_path:str,
+) -> None:
+    """Publish multiple ads with retry and uncertainty handling.
+
+    Args:
+        web: A WebScrapingMixin instance for browser interactions.
+        ad_cfgs: List of (ad_file, ad_cfg, ad_cfg_orig) tuples.
+        root_url: Base Kleinanzeigen URL.
+        config: Full application config.
+        keep_old_ads: If True, skip old-ad deletion.
+        capture_diagnostics: Optional async callable that captures publish
+            error diagnostics. Expected signature:
+            ``(ad_cfg, ad_cfg_orig, ad_file, attempt, exc)``.
+        config_file_path: Path to the config file (for relative path
+            resolution).
+    """
+    count = 0
+    failed_count = 0
+    max_retries = SUBMISSION_MAX_RETRIES
+
+    published_ads_list = await published_ads.fetch_published_ads(web, root_url)
+
+    for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ad_cfgs, start = 1):
+        LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ad_cfgs), ad_cfg.title, ad_file)
+
+        if any(ad_matches_id(x, ad_cfg.id) and x.get("state") == "paused" for x in published_ads_list):
+            LOG.info("Skipping because ad is reserved")
+            continue
+
+        count += 1
+        success = False
+        baseline_price = ad_cfg.price
+        baseline_price_reduction_count = ad_cfg.price_reduction_count
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                # publish_ad mutates pricing fields before submit; reset them
+                # so retries remain idempotent for a single eligible reduction cycle.
+                ad_cfg.price = baseline_price
+                ad_cfg.price_reduction_count = baseline_price_reduction_count
+                await publish_ad(
+                    web, ad_file, ad_cfg, ad_cfg_orig,
+                    published_ads_list, AdUpdateStrategy.REPLACE,
+                    root_url = root_url, config = config,
+                    keep_old_ads = keep_old_ads,
+                    config_file_path = config_file_path,
+                )
+                success = True
+                break  # Publish succeeded, exit retry loop
+            except asyncio.CancelledError:
+                raise  # Respect task cancellation
+            except CategoryResolutionError as ex:
+                if capture_diagnostics:
+                    await capture_diagnostics(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                LOG.error(
+                    "Category resolution failed for '%s': %s. Skipping ad (configuration error, no retry).",
+                    ad_cfg.title, ex,
+                )
+                failed_count += 1
+                break
+            except PublishSubmissionUncertainError as ex:
+                if capture_diagnostics:
+                    await capture_diagnostics(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                LOG.warning(
+                    "Attempt %s/%s for '%s' reached submit boundary but failed: %s. "
+                    "Not retrying to prevent duplicate listings.",
+                    attempt, max_retries, ad_cfg.title, ex,
+                )
+                LOG.warning(
+                    "Manual recovery required for '%s'. Check 'Meine Anzeigen' to "
+                    "confirm whether the ad was posted.",
+                    ad_cfg.title,
+                )
+                LOG.warning(
+                    "If posted, sync local state with 'kleinanzeigen-bot download "
+                    "--ads=new' or 'kleinanzeigen-bot download --ads=<id>'; "
+                    "otherwise rerun publish for this ad.",
+                )
+                failed_count += 1
+                break
+            except (TimeoutError, ProtocolException) as ex:
+                if capture_diagnostics:
+                    await capture_diagnostics(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                if attempt >= max_retries:
+                    LOG.error(
+                        "All %s attempts failed for '%s': %s. Skipping ad.",
+                        max_retries, ad_cfg.title, ex,
+                    )
+                    failed_count += 1
+                    break
+
+                LOG.warning(
+                    "Attempt %s/%s failed for '%s': %s. Retrying...",
+                    attempt, max_retries, ad_cfg.title, ex,
+                )
+                await web.web_sleep(2_000)  # Wait before retry
+
+        # Check publishing result separately (no retry - ad is already submitted)
+        if success:
+            try:
+                publish_timeout = web.timeout("publishing_result")
+                await web.web_await(
+                    lambda: check_publishing_result(web),
+                    timeout = publish_timeout,
+                )
+            except TimeoutError:
+                LOG.warning(
+                    " -> Could not confirm publishing for '%s', but ad may be online",
+                    ad_cfg.title,
+                )
+
+            await delete_old_ad_if_needed(
+                web, ad_cfg, published_ads_list,
+                timing = "AFTER_PUBLISH",
+                keep_old_ads = keep_old_ads,
+                config = config,
+                root_url = root_url,
+            )
+
+    LOG.info("############################################")
+    if failed_count > 0:
+        LOG.info(
+            "DONE: (Re-)published %s (%s failed after retries)",
+            pluralize("ad", count - failed_count), failed_count,
+        )
+    else:
+        LOG.info("DONE: (Re-)published %s", pluralize("ad", count))
+    LOG.info("############################################")
+
+
+async def update_ads(
+    web:WebScrapingMixin,
+    ad_cfgs:list[tuple[str, Ad, dict[str, Any]]],
+    *,
+    root_url:str,
+    config:Config,
+    keep_old_ads:bool,
+    capture_diagnostics:Callable[..., Awaitable[None]] | None = None,
+    config_file_path:str,
+) -> None:
+    """Update multiple published ads with retry and uncertainty handling.
+
+    Filters to only already-published ads. Calls :func:`publish_ad` in
+    MODIFY mode.
+
+    Args:
+        web: A WebScrapingMixin instance for browser interactions.
+        ad_cfgs: List of (ad_file, ad_cfg, ad_cfg_orig) tuples.
+        root_url: Base Kleinanzeigen URL.
+        config: Full application config.
+        keep_old_ads: If True, skip old-ad deletion.
+        capture_diagnostics: Optional async callable that captures publish
+            error diagnostics. Expected signature:
+            ``(ad_cfg, ad_cfg_orig, ad_file, attempt, exc)``.
+        config_file_path: Path to the config file (for relative path
+            resolution).
+    """
+    count = 0
+    failed_count = 0
+    max_retries = SUBMISSION_MAX_RETRIES
+
+    published_ads_list = await published_ads.fetch_published_ads(web, root_url)
+
+    for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ad_cfgs, start = 1):
+        LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ad_cfgs), ad_cfg.title, ad_file)
+
+        ad = next((published_ad for published_ad in published_ads_list if ad_matches_id(published_ad, ad_cfg.id)), None)
+
+        if not ad:
+            LOG.warning(
+                " -> SKIPPED: ad '%s' (ID: %s) not found in published ads",
+                ad_cfg.title, ad_cfg.id,
+            )
+            continue
+
+        if ad["state"] == "paused":
+            LOG.info("Skipping because ad is reserved")
+            continue
+
+        count += 1
+        success = False
+        baseline_price = ad_cfg.price
+        baseline_price_reduction_count = ad_cfg.price_reduction_count
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                ad_cfg.price = baseline_price
+                ad_cfg.price_reduction_count = baseline_price_reduction_count
+                await publish_ad(
+                    web, ad_file, ad_cfg, ad_cfg_orig,
+                    published_ads_list, AdUpdateStrategy.MODIFY,
+                    root_url = root_url, config = config,
+                    keep_old_ads = keep_old_ads,
+                    config_file_path = config_file_path,
+                )
+                success = True
+                break
+            except asyncio.CancelledError:
+                raise
+            except PublishSubmissionUncertainError as ex:
+                if capture_diagnostics:
+                    await capture_diagnostics(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                LOG.warning(
+                    "Attempt %s/%s for '%s' reached submit boundary but failed: %s. "
+                    "Not retrying to prevent duplicate modifications.",
+                    attempt, max_retries, ad_cfg.title, ex,
+                )
+                LOG.warning(
+                    "Manual recovery required for '%s'. Check 'Meine Anzeigen' to "
+                    "confirm whether the update was applied.",
+                    ad_cfg.title,
+                )
+                failed_count += 1
+                break
+            except CategoryResolutionError as ex:
+                if capture_diagnostics:
+                    await capture_diagnostics(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                LOG.error(
+                    "Category resolution failed for '%s': %s. Skipping ad (configuration error, no retry).",
+                    ad_cfg.title, ex,
+                )
+                failed_count += 1
+                break
+            except (TimeoutError, ProtocolException) as ex:
+                if capture_diagnostics:
+                    await capture_diagnostics(ad_cfg, ad_cfg_orig, ad_file, attempt, ex)
+                if attempt >= max_retries:
+                    LOG.error(
+                        "All %s attempts failed for '%s': %s. Skipping ad.",
+                        max_retries, ad_cfg.title, ex,
+                    )
+                    failed_count += 1
+                    break
+
+                LOG.warning(
+                    "Attempt %s/%s failed for '%s': %s. Retrying...",
+                    attempt, max_retries, ad_cfg.title, ex,
+                )
+                await web.web_sleep(2_000)
+
+        if success:
+            try:
+                publish_timeout = web.timeout("publishing_result")
+                await web.web_await(
+                    lambda: check_publishing_result(web),
+                    timeout = publish_timeout,
+                )
+            except TimeoutError:
+                LOG.warning(
+                    " -> Could not confirm update for '%s', but changes may be online",
+                    ad_cfg.title,
+                )
+
+    LOG.info("############################################")
+    if failed_count > 0:
+        LOG.info(
+            "DONE: updated %s (%s failed after retries)",
+            pluralize("ad", count - failed_count), failed_count,
+        )
+    else:
+        LOG.info("DONE: updated %s", pluralize("ad", count))
+    LOG.info("############################################")

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -119,6 +119,32 @@ kleinanzeigen_bot/__init__.py:
   handle_after_login_logic:
     "Handling GDPR disclaimer...": "Verarbeite DSGVO-Hinweis..."
 
+  run:
+    "DONE: No configuration errors found.": "FERTIG: Keine Konfigurationsfehler gefunden."
+    "DONE: No active ads found.": "FERTIG: Keine aktiven Anzeigen gefunden."
+    "Invalid --ads selector: \"%s\". Valid values: comma-separated keywords (all, new, due, changed) or numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: kommagetrennte Schlüsselwörter (all, new, due, changed) oder numerische IDs."
+    "Invalid --ads selector: \"%s\". Valid values: comma-separated keywords (all, changed) or numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: kommagetrennte Schlüsselwörter (all, changed) oder numerische IDs."
+    "Invalid --ads selector: \"%s\". Valid values: comma-separated keywords (all, new) or numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: kommagetrennte Schlüsselwörter (all, new) oder numerische IDs."
+    "Invalid --ads selector: \"%s\". Valid values: all or comma-separated numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: all oder kommagetrennte numerische IDs."
+    "DONE: No new/outdated ads found.": "FERTIG: Keine neuen/veralteten Anzeigen gefunden."
+    "DONE: No ads to delete found.": "FERTIG: Keine zu löschenden Anzeigen gefunden."
+    "DONE: No changed ads found.": "FERTIG: Keine geänderten Anzeigen gefunden."
+    "Extending all ads within 8-day window...": "Verlängere alle Anzeigen innerhalb des 8-Tage-Zeitfensters..."
+    "DONE: No ads found to extend.": "FERTIG: Keine Anzeigen zum Verlängern gefunden."
+    "Unknown command: %s": "Unbekannter Befehl: %s"
+    "Timing collector flush failed: %s": "Zeitmessdaten konnten nicht gespeichert werden: %s"
+
+#################################################
+kleinanzeigen_bot/publishing_workflow.py:
+
+#################################################
+
+  publish_ad:
+    "Publishing ad '%s'...": "Veröffentliche Anzeige '%s'..."
+    "Updating ad '%s'...": "Aktualisiere Anzeige '%s'..."
+    " -> effective ad meta:": " -> effektive Anzeigen-Metadaten:"
+    "Post-publish persistence failed for '%s' (ad ID %s - ad is live on Kleinanzeigen but local YAML may be out of sync)": "Persistenz nach Veröffentlichung fehlgeschlagen für '%s' (Anzeigen-ID %s - Anzeige ist auf Kleinanzeigen live, aber die lokale YAML ist möglicherweise nicht synchron)"
+
   publish_ads:
     "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' von [%s]..."
     "Skipping because ad is reserved": "Überspringen, da Anzeige reserviert ist"
@@ -134,14 +160,6 @@ kleinanzeigen_bot/__init__.py:
     "DONE: (Re-)published %s": "FERTIG: %s (erneut) veröffentlicht"
     "ad": "Anzeige"
 
-  publish_ad:
-    "Publishing ad '%s'...": "Veröffentliche Anzeige '%s'..."
-    "Updating ad '%s'...": "Aktualisiere Anzeige '%s'..."
-    " -> effective ad meta:": " -> effektive Anzeigen-Metadaten:"
-    "Post-publish persistence failed for '%s' (ad ID %s - ad is live on Kleinanzeigen but local YAML may be out of sync)": "Persistenz nach Veröffentlichung fehlgeschlagen für '%s' (Anzeigen-ID %s - Anzeige ist auf Kleinanzeigen live, aber die lokale YAML ist möglicherweise nicht synchron)"
-
-  _fill_ad_form:
-
   update_ads:
     "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' von [%s]..."
     "Skipping because ad is reserved": "Überspringen, da Anzeige reserviert ist"
@@ -155,21 +173,6 @@ kleinanzeigen_bot/__init__.py:
     "DONE: updated %s (%s failed after retries)": "FERTIG: %s aktualisiert (%s nach Wiederholungen fehlgeschlagen)"
     "DONE: updated %s": "FERTIG: %s aktualisiert"
     "ad": "Anzeige"
-
-  run:
-    "DONE: No configuration errors found.": "FERTIG: Keine Konfigurationsfehler gefunden."
-    "DONE: No active ads found.": "FERTIG: Keine aktiven Anzeigen gefunden."
-    "Invalid --ads selector: \"%s\". Valid values: comma-separated keywords (all, new, due, changed) or numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: kommagetrennte Schlüsselwörter (all, new, due, changed) oder numerische IDs."
-    "Invalid --ads selector: \"%s\". Valid values: comma-separated keywords (all, changed) or numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: kommagetrennte Schlüsselwörter (all, changed) oder numerische IDs."
-    "Invalid --ads selector: \"%s\". Valid values: comma-separated keywords (all, new) or numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: kommagetrennte Schlüsselwörter (all, new) oder numerische IDs."
-    "Invalid --ads selector: \"%s\". Valid values: all or comma-separated numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: all oder kommagetrennte numerische IDs."
-    "DONE: No new/outdated ads found.": "FERTIG: Keine neuen/veralteten Anzeigen gefunden."
-    "DONE: No ads to delete found.": "FERTIG: Keine zu löschenden Anzeigen gefunden."
-    "DONE: No changed ads found.": "FERTIG: Keine geänderten Anzeigen gefunden."
-    "Extending all ads within 8-day window...": "Verlängere alle Anzeigen innerhalb des 8-Tage-Zeitfensters..."
-    "DONE: No ads found to extend.": "FERTIG: Keine Anzeigen zum Verlängern gefunden."
-    "Unknown command: %s": "Unbekannter Befehl: %s"
-    "Timing collector flush failed: %s": "Zeitmessdaten konnten nicht gespeichert werden: %s"
 
 #################################################
 kleinanzeigen_bot/published_ads.py:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -12,7 +12,6 @@ import pytest
 from nodriver.core.connection import ProtocolException
 
 from kleinanzeigen_bot import (
-    SUBMISSION_MAX_RETRIES,
     KleinanzeigenBot,
     LoginDetectionReason,
     LoginDetectionResult,
@@ -26,6 +25,7 @@ from kleinanzeigen_bot.model.config_model import (
     DiagnosticsConfig,
     PublishingConfig,
 )
+from kleinanzeigen_bot.publishing_workflow import SUBMISSION_MAX_RETRIES
 from kleinanzeigen_bot.utils import xdg_paths
 from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError, PublishSubmissionUncertainError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
@@ -881,7 +881,7 @@ class TestKleinanzeigenBotDiagnostics:
 
         with (
             patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
         ):
             await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
 
@@ -923,7 +923,7 @@ class TestKleinanzeigenBotDiagnostics:
 
         with (
             patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
         ):
             await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
 
@@ -955,7 +955,7 @@ class TestKleinanzeigenBotDiagnostics:
 
         with (
             patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps({"ads": []})}),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
         ):
             await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
 
@@ -992,7 +992,7 @@ class TestKleinanzeigenBotBasics:
 
         with (
             patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps(payload)}) as web_request_mock,
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_ad_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_ad_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True) as web_await_mock,
             patch("kleinanzeigen_bot.delete_flow.delete_ad", new_callable = AsyncMock) as delete_ad_mock,
         ):
@@ -1001,7 +1001,12 @@ class TestKleinanzeigenBotBasics:
             # web_request is called once for initial published-ads snapshot
             expected_url = f"{test_bot.root_url}/m-meine-anzeigen-verwalten.json?sort=DEFAULT&pageNum=1"
             web_request_mock.assert_awaited_once_with(expected_url)
-            publish_ad_mock.assert_awaited_once_with("ad.yaml", ad_cfgs[0][1], {}, [], AdUpdateStrategy.REPLACE)
+            publish_ad_mock.assert_awaited_once()
+            call_args = publish_ad_mock.call_args
+            assert call_args is not None
+            assert call_args.args[1] == "ad.yaml"
+            assert call_args.args[2] is ad_cfgs[0][1]
+            assert call_args.args[5] == AdUpdateStrategy.REPLACE
             web_await_mock.assert_awaited_once()
             delete_ad_mock.assert_awaited_once_with(
                 web = test_bot, root_url = test_bot.root_url,
@@ -1028,11 +1033,13 @@ class TestKleinanzeigenBotBasics:
         seen_prices:list[tuple[int | None, int | None]] = []
 
         async def publish_side_effect(
+            _web:Any,
             _ad_file:str,
             candidate_cfg:Ad,
             _candidate_orig:dict[str, Any],
             _published_ads:list[dict[str, Any]],
             _mode:AdUpdateStrategy,
+            **kwargs:Any,
         ) -> None:
             seen_prices.append((candidate_cfg.price, candidate_cfg.price_reduction_count))
             if len(seen_prices) == 1:
@@ -1043,7 +1050,7 @@ class TestKleinanzeigenBotBasics:
 
         with (
             patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
@@ -1075,9 +1082,8 @@ class TestKleinanzeigenBotBasics:
                 new_callable = AsyncMock,
                 return_value = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})},
             ),
-            patch.object(
-                test_bot,
-                "publish_ad",
+            patch(
+                "kleinanzeigen_bot.publishing_workflow.publish_ad",
                 new_callable = AsyncMock,
                 side_effect = PublishSubmissionUncertainError("submission may have succeeded before failure"),
             ) as publish_mock,
@@ -1109,9 +1115,8 @@ class TestKleinanzeigenBotBasics:
                 new_callable = AsyncMock,
                 return_value = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})},
             ),
-            patch.object(
-                test_bot,
-                "publish_ad",
+            patch(
+                "kleinanzeigen_bot.publishing_workflow.publish_ad",
                 new_callable = AsyncMock,
                 side_effect = CategoryResolutionError("no suggestion matched"),
             ) as publish_mock,
@@ -1409,26 +1414,28 @@ class TestKleinanzeigenBotUpdateAdsResilience:
         ad_two = self._build_update_ad(base_ad_config, 102, "Success Ad")
 
         async def publish_side_effect(
+            _web:Any,
             _ad_file:str,
             ad_cfg:Ad,
             _ad_cfg_orig:dict[str, Any],
             _published_ads:list[dict[str, Any]],
             _mode:AdUpdateStrategy,
+            **kwargs:Any,
         ) -> None:
             if ad_cfg.id == 101:
                 raise first_failure
 
         with (
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(101, 102)),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
             await test_bot.update_ads([ad_one, ad_two])
 
         assert publish_mock.await_count == SUBMISSION_MAX_RETRIES + 1
-        assert any(call.args[1].id == 102 for call in publish_mock.await_args_list)
-        assert all(call.args[4] == AdUpdateStrategy.MODIFY for call in publish_mock.await_args_list)
+        assert any(call.args[2].id == 102 for call in publish_mock.await_args_list)
+        assert all(call.args[5] == AdUpdateStrategy.MODIFY for call in publish_mock.await_args_list)
         assert sleep_mock.await_count == SUBMISSION_MAX_RETRIES - 1
 
     @pytest.mark.asyncio
@@ -1437,18 +1444,20 @@ class TestKleinanzeigenBotUpdateAdsResilience:
         ad_two = self._build_update_ad(base_ad_config, 302, "Second Update")
 
         async def publish_side_effect(
+            _web:Any,
             _ad_file:str,
             ad_cfg:Ad,
             _ad_cfg_orig:dict[str, Any],
             _published_ads:list[dict[str, Any]],
             _mode:AdUpdateStrategy,
+            **kwargs:Any,
         ) -> None:
             if ad_cfg.id == 301:
                 raise PublishSubmissionUncertainError("submission may have succeeded before failure")
 
         with (
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(301, 302)),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
@@ -1463,24 +1472,26 @@ class TestKleinanzeigenBotUpdateAdsResilience:
         ad_two = self._build_update_ad(base_ad_config, 304, "Second Update")
 
         async def publish_side_effect(
+            _web:Any,
             _ad_file:str,
             ad_cfg:Ad,
             _ad_cfg_orig:dict[str, Any],
             _published_ads:list[dict[str, Any]],
             _mode:AdUpdateStrategy,
+            **kwargs:Any,
         ) -> None:
             if ad_cfg.id == 303:
                 raise CategoryResolutionError("no suggestion matched")
 
         with (
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(303, 304)),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
             await test_bot.update_ads([ad_one, ad_two])
 
-        assert [call.args[1].id for call in publish_mock.await_args_list] == [303, 304]
+        assert [call.args[2].id for call in publish_mock.await_args_list] == [303, 304]
         sleep_mock.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1490,7 +1501,7 @@ class TestKleinanzeigenBotUpdateAdsResilience:
 
         with (
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(401, 402)),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock, side_effect = asyncio.CancelledError()) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = asyncio.CancelledError()) as publish_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
             pytest.raises(asyncio.CancelledError),
         ):
@@ -1504,7 +1515,7 @@ class TestKleinanzeigenBotUpdateAdsResilience:
 
         with (
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = self._build_published_ads(501)),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = TimeoutError("result timeout")),
         ):
             await test_bot.update_ads([ad_one])
@@ -1539,7 +1550,7 @@ class TestDisplayCounterProgression:
         with (
             caplog.at_level(logging.INFO),
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
             await test_bot.publish_ads(ad_cfgs)
@@ -1554,7 +1565,7 @@ class TestDisplayCounterProgression:
         assert len(skip_msgs) == 2
 
         publish_mock.assert_awaited_once()
-        assert publish_mock.call_args.args[1].id == 102
+        assert publish_mock.call_args.args[2].id == 102
 
         summary = [r for r in caplog.records if "DONE:" in r.message]
         assert any("1 ad" in r.message for r in summary)
@@ -1574,7 +1585,7 @@ class TestDisplayCounterProgression:
         with (
             caplog.at_level(logging.INFO),
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
@@ -1590,7 +1601,7 @@ class TestDisplayCounterProgression:
         assert len(skip_msgs) == 2
 
         publish_mock.assert_awaited_once()
-        assert publish_mock.call_args.args[1].id == 202
+        assert publish_mock.call_args.args[2].id == 202
 
         summary = [r for r in caplog.records if "DONE:" in r.message]
         assert any("1 ad" in r.message for r in summary)
@@ -1609,7 +1620,7 @@ class TestDisplayCounterProgression:
         with (
             caplog.at_level(logging.INFO),
             patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
-            patch.object(test_bot, "publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
         ):
@@ -1625,7 +1636,7 @@ class TestDisplayCounterProgression:
         assert len(skip_msgs) == 1
 
         publish_mock.assert_awaited_once()
-        assert publish_mock.call_args.args[1].id == 302
+        assert publish_mock.call_args.args[2].id == 302
 
 
 class TestKleinanzeigenBotCommands:

--- a/tests/unit/test_publishing_persistence.py
+++ b/tests/unit/test_publishing_persistence.py
@@ -296,7 +296,7 @@ async def test_publish_ad_survives_persistence_failure() -> None:
     bot.config = cfg
 
     with (
-        patch.object(bot, "_delete_old_ad_if_needed", new_callable = AsyncMock),
+        patch("kleinanzeigen_bot.publishing_workflow.delete_old_ad_if_needed", new_callable = AsyncMock),
         patch.object(bot, "web_open", new_callable = AsyncMock),
         patch.object(bot, "_dismiss_consent_banner", new_callable = AsyncMock),
         patch("kleinanzeigen_bot.publishing_form.fill_ad_form", new_callable = AsyncMock),

--- a/tests/unit/test_translations.py
+++ b/tests/unit/test_translations.py
@@ -27,7 +27,8 @@ from kleinanzeigen_bot import resources
 
 # Messages that are intentionally not translated (internal/debug messages)
 EXCLUDED_MESSAGES:dict[str, set[str]] = {
-    "kleinanzeigen_bot/__init__.py": {"############################################"}
+    "kleinanzeigen_bot/__init__.py": {"############################################"},
+    "kleinanzeigen_bot/publishing_workflow.py": {"############################################"},
 }
 
 # Special modules that are known to be needed even if not in messages_by_file


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): N/A
- Extracts publish/update orchestration from the monolithic bot class into `publishing_workflow.py` as Step 21 of the monolith breakdown.

## 📋 Changes Summary

- Added `src/kleinanzeigen_bot/publishing_workflow.py` for publish/update orchestration, retry/uncertainty handling, result checks, and delete-before/after-publish wiring.
- Kept `KleinanzeigenBot` publish/update methods as narrow delegation seams with explicit dependencies.
- Moved WANTED ad type selection into `publishing_form.fill_ad_form()` so form details stay in the form module.
- Updated German translations and unit tests to patch concrete workflow module paths.
- No dependency or configuration changes.

### ⚙️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)
- [x] Refactor (no user-facing behavior change)

## ✅ Checklist

Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form rendering for WANTED ad type by ensuring the ad type is pre-selected before populating other form fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->