### PR TITLE
refactor: move publishing diagnostics tests

### DIFF
--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-import copy, os  # isort: skip
+import copy
+import os
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 from pathlib import Path

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © Jens Bergmann and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-import copy, fnmatch, json, os  # isort: skip
+import copy, os  # isort: skip
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
@@ -20,10 +20,8 @@ from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.model.config_model import (
     AutoPriceReductionConfig,
     Config,
-    DiagnosticsConfig,
     PublishingConfig,
 )
-from kleinanzeigen_bot.publishing_workflow import SUBMISSION_MAX_RETRIES
 from kleinanzeigen_bot.utils import xdg_paths
 from kleinanzeigen_bot.utils.exceptions import PublishSubmissionUncertainError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
@@ -139,141 +137,6 @@ class TestKleinanzeigenBotInitialization:
 
         expected_state_path = (tmp_path / "config.yaml").resolve().parent / ".temp" / "update_check_state.json"
         assert update_checker_calls == [(test_bot.config, expected_state_path)]
-
-
-class TestKleinanzeigenBotDiagnostics:
-    @pytest.fixture
-    def diagnostics_ad_config(self) -> dict[str, Any]:
-        return {
-            "active": True,
-            "type": "OFFER",
-            "title": "Test ad title",
-            "description": "Test description",
-            "category": "161/176/sonstige",
-            "price_type": "NEGOTIABLE",
-            "shipping_type": "PICKUP",
-            "sell_directly": False,
-            "contact": {
-                "name": "Tester",
-                "zipcode": "12345",
-            },
-            "republication_interval": 7,
-        }
-
-    @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_publish_ads_captures_diagnostics_on_failures(
-        self,
-        test_bot:KleinanzeigenBot,
-        tmp_path:Path,
-        diagnostics_ad_config:dict[str, Any],
-    ) -> None:
-        """Ensure publish failures capture diagnostics artifacts."""
-        log_file_path = tmp_path / "test.log"
-        log_file_path.write_text("Test log content\n", encoding = "utf-8")
-        test_bot.log_file_path = str(log_file_path)
-
-        test_bot.config.diagnostics = DiagnosticsConfig.model_validate({"capture_on": {"publish": True}, "output_dir": str(tmp_path)})
-
-        page = MagicMock()
-        page.save_screenshot = AsyncMock()
-        page.get_content = AsyncMock(return_value = "<html></html>")
-        page.sleep = AsyncMock()
-        page.url = "https://example.com/fail"
-        test_bot.page = page
-
-        ad_cfg = Ad.model_validate(diagnostics_ad_config)
-        ad_cfg_orig = copy.deepcopy(diagnostics_ad_config)
-        ad_file = str(tmp_path / "ad_000001_Test.yml")
-        ads_response = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})}
-
-        with (
-            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
-            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
-        ):
-            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
-
-        expected_retries = SUBMISSION_MAX_RETRIES
-        assert page.save_screenshot.await_count == expected_retries
-        assert page.get_content.await_count == expected_retries
-        entries = os.listdir(tmp_path)
-        html_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.html")]
-        json_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.json")]
-        assert len(html_files) == expected_retries
-        assert len(json_files) == expected_retries
-
-    @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_publish_ads_captures_log_copy_when_enabled(
-        self,
-        test_bot:KleinanzeigenBot,
-        tmp_path:Path,
-        diagnostics_ad_config:dict[str, Any],
-    ) -> None:
-        """Ensure publish failures copy log file when capture_log_copy is enabled."""
-        log_file_path = tmp_path / "test.log"
-        log_file_path.write_text("Test log content\n", encoding = "utf-8")
-        test_bot.log_file_path = str(log_file_path)
-
-        test_bot.config.diagnostics = DiagnosticsConfig.model_validate({"capture_on": {"publish": True}, "capture_log_copy": True, "output_dir": str(tmp_path)})
-
-        page = MagicMock()
-        page.save_screenshot = AsyncMock()
-        page.get_content = AsyncMock(return_value = "<html></html>")
-        page.sleep = AsyncMock()
-        page.url = "https://example.com/fail"
-        test_bot.page = page
-
-        ad_cfg = Ad.model_validate(diagnostics_ad_config)
-        ad_cfg_orig = copy.deepcopy(diagnostics_ad_config)
-        ad_file = str(tmp_path / "ad_000001_Test.yml")
-        ads_response = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})}
-
-        with (
-            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
-            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
-        ):
-            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
-
-        entries = os.listdir(tmp_path)
-        log_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.log")]
-        assert len(log_files) == SUBMISSION_MAX_RETRIES
-
-    @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_publish_ads_does_not_capture_diagnostics_when_disabled(
-        self,
-        test_bot:KleinanzeigenBot,
-        tmp_path:Path,
-        diagnostics_ad_config:dict[str, Any],
-    ) -> None:
-        """Ensure diagnostics are not captured when disabled."""
-        test_bot.config.diagnostics = DiagnosticsConfig.model_validate({"capture_on": {"publish": False}, "output_dir": str(tmp_path)})
-
-        page = MagicMock()
-        page.save_screenshot = AsyncMock()
-        page.get_content = AsyncMock(return_value = "<html></html>")
-        page.sleep = AsyncMock()
-        page.url = "https://example.com/fail"
-        test_bot.page = page
-
-        ad_cfg = Ad.model_validate(diagnostics_ad_config)
-        ad_cfg_orig = copy.deepcopy(diagnostics_ad_config)
-        ad_file = str(tmp_path / "ad_000001_Test.yml")
-
-        with (
-            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps({"ads": []})}),
-            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
-        ):
-            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
-
-        page.save_screenshot.assert_not_called()
-        page.get_content.assert_not_called()
-        entries = os.listdir(tmp_path)
-        html_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.html")]
-        json_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.json")]
-        assert not html_files
-        assert not json_files
 
 
 class TestKleinanzeigenBotBasics:

