### PR TITLE
refactor: move publishing orchestration tests

### DIFF
--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-import copy, fnmatch, json, logging, os  # isort: skip
+import copy, fnmatch, json, os  # isort: skip
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
@@ -25,9 +25,8 @@ from kleinanzeigen_bot.model.config_model import (
 )
 from kleinanzeigen_bot.publishing_workflow import SUBMISSION_MAX_RETRIES
 from kleinanzeigen_bot.utils import xdg_paths
-from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError, PublishSubmissionUncertainError
+from kleinanzeigen_bot.utils.exceptions import PublishSubmissionUncertainError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
-from tests.conftest import build_published_ads, build_update_ad
 
 
 @pytest.fixture
@@ -285,158 +284,6 @@ class TestKleinanzeigenBotBasics:
         assert test_bot.get_version() == __version__
 
     @pytest.mark.asyncio
-    async def test_publish_ads_triggers_publish_and_cleanup(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-    ) -> None:
-        """Simulate publish job wiring without hitting the live site."""
-        test_bot.page = mock_page
-        test_bot.config.publishing.delete_old_ads = "AFTER_PUBLISH"
-        test_bot.keep_old_ads = False
-
-        payload:dict[str, list[Any]] = {"ads": []}
-        ad_cfgs:list[tuple[str, Ad, dict[str, Any]]] = [("ad.yaml", Ad.model_validate(base_ad_config), {})]
-
-        with (
-            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps(payload)}) as web_request_mock,
-            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_ad_mock,
-            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True) as web_await_mock,
-            patch("kleinanzeigen_bot.delete_flow.delete_ad", new_callable = AsyncMock) as delete_ad_mock,
-        ):
-            await test_bot.publish_ads(ad_cfgs)
-
-            # web_request is called once for initial published-ads snapshot
-            expected_url = f"{test_bot.root_url}/m-meine-anzeigen-verwalten.json?sort=DEFAULT&pageNum=1"
-            web_request_mock.assert_awaited_once_with(expected_url)
-            publish_ad_mock.assert_awaited_once()
-            call_args = publish_ad_mock.call_args
-            assert call_args is not None
-            assert call_args.args[1] == "ad.yaml"
-            assert call_args.args[2] is ad_cfgs[0][1]
-            assert call_args.args[5] == AdUpdateStrategy.REPLACE
-            web_await_mock.assert_awaited_once()
-            delete_ad_mock.assert_awaited_once_with(
-                web = test_bot, root_url = test_bot.root_url,
-                ad_cfg = ad_cfgs[0][1],
-                published_ads_list = [],
-                delete_old_ads_by_title = False,
-            )
-
-    @pytest.mark.asyncio
-    async def test_publish_ads_uses_millisecond_retry_delay_on_retryable_failure(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-    ) -> None:
-        """Retry branch should sleep with explicit millisecond delay and reset price-reduction mutations."""
-        test_bot.page = mock_page
-        test_bot.keep_old_ads = True
-
-        ad_cfg = Ad.model_validate(base_ad_config | {"price": 100, "price_reduction_count": 0, "repost_count": 1})
-        ad_cfg_orig = copy.deepcopy(base_ad_config)
-        ad_file = "ad.yaml"
-        ads_response = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})}
-        seen_prices:list[tuple[int | None, int | None]] = []
-
-        async def publish_side_effect(
-            _web:Any,
-            _ad_file:str,
-            candidate_cfg:Ad,
-            _candidate_orig:dict[str, Any],
-            _published_ads:list[dict[str, Any]],
-            _mode:AdUpdateStrategy,
-            **kwargs:Any,
-        ) -> None:
-            seen_prices.append((candidate_cfg.price, candidate_cfg.price_reduction_count))
-            if len(seen_prices) == 1:
-                # Simulate in-memory mutation done by apply_auto_price_reduction before a failed attempt.
-                candidate_cfg.price = 90
-                candidate_cfg.price_reduction_count = 1
-                raise TimeoutError("transient")
-
-        with (
-            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
-            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
-            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
-        ):
-            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
-
-            assert publish_mock.await_count == 2
-            assert seen_prices == [(100, 0), (100, 0)]
-            sleep_mock.assert_awaited_once_with(2_000)
-
-    @pytest.mark.asyncio
-    async def test_publish_ads_does_not_retry_when_submission_state_is_uncertain(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-    ) -> None:
-        """Post-submit uncertainty must fail closed and skip retries."""
-        test_bot.page = mock_page
-        test_bot.keep_old_ads = True
-
-        ad_cfg = Ad.model_validate(base_ad_config)
-        ad_cfg_orig = copy.deepcopy(base_ad_config)
-        ad_file = "ad.yaml"
-
-        with (
-            patch.object(
-                test_bot,
-                "web_request",
-                new_callable = AsyncMock,
-                return_value = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})},
-            ),
-            patch(
-                "kleinanzeigen_bot.publishing_workflow.publish_ad",
-                new_callable = AsyncMock,
-                side_effect = PublishSubmissionUncertainError("submission may have succeeded before failure"),
-            ) as publish_mock,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
-        ):
-            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
-
-            assert publish_mock.await_count == 1
-            sleep_mock.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_publish_ads_does_not_retry_on_category_resolution_error(
-        self,
-        test_bot:KleinanzeigenBot,
-        base_ad_config:dict[str, Any],
-        mock_page:MagicMock,
-    ) -> None:
-        """CategoryResolutionError is deterministic configuration failure -> no retry, fail fast."""
-        test_bot.page = mock_page
-        test_bot.keep_old_ads = True
-
-        ad_cfg = Ad.model_validate(base_ad_config)
-        ad_cfg_orig = copy.deepcopy(base_ad_config)
-
-        with (
-            patch.object(
-                test_bot,
-                "web_request",
-                new_callable = AsyncMock,
-                return_value = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})},
-            ),
-            patch(
-                "kleinanzeigen_bot.publishing_workflow.publish_ad",
-                new_callable = AsyncMock,
-                side_effect = CategoryResolutionError("no suggestion matched"),
-            ) as publish_mock,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
-        ):
-            await test_bot.publish_ads([("ad.yaml", ad_cfg, ad_cfg_orig)])
-
-            assert publish_mock.await_count == 1
-            sleep_mock.assert_not_awaited()
-
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("mode", "expected_path"),
         [
@@ -691,113 +538,6 @@ class TestKleinanzeigenBotBasics:
         test_categories = {"test_cat": "test_id"}
         test_bot.categories = test_categories
         assert test_bot.categories == test_categories
-
-
-class TestDisplayCounterProgression:
-    """Regression tests for issue #977: progress counter must increment for every ad, including skipped ones."""
-
-    @pytest.mark.asyncio
-    async def test_publish_ads_counter_progression_with_paused_ads(
-        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
-    ) -> None:
-        """Display counter must advance for paused ads, and only non-paused ads are published."""
-        ad_cfgs = [
-            build_update_ad(base_ad_config, 101, "Paused Ad 1"),
-            build_update_ad(base_ad_config, 102, "Active Ad 102"),
-            build_update_ad(base_ad_config, 103, "Paused Ad 2"),
-        ]
-        published_ads = build_published_ads((101, "paused"), (102, "active"), (103, "paused"))
-
-        with (
-            caplog.at_level(logging.INFO),
-            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
-            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
-            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
-        ):
-            await test_bot.publish_ads(ad_cfgs)
-
-        processing = [r for r in caplog.records if r.message.startswith("Processing")]
-        assert len(processing) == 3
-        assert "1/3" in processing[0].message
-        assert "2/3" in processing[1].message
-        assert "3/3" in processing[2].message
-
-        skip_msgs = [r for r in caplog.records if "Skipping because ad is reserved" in r.message]
-        assert len(skip_msgs) == 2
-
-        publish_mock.assert_awaited_once()
-        assert publish_mock.call_args.args[2].id == 102
-
-        summary = [r for r in caplog.records if "DONE:" in r.message]
-        assert any("1 ad" in r.message for r in summary)
-
-    @pytest.mark.asyncio
-    async def test_update_ads_counter_progression_with_paused_ads(
-        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
-    ) -> None:
-        """Display counter must advance for paused ads, and only non-paused ads are updated."""
-        ad_cfgs = [
-            build_update_ad(base_ad_config, 201, "Paused Ad 1"),
-            build_update_ad(base_ad_config, 202, "Active Ad 202"),
-            build_update_ad(base_ad_config, 203, "Paused Ad 2"),
-        ]
-        published_ads = build_published_ads((201, "paused"), (202, "active"), (203, "paused"))
-
-        with (
-            caplog.at_level(logging.INFO),
-            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
-            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
-        ):
-            await test_bot.update_ads(ad_cfgs)
-
-        processing = [r for r in caplog.records if r.message.startswith("Processing")]
-        assert len(processing) == 3
-        assert "1/3" in processing[0].message
-        assert "2/3" in processing[1].message
-        assert "3/3" in processing[2].message
-
-        skip_msgs = [r for r in caplog.records if "Skipping because ad is reserved" in r.message]
-        assert len(skip_msgs) == 2
-
-        publish_mock.assert_awaited_once()
-        assert publish_mock.call_args.args[2].id == 202
-
-        summary = [r for r in caplog.records if "DONE:" in r.message]
-        assert any("1 ad" in r.message for r in summary)
-
-    @pytest.mark.asyncio
-    async def test_update_ads_counter_includes_not_found_ads(
-        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
-    ) -> None:
-        """Display counter must advance even for ads not found in published ads."""
-        ad_cfgs = [
-            build_update_ad(base_ad_config, 301, "Not Found Ad"),
-            build_update_ad(base_ad_config, 302, "Active Ad 302"),
-        ]
-        published_ads = build_published_ads((302, "active"))
-
-        with (
-            caplog.at_level(logging.INFO),
-            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
-            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
-        ):
-            await test_bot.update_ads(ad_cfgs)
-
-        processing = [r for r in caplog.records if r.message.startswith("Processing")]
-        assert len(processing) == 2
-        assert "1/2" in processing[0].message
-        assert "2/2" in processing[1].message
-        assert "Not Found Ad" in processing[0].message
-
-        skip_msgs = [r for r in caplog.records if "SKIPPED" in r.message and "not found" in r.message]
-        assert len(skip_msgs) == 1
-
-        publish_mock.assert_awaited_once()
-        assert publish_mock.call_args.args[2].id == 302
 
 
 class TestKleinanzeigenBotCommands:

--- a/tests/unit/test_publishing_workflow.py
+++ b/tests/unit/test_publishing_workflow.py
@@ -4,6 +4,9 @@
 """Tests for publishing workflow orchestration."""
 
 import asyncio
+import copy
+import json
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +18,17 @@ from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.publishing_workflow import SUBMISSION_MAX_RETRIES
 from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError, PublishSubmissionUncertainError
 from tests.conftest import build_published_ads, build_update_ad
+
+
+@pytest.fixture
+def mock_page() -> MagicMock:
+    """Provide a mock page object for testing."""
+    mock = MagicMock()
+    mock.sleep = AsyncMock()
+    mock.evaluate = AsyncMock()
+    mock.click = AsyncMock()
+    mock.type = AsyncMock()
+    return mock
 
 
 class TestKleinanzeigenBotUpdateAdsResilience:
@@ -167,3 +181,266 @@ class TestKleinanzeigenBotUpdateAdsResilience:
             await test_bot.update_ads([ad_one])
 
         publish_mock.assert_awaited_once()
+
+
+class TestKleinanzeigenBotPublishAdsBasics:
+    """Publish-ads orchestration tests moved from TestKleinanzeigenBotBasics."""
+
+    @pytest.mark.asyncio
+    async def test_publish_ads_triggers_publish_and_cleanup(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """Simulate publish job wiring without hitting the live site."""
+        test_bot.page = mock_page
+        test_bot.config.publishing.delete_old_ads = "AFTER_PUBLISH"
+        test_bot.keep_old_ads = False
+
+        payload:dict[str, list[Any]] = {"ads": []}
+        ad_cfgs:list[tuple[str, Ad, dict[str, Any]]] = [("ad.yaml", Ad.model_validate(base_ad_config), {})]
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps(payload)}) as web_request_mock,
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_ad_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True) as web_await_mock,
+            patch("kleinanzeigen_bot.delete_flow.delete_ad", new_callable = AsyncMock) as delete_ad_mock,
+        ):
+            await test_bot.publish_ads(ad_cfgs)
+
+            # web_request is called once for initial published-ads snapshot
+            expected_url = f"{test_bot.root_url}/m-meine-anzeigen-verwalten.json?sort=DEFAULT&pageNum=1"
+            web_request_mock.assert_awaited_once_with(expected_url)
+            publish_ad_mock.assert_awaited_once()
+            call_args = publish_ad_mock.call_args
+            assert call_args is not None
+            assert call_args.args[1] == "ad.yaml"
+            assert call_args.args[2] is ad_cfgs[0][1]
+            assert call_args.args[5] == AdUpdateStrategy.REPLACE
+            web_await_mock.assert_awaited_once()
+            delete_ad_mock.assert_awaited_once_with(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfg = ad_cfgs[0][1],
+                published_ads_list = [],
+                delete_old_ads_by_title = False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_publish_ads_uses_millisecond_retry_delay_on_retryable_failure(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """Retry branch should sleep with explicit millisecond delay and reset price-reduction mutations."""
+        test_bot.page = mock_page
+        test_bot.keep_old_ads = True
+
+        ad_cfg = Ad.model_validate(base_ad_config | {"price": 100, "price_reduction_count": 0, "repost_count": 1})
+        ad_cfg_orig = copy.deepcopy(base_ad_config)
+        ad_file = "ad.yaml"
+        ads_response = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})}
+        seen_prices:list[tuple[int | None, int | None]] = []
+
+        async def publish_side_effect(
+            _web:Any,
+            _ad_file:str,
+            candidate_cfg:Ad,
+            _candidate_orig:dict[str, Any],
+            _published_ads:list[dict[str, Any]],
+            _mode:AdUpdateStrategy,
+            **kwargs:Any,
+        ) -> None:
+            seen_prices.append((candidate_cfg.price, candidate_cfg.price_reduction_count))
+            if len(seen_prices) == 1:
+                # Simulate in-memory mutation done by apply_auto_price_reduction before a failed attempt.
+                candidate_cfg.price = 90
+                candidate_cfg.price_reduction_count = 1
+                raise TimeoutError("transient")
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = publish_side_effect) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
+
+            assert publish_mock.await_count == 2
+            assert seen_prices == [(100, 0), (100, 0)]
+            sleep_mock.assert_awaited_once_with(2_000)
+
+    @pytest.mark.asyncio
+    async def test_publish_ads_does_not_retry_when_submission_state_is_uncertain(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """Post-submit uncertainty must fail closed and skip retries."""
+        test_bot.page = mock_page
+        test_bot.keep_old_ads = True
+
+        ad_cfg = Ad.model_validate(base_ad_config)
+        ad_cfg_orig = copy.deepcopy(base_ad_config)
+        ad_file = "ad.yaml"
+
+        with (
+            patch.object(
+                test_bot,
+                "web_request",
+                new_callable = AsyncMock,
+                return_value = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})},
+            ),
+            patch(
+                "kleinanzeigen_bot.publishing_workflow.publish_ad",
+                new_callable = AsyncMock,
+                side_effect = PublishSubmissionUncertainError("submission may have succeeded before failure"),
+            ) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
+        ):
+            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
+
+            assert publish_mock.await_count == 1
+            sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_publish_ads_does_not_retry_on_category_resolution_error(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+        mock_page:MagicMock,
+    ) -> None:
+        """CategoryResolutionError is deterministic configuration failure -> no retry, fail fast."""
+        test_bot.page = mock_page
+        test_bot.keep_old_ads = True
+
+        ad_cfg = Ad.model_validate(base_ad_config)
+        ad_cfg_orig = copy.deepcopy(base_ad_config)
+
+        with (
+            patch.object(
+                test_bot,
+                "web_request",
+                new_callable = AsyncMock,
+                return_value = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})},
+            ),
+            patch(
+                "kleinanzeigen_bot.publishing_workflow.publish_ad",
+                new_callable = AsyncMock,
+                side_effect = CategoryResolutionError("no suggestion matched"),
+            ) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep_mock,
+        ):
+            await test_bot.publish_ads([("ad.yaml", ad_cfg, ad_cfg_orig)])
+
+            assert publish_mock.await_count == 1
+            sleep_mock.assert_not_awaited()
+
+
+class TestDisplayCounterProgression:
+    """Regression tests for issue #977: progress counter must increment for every ad, including skipped ones."""
+
+    @pytest.mark.asyncio
+    async def test_publish_ads_counter_progression_with_paused_ads(
+        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """Display counter must advance for paused ads, and only non-paused ads are published."""
+        ad_cfgs = [
+            build_update_ad(base_ad_config, 101, "Paused Ad 1"),
+            build_update_ad(base_ad_config, 102, "Active Ad 102"),
+            build_update_ad(base_ad_config, 103, "Paused Ad 2"),
+        ]
+        published_ads = build_published_ads((101, "paused"), (102, "active"), (103, "paused"))
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.publish_ads(ad_cfgs)
+
+        processing = [r for r in caplog.records if r.message.startswith("Processing")]
+        assert len(processing) == 3
+        assert "1/3" in processing[0].message
+        assert "2/3" in processing[1].message
+        assert "3/3" in processing[2].message
+
+        skip_msgs = [r for r in caplog.records if "Skipping because ad is reserved" in r.message]
+        assert len(skip_msgs) == 2
+
+        publish_mock.assert_awaited_once()
+        assert publish_mock.call_args.args[2].id == 102
+
+        summary = [r for r in caplog.records if "DONE:" in r.message]
+        assert any("1 ad" in r.message for r in summary)
+
+    @pytest.mark.asyncio
+    async def test_update_ads_counter_progression_with_paused_ads(
+        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """Display counter must advance for paused ads, and only non-paused ads are updated."""
+        ad_cfgs = [
+            build_update_ad(base_ad_config, 201, "Paused Ad 1"),
+            build_update_ad(base_ad_config, 202, "Active Ad 202"),
+            build_update_ad(base_ad_config, 203, "Paused Ad 2"),
+        ]
+        published_ads = build_published_ads((201, "paused"), (202, "active"), (203, "paused"))
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.update_ads(ad_cfgs)
+
+        processing = [r for r in caplog.records if r.message.startswith("Processing")]
+        assert len(processing) == 3
+        assert "1/3" in processing[0].message
+        assert "2/3" in processing[1].message
+        assert "3/3" in processing[2].message
+
+        skip_msgs = [r for r in caplog.records if "Skipping because ad is reserved" in r.message]
+        assert len(skip_msgs) == 2
+
+        publish_mock.assert_awaited_once()
+        assert publish_mock.call_args.args[2].id == 202
+
+        summary = [r for r in caplog.records if "DONE:" in r.message]
+        assert any("1 ad" in r.message for r in summary)
+
+    @pytest.mark.asyncio
+    async def test_update_ads_counter_includes_not_found_ads(
+        self, test_bot:KleinanzeigenBot, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """Display counter must advance even for ads not found in published ads."""
+        ad_cfgs = [
+            build_update_ad(base_ad_config, 301, "Not Found Ad"),
+            build_update_ad(base_ad_config, 302, "Active Ad 302"),
+        ]
+        published_ads = build_published_ads((302, "active"))
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = published_ads),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock) as publish_mock,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True),
+        ):
+            await test_bot.update_ads(ad_cfgs)
+
+        processing = [r for r in caplog.records if r.message.startswith("Processing")]
+        assert len(processing) == 2
+        assert "1/2" in processing[0].message
+        assert "2/2" in processing[1].message
+        assert "Not Found Ad" in processing[0].message
+
+        skip_msgs = [r for r in caplog.records if "SKIPPED" in r.message and "not found" in r.message]
+        assert len(skip_msgs) == 1
+
+        publish_mock.assert_awaited_once()
+        assert publish_mock.call_args.args[2].id == 302

