### PR TITLE
refactor: simplify browser diagnostics

### DIFF
--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -734,6 +734,7 @@ class WebScrapingMixin:  # noqa: PLR0904
                         proc.info["has_remote_debugging"] = has_remote_debugging
                         browser_processes.append(proc.info)
                 except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    # Process ended or is not accessible; skip it.
                     pass
             return browser_processes, None
         except (psutil.Error, PermissionError) as exc:

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -662,6 +662,83 @@ class WebScrapingMixin:  # noqa: PLR0904
 
         return False
 
+    def _detect_browser_binary(self) -> str | None:
+        """Auto-detect a compatible browser binary.
+
+        Returns the binary path or None if detection fails.
+        Debug-only failure logging is kept here; translated report-level
+        logging and binary-location mutation stay in the caller.
+        """
+        try:
+            return self.get_compatible_browser()
+        except AssertionError as exc:
+            LOG.debug("Browser auto-detection failed: %s", exc)
+            return None
+
+    def _configured_remote_debugging_port(self) -> int:
+        """Parse the first --remote-debugging-port= argument.
+
+        Returns 0 if not configured.
+        Raises ValueError for invalid port values.
+        """
+        for arg in self.browser_config.arguments:
+            if arg.startswith("--remote-debugging-port="):
+                return int(arg.split("=", maxsplit = 1)[1])
+        return 0
+
+    @staticmethod
+    def _remote_debugging_api_browser(remote_port:int, probe_timeout:float) -> tuple[str | None, Exception | None]:
+        """Probe the remote debugging API at 127.0.0.1.
+
+        Returns (browser_string, None) on success or (None, exception) on failure.
+        """
+        try:
+            response = urllib.request.urlopen(f"http://127.0.0.1:{remote_port}/json/version", timeout = probe_timeout)
+            version_info = json.loads(response.read().decode())
+            return version_info.get("Browser", "Unknown"), None
+        except Exception as exc:
+            return None, exc
+
+    def _target_browser_name(self) -> str:
+        """Return the lowercased target browser basename for process matching.
+
+        Falls back to auto-detection if binary_location is not set.
+        Detection failure is silent (no log output).
+        """
+        if self.browser_config.binary_location:
+            return os.path.basename(self.browser_config.binary_location).lower()
+        try:
+            target_browser_path = self.get_compatible_browser()
+            return os.path.basename(target_browser_path).lower()
+        except (AssertionError, TypeError):
+            return ""
+
+    @staticmethod
+    def _find_relevant_browser_processes(target_browser_name:str) -> tuple[list[dict[str, object]], Exception | None]:
+        """Find browser processes matching *target_browser_name*.
+
+        Returns (process_list, global_error). Per-process NoSuchProcess/AccessDenied
+        are silently skipped. The caller handles the global warning log.
+        """
+        try:
+            browser_processes:list[dict[str, object]] = []
+            for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+                try:
+                    proc_name = proc.info["name"] or ""
+                    cmdline = proc.info["cmdline"] or []
+
+                    is_target_browser = target_browser_name and target_browser_name in proc_name.lower()
+                    has_remote_debugging = cmdline and any(arg.startswith("--remote-debugging-port=") for arg in cmdline)
+
+                    if is_target_browser:
+                        proc.info["has_remote_debugging"] = has_remote_debugging
+                        browser_processes.append(proc.info)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+            return browser_processes, None
+        except (psutil.Error, PermissionError) as exc:
+            return [], exc
+
     def diagnose_browser_issues(self) -> None:
         """
         Diagnose common browser connection issues and provide troubleshooting information.
@@ -679,11 +756,7 @@ class WebScrapingMixin:  # noqa: PLR0904
             else:
                 LOG.error("(fail) Browser binary not found: %s", self.browser_config.binary_location)
         else:
-            try:
-                browser_path = self.get_compatible_browser()
-            except AssertionError as exc:
-                LOG.debug("Browser auto-detection failed: %s", exc)
-                browser_path = None
+            browser_path = self._detect_browser_binary()
             if browser_path:
                 LOG.info("(ok) Auto-detected browser: %s", browser_path)
                 # Set the binary location for Chrome version detection
@@ -703,11 +776,7 @@ class WebScrapingMixin:  # noqa: PLR0904
                 LOG.info("(info) User data directory does not exist (will be created): %s", self.browser_config.user_data_dir)
 
         # Check for remote debugging port
-        remote_port = 0
-        for arg in self.browser_config.arguments:
-            if arg.startswith("--remote-debugging-port="):
-                remote_port = int(arg.split("=", maxsplit = 1)[1])
-                break
+        remote_port = self._configured_remote_debugging_port()
 
         if remote_port > 0:
             LOG.info("(info) Remote debugging port configured: %d", remote_port)
@@ -716,57 +785,24 @@ class WebScrapingMixin:  # noqa: PLR0904
                 # Try to get more information about the debugging endpoint
                 try:
                     probe_timeout = self.effective_timeout("chrome_remote_probe")
-                    response = urllib.request.urlopen(f"http://127.0.0.1:{remote_port}/json/version", timeout = probe_timeout)
-                    version_info = json.loads(response.read().decode())
-                    LOG.info("(ok) Remote debugging API accessible - Browser: %s", version_info.get("Browser", "Unknown"))
+                    browser_fact, exc = self._remote_debugging_api_browser(remote_port, probe_timeout)
                 except Exception as e:
-                    LOG.warning("(fail) Remote debugging port is open but API not accessible: %s", str(e))
+                    exc = e
+                    browser_fact = None
+                if exc is None:
+                    LOG.info("(ok) Remote debugging API accessible - Browser: %s", browser_fact)
+                else:
+                    LOG.warning("(fail) Remote debugging port is open but API not accessible: %s", str(exc))
                     LOG.info("  This might indicate a browser update issue or configuration problem")
             else:
                 LOG.info("(info) Remote debugging port is not open")
 
         # Check for running browser processes
-        browser_processes = []
-        target_browser_name = ""
+        target_browser_name = self._target_browser_name()
+        browser_processes, proc_exc = self._find_relevant_browser_processes(target_browser_name)
 
-        # Get the target browser name for comparison
-        if self.browser_config.binary_location:
-            target_browser_name = os.path.basename(self.browser_config.binary_location).lower()
-        else:
-            try:
-                target_browser_path = self.get_compatible_browser()
-                target_browser_name = os.path.basename(target_browser_path).lower()
-            except (AssertionError, TypeError):
-                target_browser_name = ""
-
-        try:
-            for proc in psutil.process_iter(["pid", "name", "cmdline"]):
-                try:
-                    proc_name = proc.info["name"] or ""
-                    cmdline = proc.info["cmdline"] or []
-
-                    # Check if this is a browser process relevant to our diagnostics
-                    is_relevant_browser = False
-
-                    # Is this the target browser?
-                    is_target_browser = target_browser_name and target_browser_name in proc_name.lower()
-
-                    # Does it have remote debugging?
-                    has_remote_debugging = cmdline and any(arg.startswith("--remote-debugging-port=") for arg in cmdline)
-
-                    # Detect target browser processes for diagnostics
-                    if is_target_browser:
-                        is_relevant_browser = True
-                        # Add debugging status to the process info for better diagnostics
-                        proc.info["has_remote_debugging"] = has_remote_debugging
-
-                    if is_relevant_browser:
-                        browser_processes.append(proc.info)
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    # Process ended or is not accessible; skip it.
-                    pass
-        except (psutil.Error, PermissionError) as exc:
-            LOG.warning("(warn) Unable to inspect browser processes: %s", exc)
+        if proc_exc is not None:
+            LOG.warning("(warn) Unable to inspect browser processes: %s", proc_exc)
             browser_processes = []
 
         if browser_processes:

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -2217,11 +2217,11 @@ class TestWebScrapingDiagnostics:
             assert "=== End Diagnostics ===" in caplog.text
 
     def test_diagnose_browser_issues_remote_debugging_host_configured(self, scraper_with_config:WebScrapingMixin, caplog:pytest.LogCaptureFixture) -> None:
-        """Test diagnostic when remote debugging host is configured."""
+        """Test diagnostic ignores configured remote debugging host and uses 127.0.0.1."""
         with (
             patch("os.path.exists", return_value = True),
             patch("os.access", return_value = True),
-            patch("kleinanzeigen_bot.utils.net.is_port_open", return_value = True),
+            patch("kleinanzeigen_bot.utils.net.is_port_open", return_value = True) as mock_is_port_open,
             patch("urllib.request.urlopen") as mock_urlopen,
             patch("psutil.process_iter", return_value = []),
             patch("platform.system", return_value = "Linux"),
@@ -2238,6 +2238,9 @@ class TestWebScrapingDiagnostics:
 
             assert "(info) Remote debugging port configured: 9222" in caplog.text
             assert "(ok) Remote debugging port is open" in caplog.text
+            # Verify diagnostics ignores configured host and uses 127.0.0.1
+            mock_is_port_open.assert_called_with("127.0.0.1", 9222)
+            mock_urlopen.assert_called_with("http://127.0.0.1:9222/json/version", timeout = ANY)
 
     def test_diagnose_browser_issues_process_info_missing_name(self, scraper_with_config:WebScrapingMixin, caplog:pytest.LogCaptureFixture) -> None:
         """Test diagnostic when process info is missing name."""
@@ -2515,6 +2518,32 @@ class TestWebScrapingDiagnostics:
 
             # Verify the debug message was logged
             mock_log.debug.assert_any_call(" -> No existing browser found at %s:%s", "127.0.0.1", 9222)
+
+    def test_diagnose_browser_issues_invalid_port_raises_value_error(self, scraper_with_config:WebScrapingMixin) -> None:
+        """Invalid remote debugging port value should propagate ValueError."""
+        scraper_with_config.browser_config.arguments = ["--remote-debugging-port=abc"]
+        with pytest.raises(ValueError, match = "invalid literal for int"):
+            scraper_with_config.diagnose_browser_issues()
+
+    def test_diagnose_browser_issues_first_port_wins(self, scraper_with_config:WebScrapingMixin, caplog:pytest.LogCaptureFixture) -> None:
+        """First --remote-debugging-port= should win when multiple are present."""
+        with patch("kleinanzeigen_bot.utils.net.is_port_open", return_value = False):
+            scraper_with_config.browser_config.arguments = ["--remote-debugging-port=9222", "--remote-debugging-port=9223"]
+            scraper_with_config.diagnose_browser_issues()
+
+        assert "(info) Remote debugging port configured: 9222" in caplog.text
+        assert "9223" not in caplog.text
+
+    @patch.object(WebScrapingMixin, "_diagnose_chrome_version_issues")
+    def test_diagnose_browser_issues_port_zero_skips_probe_but_passes_through(
+        self, mock_diagnose:Mock, scraper_with_config:WebScrapingMixin, caplog:pytest.LogCaptureFixture
+    ) -> None:
+        """Port 0 should skip remote debugging probe but pass through to chrome diagnostics."""
+        scraper_with_config.browser_config.arguments = ["--remote-debugging-port=0"]
+        scraper_with_config.diagnose_browser_issues()
+
+        assert "Remote debugging port configured" not in caplog.text
+        mock_diagnose.assert_called_once_with(0)
 
 
 class TestWebScrapingMixinPortRetry:


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #
- Refactor browser diagnostics to reduce the complexity of the diagnostics orchestration while preserving the generated diagnostics report and browser workflow behavior.

## 📋 Changes Summary

- Extract factual browser diagnostic checks into focused helpers for binary detection, remote debugging port parsing, remote API probing, target browser name detection, and process discovery.
- Keep translated diagnostics logging as direct literal log calls in `diagnose_browser_issues`.
- Add regression coverage for remote debugging host handling, invalid ports, first-port precedence, and port `0` pass-through behavior.
- No dependencies, configuration changes, or additional requirements introduced.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)
- [x] ♻️ Refactor (no user-facing behavior change)

## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved browser diagnostics by breaking down remote debugging checks into clearer steps, enhancing resilience when probing the browser and inspecting running processes, and refining success vs failure logging.

* **Tests**
  * Expanded unit coverage to ensure remote debugging probing always targets `http://127.0.0.1:<port>`, validates `--remote-debugging-port` parsing (including invalid and multi-argument cases), and skips remote debugging when the port is `0` while continuing Chrome version diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->