--- a/tests/unit/test_publishing_workflow.py
+++ b/tests/unit/test_publishing_workflow.py
@@ -5,8 +5,11 @@
 
 import asyncio
 import copy
+import fnmatch
 import json
 import logging
+import os
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +18,7 @@ from nodriver.core.connection import ProtocolException
 
 from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
+from kleinanzeigen_bot.model.config_model import DiagnosticsConfig
 from kleinanzeigen_bot.publishing_workflow import SUBMISSION_MAX_RETRIES
 from kleinanzeigen_bot.utils.exceptions import CategoryResolutionError, PublishSubmissionUncertainError
 from tests.conftest import build_published_ads, build_update_ad
@@ -444,3 +448,138 @@ class TestDisplayCounterProgression:
 
         publish_mock.assert_awaited_once()
         assert publish_mock.call_args.args[2].id == 302
+
+
+class TestKleinanzeigenBotDiagnostics:
+    @pytest.fixture
+    def diagnostics_ad_config(self) -> dict[str, Any]:
+        return {
+            "active": True,
+            "type": "OFFER",
+            "title": "Test ad title",
+            "description": "Test description",
+            "category": "161/176/sonstige",
+            "price_type": "NEGOTIABLE",
+            "shipping_type": "PICKUP",
+            "sell_directly": False,
+            "contact": {
+                "name": "Tester",
+                "zipcode": "12345",
+            },
+            "republication_interval": 7,
+        }
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_publish_ads_captures_diagnostics_on_failures(
+        self,
+        test_bot:KleinanzeigenBot,
+        tmp_path:Path,
+        diagnostics_ad_config:dict[str, Any],
+    ) -> None:
+        """Ensure publish failures capture diagnostics artifacts."""
+        log_file_path = tmp_path / "test.log"
+        log_file_path.write_text("Test log content\n", encoding = "utf-8")
+        test_bot.log_file_path = str(log_file_path)
+
+        test_bot.config.diagnostics = DiagnosticsConfig.model_validate({"capture_on": {"publish": True}, "output_dir": str(tmp_path)})
+
+        page = MagicMock()
+        page.save_screenshot = AsyncMock()
+        page.get_content = AsyncMock(return_value = "<html></html>")
+        page.sleep = AsyncMock()
+        page.url = "https://example.com/fail"
+        test_bot.page = page
+
+        ad_cfg = Ad.model_validate(diagnostics_ad_config)
+        ad_cfg_orig = copy.deepcopy(diagnostics_ad_config)
+        ad_file = str(tmp_path / "ad_000001_Test.yml")
+        ads_response = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})}
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
+        ):
+            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
+
+        expected_retries = SUBMISSION_MAX_RETRIES
+        assert page.save_screenshot.await_count == expected_retries
+        assert page.get_content.await_count == expected_retries
+        entries = os.listdir(tmp_path)
+        html_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.html")]
+        json_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.json")]
+        assert len(html_files) == expected_retries
+        assert len(json_files) == expected_retries
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_publish_ads_captures_log_copy_when_enabled(
+        self,
+        test_bot:KleinanzeigenBot,
+        tmp_path:Path,
+        diagnostics_ad_config:dict[str, Any],
+    ) -> None:
+        """Ensure publish failures copy log file when capture_log_copy is enabled."""
+        log_file_path = tmp_path / "test.log"
+        log_file_path.write_text("Test log content\n", encoding = "utf-8")
+        test_bot.log_file_path = str(log_file_path)
+
+        test_bot.config.diagnostics = DiagnosticsConfig.model_validate({"capture_on": {"publish": True}, "capture_log_copy": True, "output_dir": str(tmp_path)})
+
+        page = MagicMock()
+        page.save_screenshot = AsyncMock()
+        page.get_content = AsyncMock(return_value = "<html></html>")
+        page.sleep = AsyncMock()
+        page.url = "https://example.com/fail"
+        test_bot.page = page
+
+        ad_cfg = Ad.model_validate(diagnostics_ad_config)
+        ad_cfg_orig = copy.deepcopy(diagnostics_ad_config)
+        ad_file = str(tmp_path / "ad_000001_Test.yml")
+        ads_response = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})}
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = ads_response),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
+        ):
+            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
+
+        entries = os.listdir(tmp_path)
+        log_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.log")]
+        assert len(log_files) == SUBMISSION_MAX_RETRIES
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_publish_ads_does_not_capture_diagnostics_when_disabled(
+        self,
+        test_bot:KleinanzeigenBot,
+        tmp_path:Path,
+        diagnostics_ad_config:dict[str, Any],
+    ) -> None:
+        """Ensure diagnostics are not captured when disabled."""
+        test_bot.config.diagnostics = DiagnosticsConfig.model_validate({"capture_on": {"publish": False}, "output_dir": str(tmp_path)})
+
+        page = MagicMock()
+        page.save_screenshot = AsyncMock()
+        page.get_content = AsyncMock(return_value = "<html></html>")
+        page.sleep = AsyncMock()
+        page.url = "https://example.com/fail"
+        test_bot.page = page
+
+        ad_cfg = Ad.model_validate(diagnostics_ad_config)
+        ad_cfg_orig = copy.deepcopy(diagnostics_ad_config)
+        ad_file = str(tmp_path / "ad_000001_Test.yml")
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps({"ads": []})}),
+            patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
+        ):
+            await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])
+
+        page.save_screenshot.assert_not_called()
+        page.get_content.assert_not_called()
+        entries = os.listdir(tmp_path)
+        html_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.html")]
+        json_files = [name for name in entries if fnmatch.fnmatch(name, "publish_error_*_attempt*_ad_000001_Test.json")]
+        assert not html_files
+        assert not json_files

