### PR TITLE
refactor: remove KleinanzeigenBot re-export from package root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,7 @@ select = [
   "E",    # pycodestyle-errors
   "W",    # pycodestyle-warnings
 
-  #"C90", # mccabe
+  "C90",  # mccabe
   "D",    # pydocstyle
   "F",    # pyflakes
   "FLY",  # flynt
@@ -290,11 +290,15 @@ min-file-size = 256
 # https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#design-checker-messages
 max-args       = 6      # max. number of args for function / method (R0913)
 # max-attributes = 15   # TODO max. number of instance attrs for a class (R0902)
-max-branches   = 45     # max. number of branch for function / method body (R0912)
-max-locals     = 30     # max. number of local vars for function / method body (R0914)
-max-returns    = 15     # max. number of return / yield for function / method body (R0911)
-max-statements = 150    # max. number of statements in function / method body (R0915)
-max-public-methods = 25 # max. number of public methods for a class (R0904)
+max-branches   = 42     # max. number of branch for function / method body (R0912)
+max-locals     = 27     # max. number of local vars for function / method body (R0914)
+max-returns    = 13     # max. number of return / yield for function / method body (R0911)
+max-statements = 115    # max. number of statements in function / method body (R0915)
+max-public-methods = 20 # max. number of public methods for a class (R0904)
+
+[tool.ruff.lint.mccabe]
+# https://docs.astral.sh/ruff/settings/#lint_mccabe_max-complexity
+max-complexity = 40
 # max-positional-arguments = 5  # max. number of positional args for function / method (R0917)
 
 

--- a/src/kleinanzeigen_bot/__init__.py
+++ b/src/kleinanzeigen_bot/__init__.py
@@ -7,7 +7,6 @@ from typing import Final
 
 import colorama
 
-from .app import KleinanzeigenBot as KleinanzeigenBot
 from .utils import loggers as _loggers
 
 LOG:Final[_loggers.Logger] = _loggers.get_logger(__name__)

--- a/src/kleinanzeigen_bot/utils/pydantics.py
+++ b/src/kleinanzeigen_bot/utils/pydantics.py
@@ -89,7 +89,7 @@ def format_validation_error(ex:ValidationError) -> str:
     return "\n".join(lines)
 
 
-def __get_message_template(error_code:str) -> str | None:
+def __get_message_template(error_code:str) -> str | None:  # noqa: C901  # generated/static pydantic error-code mapping
     # https://github.com/pydantic/pydantic-core/blob/d03bf4a01ca3b378cc8590bd481f307e82115bc6/src/errors/types.rs#L477
     # ruff: noqa: PLR0911 Too many return statements
     # ruff: noqa: PLR0912 Too many branches

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from kleinanzeigen_bot import KleinanzeigenBot
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad
 from kleinanzeigen_bot.model.config_model import Config
 from kleinanzeigen_bot.utils import i18n, loggers

--- a/tests/unit/test_captcha_flow.py
+++ b/tests/unit/test_captcha_flow.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kleinanzeigen_bot import KleinanzeigenBot, captcha_flow
+from kleinanzeigen_bot import captcha_flow
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.config_model import CaptchaConfig
 from kleinanzeigen_bot.utils.exceptions import CaptchaEncountered
 

--- a/tests/unit/test_delete_flow.py
+++ b/tests/unit/test_delete_flow.py
@@ -10,7 +10,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from kleinanzeigen_bot import KleinanzeigenBot, delete_flow
+from kleinanzeigen_bot import delete_flow
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.delete_flow import DeleteResult
 from kleinanzeigen_bot.model.ad_model import Ad
 

--- a/tests/unit/test_download_flow.py
+++ b/tests/unit/test_download_flow.py
@@ -10,7 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kleinanzeigen_bot import KleinanzeigenBot, download_flow
+from kleinanzeigen_bot import download_flow
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad
 from kleinanzeigen_bot.published_ads import PublishedAdsFetchIncompleteError
 from kleinanzeigen_bot.utils import xdg_paths

--- a/tests/unit/test_extend_flow.py
+++ b/tests/unit/test_extend_flow.py
@@ -11,7 +11,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kleinanzeigen_bot import KleinanzeigenBot, extend_flow, runtime_config
+from kleinanzeigen_bot import extend_flow, runtime_config
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad
 from kleinanzeigen_bot.utils import dicts, misc, xdg_paths
 from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element

--- a/tests/unit/test_login_flow.py
+++ b/tests/unit/test_login_flow.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
-from kleinanzeigen_bot import KleinanzeigenBot
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.login_flow import (
     LoginDetectionReason,
     LoginDetectionResult,

--- a/tests/unit/test_published_ads.py
+++ b/tests/unit/test_published_ads.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from kleinanzeigen_bot import KleinanzeigenBot, published_ads
+from kleinanzeigen_bot import published_ads
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.published_ads import PublishedAdsFetchIncompleteError
 from kleinanzeigen_bot.utils import misc
 

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -13,8 +13,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kleinanzeigen_bot import LOG, KleinanzeigenBot
+from kleinanzeigen_bot import LOG
 from kleinanzeigen_bot.ad_form_helpers import VERSAND_COMBOBOX_SELECTOR
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.model.config_model import PublishingConfig
 from kleinanzeigen_bot.publishing_form import (

--- a/tests/unit/test_publishing_persistence.py
+++ b/tests/unit/test_publishing_persistence.py
@@ -10,12 +10,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kleinanzeigen_bot import (
-    KleinanzeigenBot,
-    publishing_persistence,
-)
-from kleinanzeigen_bot import (
     local_path_renaming as _local_path_renaming,
 )
+from kleinanzeigen_bot import publishing_persistence
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.local_path_renaming import ImageRenameResult, LocalPathRenameResult, RenameStatus
 from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.model.config_model import Config

--- a/tests/unit/test_publishing_submission.py
+++ b/tests/unit/test_publishing_submission.py
@@ -7,7 +7,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from kleinanzeigen_bot import KleinanzeigenBot, publishing_submission
+from kleinanzeigen_bot import publishing_submission
+from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.utils.exceptions import PublishSubmissionUncertainError
 from kleinanzeigen_bot.utils.web_scraping_mixin import By


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): N/A
- Removes the unsupported package-root `KleinanzeigenBot` re-export after tests were moved to their owning modules.
- Updates remaining tests and `conftest.py` to import `KleinanzeigenBot` from `kleinanzeigen_bot.app` directly.
- Re-enables Ruff's mccabe complexity checks and tightens high Pylint complexity thresholds left over from the old package-root monolith.

## 📋 Changes Summary

- Removed `KleinanzeigenBot` from `src/kleinanzeigen_bot/__init__.py`.
- Updated all remaining test imports to use `from kleinanzeigen_bot.app import KleinanzeigenBot`.
- Enabled `C90`/mccabe complexity linting with an explicit `max-complexity`.
- Lowered the broad Pylint limits for branches, locals, returns, statements, and public methods.
- Kept the generated/static pydantic error-code mapping explicitly exempted from complexity checks.
- No runtime behavior, CLI, config, translations, or ad YAML changes.
- No new dependencies.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [x] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module import structure for consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
