### PR TITLE
refactor: split published ads pagination

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,7 +293,7 @@ max-args       = 6      # max. number of args for function / method (R0913)
 max-branches   = 35     # max. number of branch for function / method body (R0912)
 max-locals     = 20     # max. number of local vars for function / method body (R0914)
 max-returns    = 8      # max. number of return / yield for function / method body (R0911)
-max-statements = 115    # max. number of statements in function / method body (R0915)
+max-statements = 90    # max. number of statements in function / method body (R0915)
 max-public-methods = 20 # max. number of public methods for a class (R0904)
 
 [tool.ruff.lint.mccabe]

--- a/src/kleinanzeigen_bot/published_ads.py
+++ b/src/kleinanzeigen_bot/published_ads.py
@@ -41,6 +41,125 @@ class PublishedAdsFetchIncompleteError(KleinanzeigenBotError):
     """Raised when published ads cannot be fetched completely for ownership-critical operations."""
 
 
+def _parse_published_ads_page(
+    response:dict[str, Any],
+    page:int,
+    *,
+    strict:bool,
+) -> tuple[list[PublishedAd], Any, int] | None:
+    """Decode and extract ads from one raw API response dict."""
+    _SNIPPET_LIMIT:Final[int] = 500
+
+    def _truncate_preview(text:str, limit:int = _SNIPPET_LIMIT) -> str:
+        return text[:limit] + ("..." if len(text) > limit else "")
+
+    content = response.get("content", "")
+    if isinstance(content, bytearray):
+        content = bytes(content)
+    if isinstance(content, bytes):
+        content = content.decode("utf-8", errors = "replace")
+    if not isinstance(content, str):
+        LOG.warning("Unexpected response content type on page %s: %s", page, type(content).__name__)
+        if strict:
+            raise PublishedAdsFetchIncompleteError(_("Unexpected response content type on page %s: %s") % (page, type(content).__name__))
+        return None
+
+    try:
+        json_data = json.loads(content)
+    except (json.JSONDecodeError, TypeError) as ex:
+        if not content:
+            LOG.warning("Empty JSON response content on page %s", page)
+            if strict:
+                raise PublishedAdsFetchIncompleteError(_("Empty JSON response content on page %s") % page) from ex
+            return None
+        snippet = _truncate_preview(content)
+        LOG.warning("Failed to parse JSON response on page %s: %s (content: %s)", page, ex, snippet)
+        if strict:
+            raise PublishedAdsFetchIncompleteError(_("Failed to parse JSON response on page %s: %s (content: %s)") % (page, ex, snippet)) from ex
+        return None
+
+    if not isinstance(json_data, dict):
+        snippet = _truncate_preview(content)
+        LOG.warning("Unexpected JSON payload on page %s (content: %s)", page, snippet)
+        if strict:
+            raise PublishedAdsFetchIncompleteError(_("Unexpected JSON payload on page %s (content: %s)") % (page, snippet))
+        return None
+
+    page_ads = json_data.get("ads", [])
+    if not isinstance(page_ads, list):
+        preview = _truncate_preview(str(page_ads))
+        LOG.warning("Unexpected 'ads' type on page %s: %s value: %s", page, type(page_ads).__name__, preview)
+        if strict:
+            raise PublishedAdsFetchIncompleteError(_("Unexpected 'ads' type on page %s: %s value: %s") % (page, type(page_ads).__name__, preview))
+        return None
+
+    filtered_page_ads:list[PublishedAd] = []
+    rejected_count = 0
+    rejected_preview:str | None = None
+    for entry in page_ads:
+        if isinstance(entry, dict) and "id" in entry and "state" in entry:
+            filtered_page_ads.append(entry)
+            continue
+        rejected_count += 1
+        if rejected_preview is None:
+            rejected_preview = repr(entry)
+
+    if rejected_count > 0:
+        preview = _truncate_preview(rejected_preview or "<none>")
+        LOG.warning("Filtered %s malformed ad entries on page %s (sample: %s)", rejected_count, page, preview)
+        if strict:
+            raise PublishedAdsFetchIncompleteError(_("Filtered %s malformed ad entries on page %s (sample: %s)") % (rejected_count, page, preview))
+
+    paging = json_data.get("paging")
+    return (filtered_page_ads, paging, len(page_ads))
+
+
+def _determine_next_page(
+    paging:Any,
+    requested_page:int,
+    raw_ads_count:int,
+    *,
+    strict:bool,
+) -> int | None:
+    """Determine the next page number from paging metadata."""
+    if not isinstance(paging, dict):
+        LOG.debug("No paging dict found on page %s, assuming single page", requested_page)
+        if strict:
+            raise PublishedAdsFetchIncompleteError(_("No paging dict found on page %s") % requested_page)
+        return None
+
+    current_page_num = _misc.coerce_page_number(paging.get("pageNum"))
+    if current_page_num is None:
+        LOG.warning("Invalid 'pageNum' in paging info: %s, stopping pagination", paging.get("pageNum"))
+        if strict:
+            raise PublishedAdsFetchIncompleteError(_("Invalid 'pageNum' in paging info: %s, stopping pagination") % paging.get("pageNum"))
+        return None
+
+    total_pages = _misc.coerce_page_number(paging.get("last"))
+
+    if total_pages is not None and current_page_num >= total_pages:
+        LOG.info("Reached last page %s of %s, stopping pagination", current_page_num, total_pages)
+        return None
+
+    if raw_ads_count == 0:
+        LOG.info("No ads found on page %s, stopping pagination", requested_page)
+        return None
+
+    LOG.debug("Page %s: fetched %s ads (numFound=%s)", requested_page, raw_ads_count, paging.get("numFound"))
+
+    next_page = _misc.coerce_page_number(paging.get("next"))
+    if next_page is None:
+        if total_pages is not None:
+            LOG.warning("Invalid 'next' page value in paging info: %s, stopping pagination", paging.get("next"))
+            if strict:
+                raise PublishedAdsFetchIncompleteError(_("Invalid 'next' page value in paging info: %s, stopping pagination") % paging.get("next"))
+        else:
+            LOG.debug("No 'next' in paging on page %s, assuming last page", requested_page)
+        return None
+
+    return next_page
+
+
 async def fetch_published_ads(
     web:WebScrapingMixin,
     root_url:str,
@@ -60,123 +179,36 @@ async def fetch_published_ads(
     ads:list[PublishedAd] = []
     page = 1
     MAX_PAGE_LIMIT:Final[int] = 100
-    SNIPPET_LIMIT:Final[int] = 500
-
-    def _handle_incomplete_fetch(template:str, *args:Any, cause:Exception | None = None) -> None:
-        if strict:
-            raise PublishedAdsFetchIncompleteError(_(template) % args) from cause
-
     while True:
         # Safety check: don't paginate beyond reasonable limit
         if page > MAX_PAGE_LIMIT:
             LOG.warning("Stopping pagination after %s pages to avoid infinite loop", MAX_PAGE_LIMIT)
-            _handle_incomplete_fetch("Stopping pagination after %s pages to avoid infinite loop", MAX_PAGE_LIMIT)
+            if strict:
+                raise PublishedAdsFetchIncompleteError(_("Stopping pagination after %s pages to avoid infinite loop") % MAX_PAGE_LIMIT)
             break
 
         try:
             response = await web.web_request(f"{root_url}/m-meine-anzeigen-verwalten.json?sort=DEFAULT&pageNum={page}")
         except TimeoutError as ex:
             LOG.warning("Pagination request failed on page %s: %s", page, ex)
-            _handle_incomplete_fetch("Pagination request failed on page %s: %s", page, ex, cause = ex)
+            if strict:
+                raise PublishedAdsFetchIncompleteError(_("Pagination request failed on page %s: %s") % (page, ex)) from ex
             break
 
         if not isinstance(response, dict):
             LOG.warning("Unexpected pagination response type on page %s: %s", page, type(response).__name__)
-            _handle_incomplete_fetch("Unexpected pagination response type on page %s: %s", page, type(response).__name__)
+            if strict:
+                raise PublishedAdsFetchIncompleteError(_("Unexpected pagination response type on page %s: %s") % (page, type(response).__name__))
             break
 
-        content = response.get("content", "")
-        if isinstance(content, bytearray):
-            content = bytes(content)
-        if isinstance(content, bytes):
-            content = content.decode("utf-8", errors = "replace")
-        if not isinstance(content, str):
-            LOG.warning("Unexpected response content type on page %s: %s", page, type(content).__name__)
-            _handle_incomplete_fetch("Unexpected response content type on page %s: %s", page, type(content).__name__)
+        result = _parse_published_ads_page(response, page, strict = strict)
+        if result is None:
             break
+        filtered_ads, paging, raw_ads_count = result
+        ads.extend(filtered_ads)
 
-        try:
-            json_data = json.loads(content)
-        except (json.JSONDecodeError, TypeError) as ex:
-            if not content:
-                LOG.warning("Empty JSON response content on page %s", page)
-                _handle_incomplete_fetch("Empty JSON response content on page %s", page, cause = ex)
-                break
-            snippet = content[:SNIPPET_LIMIT] + ("..." if len(content) > SNIPPET_LIMIT else "")
-            LOG.warning("Failed to parse JSON response on page %s: %s (content: %s)", page, ex, snippet)
-            _handle_incomplete_fetch("Failed to parse JSON response on page %s: %s (content: %s)", page, ex, snippet, cause = ex)
-            break
-
-        if not isinstance(json_data, dict):
-            snippet = content[:SNIPPET_LIMIT] + ("..." if len(content) > SNIPPET_LIMIT else "")
-            LOG.warning("Unexpected JSON payload on page %s (content: %s)", page, snippet)
-            _handle_incomplete_fetch("Unexpected JSON payload on page %s (content: %s)", page, snippet)
-            break
-
-        page_ads = json_data.get("ads", [])
-        if not isinstance(page_ads, list):
-            preview = str(page_ads)
-            if len(preview) > SNIPPET_LIMIT:
-                preview = preview[:SNIPPET_LIMIT] + "..."
-            LOG.warning("Unexpected 'ads' type on page %s: %s value: %s", page, type(page_ads).__name__, preview)
-            _handle_incomplete_fetch("Unexpected 'ads' type on page %s: %s value: %s", page, type(page_ads).__name__, preview)
-            break
-
-        filtered_page_ads:list[PublishedAd] = []
-        rejected_count = 0
-        rejected_preview:str | None = None
-        for entry in page_ads:
-            if isinstance(entry, dict) and "id" in entry and "state" in entry:
-                filtered_page_ads.append(entry)
-                continue
-            rejected_count += 1
-            if rejected_preview is None:
-                rejected_preview = repr(entry)
-
-        if rejected_count > 0:
-            preview = rejected_preview or "<none>"
-            if len(preview) > SNIPPET_LIMIT:
-                preview = preview[:SNIPPET_LIMIT] + "..."
-            LOG.warning("Filtered %s malformed ad entries on page %s (sample: %s)", rejected_count, page, preview)
-            _handle_incomplete_fetch("Filtered %s malformed ad entries on page %s (sample: %s)", rejected_count, page, preview)
-
-        ads.extend(filtered_page_ads)
-
-        paging = json_data.get("paging")
-        if not isinstance(paging, dict):
-            LOG.debug("No paging dict found on page %s, assuming single page", page)
-            _handle_incomplete_fetch("No paging dict found on page %s", page)
-            break
-
-        # Use only real API fields (confirmed from production data)
-        current_page_num = _misc.coerce_page_number(paging.get("pageNum"))
-        total_pages = _misc.coerce_page_number(paging.get("last"))
-
-        if current_page_num is None:
-            LOG.warning("Invalid 'pageNum' in paging info: %s, stopping pagination", paging.get("pageNum"))
-            _handle_incomplete_fetch("Invalid 'pageNum' in paging info: %s, stopping pagination", paging.get("pageNum"))
-            break
-
-        # Stop if reached last page (only when API provides 'last')
-        if total_pages is not None and current_page_num >= total_pages:
-            LOG.info("Reached last page %s of %s, stopping pagination", current_page_num, total_pages)
-            break
-
-        # Safety: stop if no ads returned
-        if len(page_ads) == 0:
-            LOG.info("No ads found on page %s, stopping pagination", page)
-            break
-
-        LOG.debug("Page %s: fetched %s ads (numFound=%s)", page, len(page_ads), paging.get("numFound"))
-
-        # Use API's next field for navigation (more robust than our counter)
-        next_page = _misc.coerce_page_number(paging.get("next"))
+        next_page = _determine_next_page(paging, page, raw_ads_count, strict = strict)
         if next_page is None:
-            if total_pages is not None:
-                LOG.warning("Invalid 'next' page value in paging info: %s, stopping pagination", paging.get("next"))
-                _handle_incomplete_fetch("Invalid 'next' page value in paging info: %s, stopping pagination", paging.get("next"))
-            else:
-                LOG.debug("No 'next' in paging on page %s, assuming last page", page)
             break
         page = next_page
 

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -209,19 +209,24 @@ kleinanzeigen_bot/publishing_workflow.py:
 kleinanzeigen_bot/published_ads.py:
 #################################################
   fetch_published_ads:
-    "Empty JSON response content on page %s": "Leerer JSON-Antwortinhalt auf Seite %s"
-    "Failed to parse JSON response on page %s: %s (content: %s)": "Fehler beim Parsen der JSON-Antwort auf Seite %s: %s (Inhalt: %s)"
     "Stopping pagination after %s pages to avoid infinite loop": "Stoppe die Seitenaufschaltung nach %s Seiten, um eine Endlosschleife zu vermeiden"
     "Pagination request failed on page %s: %s": "Seitenabfrage auf Seite %s fehlgeschlagen: %s"
     "Unexpected pagination response type on page %s: %s": "Unerwarteter Typ der Paginierungsantwort auf Seite %s: %s"
+
+  _parse_published_ads_page:
     "Unexpected response content type on page %s: %s": "Unerwarteter Antwortinhalt-Typ auf Seite %s: %s"
+    "Empty JSON response content on page %s": "Leerer JSON-Antwortinhalt auf Seite %s"
+    "Failed to parse JSON response on page %s: %s (content: %s)": "Fehler beim Parsen der JSON-Antwort auf Seite %s: %s (Inhalt: %s)"
     "Unexpected JSON payload on page %s (content: %s)": "Unerwartete JSON-Antwort auf Seite %s (Inhalt: %s)"
     "Unexpected 'ads' type on page %s: %s value: %s": "Unerwarteter 'ads'-Typ auf Seite %s: %s Wert: %s"
     "Filtered %s malformed ad entries on page %s (sample: %s)": "%s fehlerhafte Anzeigen-Einträge auf Seite %s gefiltert (Beispiel: %s)"
+
+  _determine_next_page:
     "Reached last page %s of %s, stopping pagination": "Letzte Seite %s von %s erreicht, beende Paginierung"
     "No ads found on page %s, stopping pagination": "Keine Anzeigen auf Seite %s gefunden, beende Paginierung"
     "Invalid 'next' page value in paging info: %s, stopping pagination": "Ungültiger 'next'-Seitenwert in Paginierungsinfo: %s, beende Paginierung"
     "Invalid 'pageNum' in paging info: %s, stopping pagination": "Ungültiger 'pageNum'-Wert in Paginierungsinfo: %s, beende Paginierung"
+    "No paging dict found on page %s": "Kein Paging-Dictionary auf Seite %s gefunden"
 
 #################################################
 kleinanzeigen_bot/publishing_form.py:

--- a/src/kleinanzeigen_bot/utils/pydantics.py
+++ b/src/kleinanzeigen_bot/utils/pydantics.py
@@ -93,6 +93,7 @@ def __get_message_template(error_code:str) -> str | None:  # noqa: C901  # gener
     # https://github.com/pydantic/pydantic-core/blob/d03bf4a01ca3b378cc8590bd481f307e82115bc6/src/errors/types.rs#L477
     # ruff: noqa: PLR0911 Too many return statements
     # ruff: noqa: PLR0912 Too many branches
+    # ruff: noqa: PLR0915 Too many statements
     # ruff: noqa: E701 Multiple statements on one line (colon)
     match error_code:
         case "no_such_attribute": return _("Object has no attribute '{attribute}'")

--- a/tests/unit/test_published_ads.py
+++ b/tests/unit/test_published_ads.py
@@ -381,3 +381,111 @@ class TestJSONPagination:
         assert published_ads.ad_matches_id({"id": "nope"}, 42) is False
         # Boolean (True → 1) — accepting bool-to-int coercion is current behavior
         assert published_ads.ad_matches_id({"id": True}, 1) is True
+
+    # ── Bytearray / bytes content decode ──────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_bytearray_content_decodes(self, bot:KleinanzeigenBot) -> None:
+        """Bytearray response content should be decoded correctly (non-strict, happy path)."""
+        response_payload = bytearray(b'{"ads":[],"paging":{"pageNum":1,"last":1}}')
+        with patch.object(bot, "web_request", new_callable = AsyncMock) as mock_request:
+            mock_request.return_value = {"content": response_payload}
+            result = await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url)
+            if not isinstance(result, list):
+                pytest.fail(f"expected result to be list, got {type(result).__name__}")
+            if len(result) != 0:
+                pytest.fail(f"expected empty list, got {len(result)} items")
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_bytes_content_decodes(self, bot:KleinanzeigenBot) -> None:
+        """Bytes response content should be decoded correctly (non-strict, happy path)."""
+        response_payload = b'{"ads":[],"paging":{"pageNum":1,"last":1}}'
+        with patch.object(bot, "web_request", new_callable = AsyncMock) as mock_request:
+            mock_request.return_value = {"content": response_payload}
+            result = await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url)
+            if not isinstance(result, list):
+                pytest.fail(f"expected result to be list, got {type(result).__name__}")
+            if len(result) != 0:
+                pytest.fail(f"expected empty list, got {len(result)} items")
+
+    # ── _parse_published_ads_page – strict error paths ────────────────────
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_non_dict_json_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should raise on non-dict JSON payload (e.g. JSON array)."""
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = {"content": '["not", "a", "dict"]'}),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = "Unexpected JSON payload"),
+        ):
+            await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url, strict = True)
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_empty_json_content_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should raise on empty JSON content string."""
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = {"content": ""}),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = "Empty JSON response content"),
+        ):
+            await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url, strict = True)
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_json_parse_failure_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should raise on JSON parse failure."""
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = {"content": "{invalid"}),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = "Failed to parse JSON"),
+        ):
+            await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url, strict = True)
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_non_list_ads_type_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should raise when 'ads' field is not a list."""
+        response_data = {"ads": "not_a_list", "paging": {"pageNum": 1, "last": 1}}
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps(response_data)}),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = "Unexpected 'ads' type"),
+        ):
+            await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url, strict = True)
+
+    # ── _determine_next_page – strict error paths ─────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_missing_paging_dict_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should raise when paging dict is entirely absent from response."""
+        response_data = {"ads": [{"id": 1, "state": "active"}]}
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps(response_data)}),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = "No paging dict found"),
+        ):
+            await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url, strict = True)
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_invalid_page_num_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should raise when paging 'pageNum' is not a valid number."""
+        response_data = {"ads": [{"id": 1, "state": "active"}], "paging": {"pageNum": "not_a_number", "last": 1}}
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps(response_data)}),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = "Invalid 'pageNum'"),
+        ):
+            await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url, strict = True)
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_invalid_next_page_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should raise when 'next' page value is invalid and total_pages is known."""
+        response_data = {"ads": [{"id": 1, "state": "active"}], "paging": {"pageNum": 1, "last": 3, "next": "garbage"}}
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = {"content": json.dumps(response_data)}),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = "Invalid 'next' page value"),
+        ):
+            await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url, strict = True)
+
+    # ── fetch_published_ads – strict guards ───────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_fetch_published_ads_non_dict_response_type_strict_raises(self, bot:KleinanzeigenBot) -> None:
+        """Strict mode should raise when web_request returns a non-dict response."""
+        with (
+            patch.object(bot, "web_request", new_callable = AsyncMock, return_value = "not a dict"),
+            pytest.raises(PublishedAdsFetchIncompleteError, match = "Unexpected pagination response type"),
+        ):
+            await published_ads.fetch_published_ads(web = bot, root_url = bot.root_url, strict = True)