--- a/tests/unit/test_publishing_workflow.py
+++ b/tests/unit/test_publishing_workflow.py
@@ -571,7 +571,12 @@ class TestKleinanzeigenBotDiagnostics:
         ad_file = str(tmp_path / "ad_000001_Test.yml")
 
         with (
-            patch.object(test_bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps({"ads": []})}),
+            patch.object(
+                test_bot,
+                "web_request",
+                new_callable = AsyncMock,
+                return_value = {"content": json.dumps({"ads": [], "paging": {"pageNum": 1, "last": 1}})},
+            ),
             patch("kleinanzeigen_bot.publishing_workflow.publish_ad", new_callable = AsyncMock, side_effect = TimeoutError("boom")),
         ):
             await test_bot.publish_ads([(ad_file, ad_cfg, ad_cfg_orig)])


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): N/A
- Move the publish failure diagnostics tests out of the initializer-focused unit test module and into the publishing workflow unit test module.
- This is a behavior-neutral test organization change.

## 📋 Changes Summary

- Moved `TestKleinanzeigenBotDiagnostics` from `tests/unit/test_init.py` to `tests/unit/test_publishing_workflow.py`.
- Kept existing assertions and publishing workflow patch targets unchanged.
- Removed stale imports from `tests/unit/test_init.py`.
- No runtime, CLI, config, translation, or ad YAML changes.

### ⚙️ Type of Change

Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for diagnostics capture during publishing failures, including verification of log file handling and behavior when diagnostics are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->