### PR TITLE
refactor: reduce return-count complexity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,7 +292,7 @@ max-args       = 6      # max. number of args for function / method (R0913)
 # max-attributes = 15   # TODO max. number of instance attrs for a class (R0902)
 max-branches   = 42     # max. number of branch for function / method body (R0912)
 max-locals     = 27     # max. number of local vars for function / method body (R0914)
-max-returns    = 10     # max. number of return / yield for function / method body (R0911)
+max-returns    = 8      # max. number of return / yield for function / method body (R0911)
 max-statements = 115    # max. number of statements in function / method body (R0915)
 max-public-methods = 20 # max. number of public methods for a class (R0904)
 

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -850,19 +850,20 @@ kleinanzeigen_bot/update_checker.py:
 #################################################
   _resolve_commitish:
     "Could not resolve commit '%s': %s": "Konnte Commit '%s' nicht aufloesen: %s"
+  _get_release_and_commitish:
+    "Could not determine release commit hash.": "Konnte Release-Commit-Hash nicht ermitteln."
+    "Could not get releases: %s": "Konnte Releases nicht abrufen: %s"
+    "Latest release from GitHub is a prerelease, but 'latest' channel expects a stable release.": "Die neueste GitHub-Version ist eine Vorabversion, aber der 'latest'-Kanal erwartet eine stabile Version."
+    "No prerelease found for 'preview' channel.": "Keine Vorabversion für den 'preview'-Kanal gefunden."
+    "Unknown update channel: %s": "Unbekannter Update-Kanal: %s"
   check_for_updates:
     "A new version is available: %s from %s UTC (current: %s from %s UTC, channel: %s)": "Eine neue Version ist verfügbar: %s vom %s UTC (aktuell: %s vom %s UTC, Kanal: %s)"
     "Could not determine commit dates for comparison.": "Konnte Commit-Daten für den Vergleich nicht ermitteln."
     "Could not determine local commit hash.": "Konnte lokalen Commit-Hash nicht ermitteln."
     "Could not determine local version.": "Konnte lokale Version nicht ermitteln."
-    "Could not determine release commit hash.": "Konnte Release-Commit-Hash nicht ermitteln."
-    "Could not get releases: %s": "Konnte Releases nicht abrufen: %s"
     ? "Release notes:\n%s"
     : "Release-Notizen:\n%s"
     "You are on the latest version: %s (compared to %s in channel %s)": "Sie verwenden die neueste Version: %s (verglichen mit %s im Kanal %s)"
-    "Latest release from GitHub is a prerelease, but 'latest' channel expects a stable release.": "Die neueste GitHub-Version ist eine Vorabversion, aber der 'latest'-Kanal erwartet eine stabile Version."
-    "No prerelease found for 'preview' channel.": "Keine Vorabversion für den 'preview'-Kanal gefunden."
-    "Unknown update channel: %s": "Unbekannter Update-Kanal: %s"
     ? "You are on a different commit than the release for channel '%s' (tag: %s). This may mean you are ahead, behind, or on a different branch. Local commit: %s (%s UTC), Release commit: %s (%s UTC)"
     : "Sie befinden sich auf einem anderen Commit als das Release für Kanal '%s' (Tag: %s). Dies kann bedeuten, dass Sie voraus, hinterher oder auf einem anderen Branch sind. Lokaler Commit: %s (%s UTC), Release-Commit: %s (%s UTC)"
 

--- a/src/kleinanzeigen_bot/update_checker.py
+++ b/src/kleinanzeigen_bot/update_checker.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import colorama
 import requests
@@ -119,6 +119,51 @@ class UpdateChecker:
             return True
         return len(release_commit) < len(local_commit) and local_commit.startswith(release_commit)
 