### PR DESCRIPTION
## ℹ️ Description

Extract content-decoding and paging-navigation logic from `fetch_published_ads` into focused module-level helpers, reducing function complexity while preserving all behavior.

## 📋 Changes Summary

- **`published_ads.py`**: Extracted `_parse_published_ads_page()` (content decode, JSON parse, payload validation, ad filtering) and `_determine_next_page()` (paging metadata resolution, last-page/empty-ads guards). Main `fetch_published_ads` is now a clean orchestration loop: request → response check → parse → extend → paginate.
- **`translations.de.yaml`**: Split the single `fetch_published_ads:` translation section into three sections (`fetch_published_ads:`, `_parse_published_ads_page:`, `_determine_next_page:`) matching the new caller function names. Added missing translation for "No paging dict found on page %s".
- **`pyproject.toml`**: Lowered `max-statements` from 115 to 90.
- **`pydantics.py`**: Added `PLR0915` noqa for `__get_message_template` (already an approved exception for the generated pydantic error-code mapping).

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved published-ads fetching by separating response decoding and pagination handling into dedicated helpers, while preserving existing behavior.
  * Reworked strict-mode validation and stopping conditions for clearer control flow and more consistent error handling.

* **Chores**
  * Updated linting limits to enforce stricter code quality.
  * Added targeted lint suppression for an overly complex section.

* **Tests**
  * Expanded unit test coverage for published-ads content decoding and strict-mode failure cases across multiple malformed/edge responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->