### PR TITLE
refactor: reduce price reduction complexity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,7 +292,7 @@ max-args       = 6      # max. number of args for function / method (R0913)
 # max-attributes = 15   # TODO max. number of instance attrs for a class (R0902)
 max-branches   = 42     # max. number of branch for function / method body (R0912)
 max-locals     = 27     # max. number of local vars for function / method body (R0914)
-max-returns    = 13     # max. number of return / yield for function / method body (R0911)
+max-returns    = 12     # max. number of return / yield for function / method body (R0911)
 max-statements = 115    # max. number of statements in function / method body (R0915)
 max-public-methods = 20 # max. number of public methods for a class (R0904)
 

--- a/src/kleinanzeigen_bot/price_reduction.py
+++ b/src/kleinanzeigen_bot/price_reduction.py
@@ -510,6 +510,35 @@ def apply_auto_price_reduction(
         )
         return
 
+    _apply_price_reduction_decision(ad_cfg, decision, ad_file_relative, base_price)
+    # Note: price_reduction_count is persisted to ad_cfg_orig only after successful publish
+
+
+def _apply_price_reduction_decision(
+    ad_cfg:Ad,
+    decision:PriceReductionDecision,
+    ad_file_relative:str,
+    base_price:int,
+) -> None:
+    """Apply the final price reduction decision (mutation phase).
+
+    Handles the final application section after all skip checks pass:
+    MODIFY-mode delay_reposts_ignored debug log, no_visible_change handling,
+    guards, optional trace logging, price assignment, and counter mutation.
+
+    Args:
+        ad_cfg: The ad configuration to mutate.
+        decision: The evaluated price reduction decision.
+        ad_file_relative: Relative path to the ad file (for logging context).
+        base_price: The base price from the decision.
+    """
+    delay_reposts = decision.delay_reposts
+    eligible_cycles = decision.eligible_cycles
+    applied_cycles = decision.applied_cycles
+    delay_days = decision.delay_days
+    elapsed_days = decision.elapsed_days
+    elapsed_display = "missing" if elapsed_days is None else str(elapsed_days)
+
     if decision.mode == AdUpdateStrategy.MODIFY and decision.delay_reposts_ignored:
         LOG.debug(
             "Auto price reduction for [%s]: delay_reposts=%s ignored in MODIFY mode (only delay_days applies)",
@@ -580,4 +609,3 @@ def apply_auto_price_reduction(
     LOG.info("Auto price reduction applied for [%s]: %s -> %s after %s reduction cycles",
              ad_file_relative, decision.restored_price, effective_price, next_cycle)
     ad_cfg.price_reduction_count = next_cycle
-    # Note: price_reduction_count is persisted to ad_cfg_orig only after successful publish

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -473,9 +473,11 @@ kleinanzeigen_bot/price_reduction.py:
     "Auto price reduction already applied for [%s]: price %s -> %s; %s reductions match %s eligible reposts": "Automatische Preisreduzierung für [%s] bereits angewendet: Preis %s -> %s; %s Reduktionen entsprechen %s berechtigten erneuten Veröffentlichungen"
     "Auto price reduction delayed for [%s]: waiting %s days (elapsed %s)": "Automatische Preisreduzierung für [%s] verzögert: Warte %s Tage (vergangen %s)"
     "Auto price reduction delayed for [%s]: waiting %s days but publish timestamp missing": "Automatische Preisreduzierung für [%s] verzögert: Warte %s Tage, aber Zeitstempel der Veröffentlichung fehlt"
+    "Auto price reduction failed for [%s]: could not calculate price for cycle %s from base price %s": "Automatische Preisreduzierung für [%s] fehlgeschlagen: Konnte Preis für Zyklus %s aus Grundpreis %s nicht berechnen"
+
+  _apply_price_reduction_decision:
     "Auto price reduction applied for [%s]: %s -> %s after %s reduction cycles": "Automatische Preisreduzierung für [%s] angewendet: %s -> %s nach %s Reduktionszyklen"
     "Auto price reduction kept price %s for [%s] after attempting %s reduction cycles": "Automatische Preisreduzierung hat Preis %s für [%s] beibehalten nach dem Versuch von %s Reduktionszyklen"
-    "Auto price reduction failed for [%s]: could not calculate price for cycle %s from base price %s": "Automatische Preisreduzierung für [%s] fehlgeschlagen: Konnte Preis für Zyklus %s aus Grundpreis %s nicht berechnen"
 
 #################################################
 kleinanzeigen_bot/extract.py:


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #
- Extracts the first complexity hotspot in the ratcheting sequence by separating the final auto price-reduction application flow from `apply_auto_price_reduction`.
- This keeps behavior unchanged while allowing the Ruff `max-returns` transitional limit to move from 13 to 12.

## 📋 Changes Summary

- Extracted `_apply_price_reduction_decision` for the final price-reduction mutation/logging phase.
- Moved German translations for the relocated `LOG.info` calls to the new helper function key.
- Lowered `tool.ruff.lint.pylint.max-returns` from 13 to 12.
- No dependency or runtime configuration changes introduced.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

Refactor-only change; none of the listed user-facing change types apply.

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration thresholds for code quality standards.

* **Refactor**
  * Improved internal code organization for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->