+    def _get_release_and_commitish(self) -> tuple[dict[str, Any], str] | None:
+        """Fetch the applicable release from GitHub and extract its commit-ish.
+
+        Returns:
+            Tuple of (release dict, commit-ish string) on success, or None
+            on any failure (unknown channel, network error, missing commitish).
+        """
+        # --- Fetch release info from GitHub using correct endpoint per channel ---
+        try:
+            if self.config.update_check.channel == "latest":
+                # Use /releases/latest endpoint for stable releases
+                response = requests.get("https://api.github.com/repos/Second-Hand-Friends/kleinanzeigen-bot/releases/latest", timeout = self._request_timeout())
+                response.raise_for_status()
+                release = response.json()
+                # Defensive: ensure it's not a prerelease
+                if release.get("prerelease", False):
+                    logger.warning("Latest release from GitHub is a prerelease, but 'latest' channel expects a stable release.")
+                    return None
+            elif self.config.update_check.channel == "preview":
+                # Use /releases endpoint and select the most recent prerelease
+                response = requests.get("https://api.github.com/repos/Second-Hand-Friends/kleinanzeigen-bot/releases", timeout = self._request_timeout())
+                response.raise_for_status()
+                releases = response.json()
+                # Find the most recent prerelease
+                release = next((r for r in releases if r.get("prerelease", False) and not r.get("draft", False)), None)
+                if not release:
+                    logger.warning("No prerelease found for 'preview' channel.")
+                    return None
+            else:
+                logger.warning("Unknown update channel: %s", self.config.update_check.channel)
+                return None
+        except Exception as e:
+            logger.warning("Could not get releases: %s", e)
+            return None
+
+        # Get release commit-ish (use tag name to avoid branch tip drift)
+        release_commitish = release.get("tag_name")
+        if not release_commitish:
+            release_commitish = release.get("target_commitish")
+        if not release_commitish:
+            logger.warning("Could not determine release commit hash.")
+            return None
+
+        return release, release_commitish
+
     def check_for_updates(self, *, skip_interval_check:bool = False) -> None:
         """Check for updates to the bot.
 
@@ -143,40 +188,10 @@ class UpdateChecker:
             return
 
         # --- Fetch release info from GitHub using correct endpoint per channel ---
-        try:
-            if self.config.update_check.channel == "latest":
-                # Use /releases/latest endpoint for stable releases
-                response = requests.get("https://api.github.com/repos/Second-Hand-Friends/kleinanzeigen-bot/releases/latest", timeout = self._request_timeout())
-                response.raise_for_status()
-                release = response.json()
-                # Defensive: ensure it's not a prerelease
-                if release.get("prerelease", False):
-                    logger.warning("Latest release from GitHub is a prerelease, but 'latest' channel expects a stable release.")
-                    return
-            elif self.config.update_check.channel == "preview":
-                # Use /releases endpoint and select the most recent prerelease
-                response = requests.get("https://api.github.com/repos/Second-Hand-Friends/kleinanzeigen-bot/releases", timeout = self._request_timeout())
-                response.raise_for_status()
-                releases = response.json()
-                # Find the most recent prerelease
-                release = next((r for r in releases if r.get("prerelease", False) and not r.get("draft", False)), None)
-                if not release:
-                    logger.warning("No prerelease found for 'preview' channel.")
-                    return
-            else:
-                logger.warning("Unknown update channel: %s", self.config.update_check.channel)
-                return
-        except Exception as e:
-            logger.warning("Could not get releases: %s", e)
+        result = self._get_release_and_commitish()
+        if result is None:
             return
-
-        # Get release commit-ish (use tag name to avoid branch tip drift)
-        release_commitish = release.get("tag_name")
-        if not release_commitish:
-            release_commitish = release.get("target_commitish")
-        if not release_commitish:
-            logger.warning("Could not determine release commit hash.")
-            return
+        release, release_commitish = result
 
         # Resolve commit hashes and dates for comparison
         local_commit, local_commit_date = self._resolve_commitish(local_commitish)


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #
- Reduces return-count complexity in the update checker while preserving existing update-check behavior.

## 📋 Changes Summary

- Extracted GitHub release selection and commit-ish validation from `check_for_updates` into a private helper.
- Moved German translation keys for logger calls that now originate from the helper.
- Ratcheted Ruff/Pylint `max-returns` from 10 to 8.

### ⚙️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The update checker now correctly handles the latest update channel by excluding pre-release versions and recommending only stable releases.

* **Chores**
  * Code quality configuration settings were adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->