### PR TITLE
refactor: separate download_ads workflow modes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,10 +290,10 @@ min-file-size = 256
 # https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#design-checker-messages
 max-args       = 6      # max. number of args for function / method (R0913)
 # max-attributes = 15   # TODO max. number of instance attrs for a class (R0902)
-max-branches   = 35     # max. number of branch for function / method body (R0912)
+max-branches   = 31     # max. number of branch for function / method body (R0912)
 max-locals     = 20     # max. number of local vars for function / method body (R0914)
 max-returns    = 8      # max. number of return / yield for function / method body (R0911)
-max-statements = 90    # max. number of statements in function / method body (R0915)
+max-statements = 76     # max. number of statements in function / method body (R0915)
 max-public-methods = 20 # max. number of public methods for a class (R0904)
 
 [tool.ruff.lint.mccabe]

--- a/src/kleinanzeigen_bot/download_flow.py
+++ b/src/kleinanzeigen_bot/download_flow.py
@@ -81,6 +81,120 @@ async def _download_ad_with_resolved_state(
     await ad_extractor.download_ad(ad_id, active = resolved.active)
 
 
+async def _fetch_published_ads_by_id(
+    web:WebScrapingMixin,
+    root_url:str,
+    *,
+    strict:bool,
+) -> dict[int, PublishedAd]:
+    """Fetch published ads from manage-ads API and build a lookup dict."""
+    LOG.info("Fetching ad metadata (status, expiry dates)...")
+    published_ads_list = await published_ads.fetch_published_ads(web, root_url, strict = strict)
+    published_ads_by_id:dict[int, PublishedAd] = {}
+    for published_ad in published_ads_list:
+        try:
+            ad_id = published_ad.get("id")
+            if ad_id is not None:
+                published_ads_by_id[int(ad_id)] = published_ad
+        except (ValueError, TypeError):
+            LOG.warning("Skipping ad with non-numeric id: %s", published_ad.get("id"))
+    LOG.info("Loaded metadata for %s published ads.", len(published_ads_by_id))
+    return published_ads_by_id
+
+
+async def _download_all_ads(
+    ad_extractor:extract.AdExtractor,
+    own_ad_urls:list[str],
+    published_ads_by_id:dict[int, PublishedAd],
+) -> None:
+    """Download all ads found on the overview page."""
+    LOG.info("Starting download of all ads...")
+
+    valid_ad_refs:list[tuple[str, int]] = []
+    for ad_url in own_ad_urls:
+        ad_id = ad_extractor.extract_ad_id_from_ad_url(ad_url)
+        if ad_id == -1:
+            # Skip ads with invalid URLs (warning already logged by extract_ad_id_from_ad_url)
+            continue
+        valid_ad_refs.append((ad_url, ad_id))
+
+    success_count = 0
+    for idx, (ad_url, ad_id) in enumerate(valid_ad_refs, start = 1):
+        LOG.info("Downloading %d/%d ads...", idx, len(valid_ad_refs))
+
+        if await ad_extractor.navigate_to_ad_page(ad_url):
+            await _download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
+            success_count += 1
+    LOG.info("%d of %d ads were downloaded from your profile.", success_count, len(valid_ad_refs))
+
+
+async def _download_new_ads(
+    ad_extractor:extract.AdExtractor,
+    own_ad_urls:list[str],
+    published_ads_by_id:dict[int, PublishedAd],
+    load_ads_func:LoadAdsFunc,
+) -> None:
+    """Download only ads that haven't been saved yet."""
+    # check which ads already saved
+    saved_ad_ids:set[int] = set()
+    ads = load_ads_func(ignore_inactive = False, exclude_ads_with_id = False)
+    for ad in ads:
+        saved_ad_id = ad[1].id
+        if saved_ad_id is None:
+            LOG.debug("Skipping saved ad without id (likely unpublished or manually created): %s", ad[0])
+            continue
+        saved_ad_ids.add(int(saved_ad_id))
+
+    # determine ad IDs from links (dict dedupes duplicate URLs)
+    ad_id_by_url = {url: ad_extractor.extract_ad_id_from_ad_url(url) for url in own_ad_urls}
+
+    LOG.info("Starting download of not yet downloaded ads...")
+    ads_to_download:list[tuple[str, int]] = []
+    for ad_url, ad_id in ad_id_by_url.items():
+        # Skip ads with invalid URLs (warning already logged by extract_ad_id_from_ad_url)
+        if ad_id == -1:
+            continue
+
+        # check if ad with ID already saved
+        if ad_id in saved_ad_ids:
+            LOG.info("The ad with id %d has already been saved.", ad_id)
+            continue
+        ads_to_download.append((ad_url, ad_id))
+
+    new_count = 0
+    for idx, (ad_url, ad_id) in enumerate(ads_to_download, start = 1):
+        LOG.info("Downloading %d/%d ads...", idx, len(ads_to_download))
+
+        if await ad_extractor.navigate_to_ad_page(ad_url):
+            await _download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
+            new_count += 1
+    LOG.info("%s were downloaded from your profile.", pluralize("new ad", new_count))
+
+
+async def _download_ads_by_ids(
+    ad_extractor:extract.AdExtractor,
+    ids:list[int],
+    published_ads_by_id:dict[int, PublishedAd],
+) -> None:
+    """Download specific ads by their numeric IDs."""
+    LOG.info("Starting download of ad(s) with the id(s):")
+    LOG.info(" | ".join([str(ad_id) for ad_id in ids]))
+
+    for idx, ad_id in enumerate(ids, start = 1):
+        LOG.info("Downloading %d/%d ads...", idx, len(ids))
+        exists = await ad_extractor.navigate_to_ad_page(ad_id)
+        if exists:
+            resolved = _download_selection.resolve_download_ad_activity(ad_id, published_ads_by_id)
+            if not resolved.owned:
+                # Foreign ad - expected for numeric IDs (can download any public ad)
+                LOG.warning("Ad id %d is not in your published profile ads. Saving downloaded ad as inactive.", ad_id)
+
+            await ad_extractor.download_ad(ad_id, active = resolved.active)
+            LOG.info("Downloaded ad with id %d", ad_id)
+        else:
+            LOG.error("The page with the id %d does not exist!", ad_id)
+
+
 async def download_ads(
     web:WebScrapingMixin,
     config:Config,
@@ -104,104 +218,29 @@ async def download_ads(
     else:
         effective_selector = ads_selector  # numeric IDs: "123,456" — unchanged
 
-    # Fetch published ads once from manage-ads JSON to avoid repetitive API calls during extraction
-    # Build lookup dict inline and pass directly to extractor (no cache abstraction needed)
-    LOG.info("Fetching ad metadata (status, expiry dates)...")
-    published_ads_list = await published_ads.fetch_published_ads(web, root_url, strict = _download_selection.is_numeric_ids_selector(effective_selector))
-    published_ads_by_id:dict[int, PublishedAd] = {}
-    for published_ad in published_ads_list:
-        try:
-            ad_id = published_ad.get("id")
-            if ad_id is not None:
-                published_ads_by_id[int(ad_id)] = published_ad
-        except (ValueError, TypeError):
-            LOG.warning("Skipping ad with non-numeric id: %s", published_ad.get("id"))
-    LOG.info("Loaded metadata for %s published ads.", len(published_ads_by_id))
+    # Fetch published ads once and build a lookup dict
+    published_ads_by_id = await _fetch_published_ads_by_id(
+        web, root_url, strict = _download_selection.is_numeric_ids_selector(effective_selector),
+    )
 
     download_dir = resolve_download_dir(config, config_file_path, workspace)
     _xdg_paths.ensure_directory(download_dir, "downloaded ads directory")
     LOG.info("Ads download directory: %s", download_dir)
     ad_extractor = extract.AdExtractor(web.browser, config, download_dir, published_ads_by_id = published_ads_by_id)
 
-    if effective_selector in {"all", "new"}:  # explore ads overview for these two modes
+    if effective_selector in {"all", "new"}:
         LOG.info("Scanning ad overview for navigation URLs...")
         own_ad_urls = await ad_extractor.extract_own_ads_urls()
         LOG.info("Found %s.", pluralize("ad URL", len(own_ad_urls)))
 
-        if effective_selector == "all":  # download all of your ads
-            LOG.info("Starting download of all ads...")
+        if effective_selector == "all":
+            await _download_all_ads(ad_extractor, own_ad_urls, published_ads_by_id)
+        else:
+            await _download_new_ads(ad_extractor, own_ad_urls, published_ads_by_id, load_ads_func)
 
-            valid_ad_refs:list[tuple[str, int]] = []
-            for ad_url in own_ad_urls:
-                ad_id = ad_extractor.extract_ad_id_from_ad_url(ad_url)
-                if ad_id == -1:
-                    # Skip ads with invalid URLs (warning already logged by extract_ad_id_from_ad_url)
-                    continue
-                valid_ad_refs.append((ad_url, ad_id))
-
-            success_count = 0
-            # call download function for each ad page
-            for idx, (ad_url, ad_id) in enumerate(valid_ad_refs, start = 1):
-                LOG.info("Downloading %d/%d ads...", idx, len(valid_ad_refs))
-
-                if await ad_extractor.navigate_to_ad_page(ad_url):
-                    await _download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
-                    success_count += 1
-            LOG.info("%d of %d ads were downloaded from your profile.", success_count, len(valid_ad_refs))
-
-        elif effective_selector == "new":  # download only unsaved ads
-            # check which ads already saved
-            saved_ad_ids:set[int] = set()
-            ads = load_ads_func(ignore_inactive = False, exclude_ads_with_id = False)  # do not skip because of existing IDs
-            for ad in ads:
-                saved_ad_id = ad[1].id
-                if saved_ad_id is None:
-                    LOG.debug("Skipping saved ad without id (likely unpublished or manually created): %s", ad[0])
-                    continue
-                saved_ad_ids.add(int(saved_ad_id))
-
-            # determine ad IDs from links
-            ad_id_by_url = {url: ad_extractor.extract_ad_id_from_ad_url(url) for url in own_ad_urls}
-
-            LOG.info("Starting download of not yet downloaded ads...")
-            ads_to_download:list[tuple[str, int]] = []
-            for ad_url, ad_id in ad_id_by_url.items():
-                # Skip ads with invalid URLs (warning already logged by extract_ad_id_from_ad_url)
-                if ad_id == -1:
-                    continue
-
-                # check if ad with ID already saved
-                if ad_id in saved_ad_ids:
-                    LOG.info("The ad with id %d has already been saved.", ad_id)
-                    continue
-                ads_to_download.append((ad_url, ad_id))
-
-            new_count = 0
-            for idx, (ad_url, ad_id) in enumerate(ads_to_download, start = 1):
-                LOG.info("Downloading %d/%d ads...", idx, len(ads_to_download))
-
-                if await ad_extractor.navigate_to_ad_page(ad_url):
-                    await _download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
-                    new_count += 1
-            LOG.info("%s were downloaded from your profile.", pluralize("new ad", new_count))
-
-    elif _download_selection.is_numeric_ids_selector(effective_selector):  # download ad(s) with specific id(s)
+    elif _download_selection.is_numeric_ids_selector(effective_selector):
         ids = [int(n) for n in effective_selector.split(",")]
-        LOG.info("Starting download of ad(s) with the id(s):")
-        LOG.info(" | ".join([str(ad_id) for ad_id in ids]))
+        await _download_ads_by_ids(ad_extractor, ids, published_ads_by_id)
 
-        for idx, ad_id in enumerate(ids, start = 1):  # call download routine for every id
-            LOG.info("Downloading %d/%d ads...", idx, len(ids))
-            exists = await ad_extractor.navigate_to_ad_page(ad_id)
-            if exists:
-                resolved = _download_selection.resolve_download_ad_activity(ad_id, published_ads_by_id)
-                if not resolved.owned:
-                    # Foreign ad - expected for numeric IDs (can download any public ad)
-                    LOG.warning("Ad id %d is not in your published profile ads. Saving downloaded ad as inactive.", ad_id)
-
-                await ad_extractor.download_ad(ad_id, active = resolved.active)
-                LOG.info("Downloaded ad with id %d", ad_id)
-            else:
-                LOG.error("The page with the id %d does not exist!", ad_id)
     else:
         LOG.error("Invalid ads selector: %s. Use 'all', 'new', or comma-separated numeric IDs.", effective_selector)

--- a/src/kleinanzeigen_bot/download_flow.py
+++ b/src/kleinanzeigen_bot/download_flow.py
@@ -218,9 +218,15 @@ async def download_ads(
     else:
         effective_selector = ads_selector  # numeric IDs: "123,456" — unchanged
 
+    # Validate selector before fetching metadata
+    is_numeric_selector = _download_selection.is_numeric_ids_selector(effective_selector)
+    if effective_selector not in {"all", "new"} and not is_numeric_selector:
+        LOG.error("Invalid ads selector: %s. Use 'all', 'new', or comma-separated numeric IDs.", effective_selector)
+        return
+
     # Fetch published ads once and build a lookup dict
     published_ads_by_id = await _fetch_published_ads_by_id(
-        web, root_url, strict = _download_selection.is_numeric_ids_selector(effective_selector),
+        web, root_url, strict = is_numeric_selector,
     )
 
     download_dir = resolve_download_dir(config, config_file_path, workspace)
@@ -238,9 +244,6 @@ async def download_ads(
         else:
             await _download_new_ads(ad_extractor, own_ad_urls, published_ads_by_id, load_ads_func)
 
-    elif _download_selection.is_numeric_ids_selector(effective_selector):
+    elif is_numeric_selector:
         ids = [int(n) for n in effective_selector.split(",")]
         await _download_ads_by_ids(ad_extractor, ids, published_ads_by_id)
-
-    else:
-        LOG.error("Invalid ads selector: %s. Use 'all', 'new', or comma-separated numeric IDs.", effective_selector)

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -402,25 +402,35 @@ kleinanzeigen_bot/download_flow.py:
 #################################################
   download_ads:
     "Ads download directory: %s": "Anzeigen-Download-Verzeichnis: %s"
-    "Fetching ad metadata (status, expiry dates)...": "Lade Anzeigen-Metadaten (Status, Ablaufdaten)..."
-    "Loaded metadata for %s published ads.": "Metadaten für %s veröffentlichte Anzeigen geladen."
     "Scanning ad overview for navigation URLs...": "Suche Navigations-URLs in Anzeigenübersicht..."
     "Found %s.": "%s gefunden."
     "ad URL": "Anzeigen-URL"
+    "Invalid ads selector: %s. Use 'all', 'new', or comma-separated numeric IDs.": "Ungültiger Anzeigen-Selektor: %s. Verwende 'all', 'new', oder kommagetrennte numerische IDs."
+
+  _fetch_published_ads_by_id:
+    "Fetching ad metadata (status, expiry dates)...": "Lade Anzeigen-Metadaten (Status, Ablaufdaten)..."
+    "Loaded metadata for %s published ads.": "Metadaten für %s veröffentlichte Anzeigen geladen."
+    "Skipping ad with non-numeric id: %s": "Überspringe Anzeige mit nicht-numerischer ID: %s"
+
+  _download_all_ads:
     "Starting download of all ads...": "Starte den Download aller Anzeigen..."
     "Downloading %d/%d ads...": "Lade Anzeige %d/%d herunter..."
     "%d of %d ads were downloaded from your profile.": "%d von %d Anzeigen wurden aus Ihrem Profil heruntergeladen."
+
+  _download_new_ads:
     "Starting download of not yet downloaded ads...": "Starte den Download noch nicht heruntergeladener Anzeigen..."
-    "Skipping ad with non-numeric id: %s": "Überspringe Anzeige mit nicht-numerischer ID: %s"
+    "Downloading %d/%d ads...": "Lade Anzeige %d/%d herunter..."
+    "Skipping saved ad without id (likely unpublished or manually created): %s": "Überspringe gespeicherte Anzeige ohne ID (vermutlich nicht veröffentlicht oder manuell erstellt): %s"
     "The ad with id %d has already been saved.": "Die Anzeige mit der ID %d wurde bereits gespeichert."
     "%s were downloaded from your profile.": "%s wurden aus Ihrem Profil heruntergeladen."
     "new ad": "neue Anzeige"
+
+  _download_ads_by_ids:
     "Starting download of ad(s) with the id(s):": "Starte Download der Anzeige(n) mit den ID(s):"
+    "Downloading %d/%d ads...": "Lade Anzeige %d/%d herunter..."
     "Ad id %d is not in your published profile ads. Saving downloaded ad as inactive.": "Anzeigen-ID %d ist nicht in Ihren veröffentlichten Profilanzeigen. Speichere die heruntergeladene Anzeige als inaktiv."
     "Downloaded ad with id %d": "Anzeige mit der ID %d heruntergeladen"
-    "Invalid ads selector: %s. Use 'all', 'new', or comma-separated numeric IDs.": "Ungültiger Anzeigen-Selektor: %s. Verwende 'all', 'new', oder kommagetrennte numerische IDs."
     "The page with the id %d does not exist!": "Die Seite mit der ID %d existiert nicht!"
-    "Skipping saved ad without id (likely unpublished or manually created): %s": "Überspringe gespeicherte Anzeige ohne ID (vermutlich nicht veröffentlicht oder manuell erstellt): %s"
 
   _download_ad_with_resolved_state:
     "Ad %d found in overview but not in published profile. Saving as inactive.": "Anzeige %d wurde in der Übersicht gefunden, aber nicht im veröffentlichten Profil. Speichere als inaktiv."


### PR DESCRIPTION
## ℹ️ Description

Extract four private async helpers from `download_ads()` to separate per-mode workflow logic.

- Motivation: Reduce function complexity, enable tighter pylint thresholds

## 📋 Changes Summary

- Extracted `_fetch_published_ads_by_id` — fetch and build published ads lookup dict
- Extracted `_download_all_ads` — download all ads from overview page
- Extracted `_download_new_ads` — download only unsaved ads (preserving URL dedup behavior)
- Extracted `_download_ads_by_ids` — download specific ads by numeric ID (preserving distinct warning semantics)
- Slimmed `download_ads()` to ~48-line orchestrator (was ~124 lines)
- Restructured `translations.de.yaml` — messages moved to per-function sections
- Ratcheted pylint thresholds: max-statements 90→76, max-branches 35→31

### ⚙️ Type of Change
- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

Internal refactor, no user-visible behavior change.

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`): 1286 passed, 4 skipped
- [x] I have formatted the code (`pdm run format`)
- [x] I have verified that linting passes (`pdm run lint`)
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened code quality standards and refactored internal ad downloading logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->