--- a/tests/unit/test_publishing_workflow.py
+++ b/tests/unit/test_publishing_workflow.py
@@ -198,7 +198,7 @@ class TestKleinanzeigenBotPublishAdsBasics:
         test_bot.config.publishing.delete_old_ads = "AFTER_PUBLISH"
         test_bot.keep_old_ads = False
 
-        payload:dict[str, list[Any]] = {"ads": []}
+        payload:dict[str, Any] = {"ads": [], "paging": {"pageNum": 1, "last": 1}}
         ad_cfgs:list[tuple[str, Ad, dict[str, Any]]] = [("ad.yaml", Ad.model_validate(base_ad_config), {})]
 
         with (


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #977
- Move another focused set of publishing/update orchestration tests out of `tests/unit/test_init.py` and into `tests/unit/test_publishing_workflow.py`.
- This is a behavior-neutral test organization change; no runtime, CLI, config, translation, or ad YAML behavior changes are intended.

## 📋 Changes Summary

- Moved display counter progression coverage into the publishing workflow test module.
- Moved publish-ads orchestration coverage into a dedicated publishing workflow test class.
- Cleaned up imports left behind in `tests/unit/test_init.py`.
- Dependencies/configuration/additional requirements: none.

### ⚙️ Type of Change

Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

Test-only refactor; none of the listed runtime change categories apply.

## ✅ Checklist

Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary. Not applicable; test-only relocation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved the ad publishing workflow test coverage by reorganizing publish/cleanup, retry behavior, and “no-retry” scenarios.
  * Added new async testing utilities (including a reusable mocked page) to better simulate browser interactions.
  * Expanded regression coverage for processing/counter progression across publishing and updating, including paused ads and “not found” cases.
  * Removed several redundant or replaced counter/retry/skip tests from the prior initialization test module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->