### PR TITLE
refactor: remove dead wrapper methods from KleinanzeigenBot

### DIFF
--- a/src/kleinanzeigen_bot/app.py
+++ b/src/kleinanzeigen_bot/app.py
@@ -4,7 +4,7 @@
 import asyncio, importlib, os, sys  # isort: skip
 from gettext import gettext as _
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import certifi
 
@@ -397,21 +397,6 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         _xdg_paths.ensure_directory(workspace.diagnostics_dir, "diagnostics directory")
         return workspace.diagnostics_dir
 
-    async def _capture_login_detection_diagnostics_if_enabled(
-        self,
-        *,
-        base_prefix:str = "login_detection_inconclusive",
-        pause_banner_message:str = "# Login detection remained inconclusive. Browser is paused for manual inspection.",
-    ) -> None:
-        await _login_flow.capture_login_detection_diagnostics_if_enabled(
-            self,
-            base_prefix = base_prefix,
-            pause_banner_message = pause_banner_message,
-            diagnostics_config = getattr(self.config, "diagnostics", None),
-            diagnostics_output_dir_fn = self._diagnostics_output_dir,
-            log_file_path = self.log_file_path,
-        )
-
     async def _capture_publish_error_diagnostics_if_enabled(
         self,
         ad_cfg:Ad,
@@ -466,34 +451,8 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         except Exception as error:  # noqa: BLE001
             LOG.warning("Diagnostics capture failed during publish error handling: %s", error)
 
-    async def _has_logged_in_marker(self) -> bool:
-        return await _login_flow.has_logged_in_marker(self, username = self.config.login.username)
-
     async def is_logged_in(self) -> bool:
         return await _login_flow.is_logged_in(self, username = self.config.login.username)
-
-    async def _check_publishing_result(self) -> bool:
-        return await _publishing_workflow.check_publishing_result(self)
-
-    async def _delete_old_ad_if_needed(
-        self, ad_cfg:Ad, published_ads_list:list[PublishedAd],
-        *, timing:Literal["BEFORE_PUBLISH", "AFTER_PUBLISH"],
-    ) -> None:
-        """Delete an old ad before or after (re-)publishing, depending on config.
-
-        Skips deletion when keep_old_ads is True or when the configured
-        ``delete_old_ads`` timing does not match *timing*.
-
-        In ``AFTER_PUBLISH`` mode, title-based deletion is always disabled to
-        avoid accidentally removing the newly published ad.
-        """
-        await _publishing_workflow.delete_old_ad_if_needed(
-            self, ad_cfg, published_ads_list,
-            timing = timing,
-            keep_old_ads = self.keep_old_ads,
-            config = self.config,
-            root_url = self.root_url,
-        )
 
     async def publish_ads(self, ad_cfgs:list[tuple[str, Ad, dict[str, Any]]]) -> None:
         await _publishing_workflow.publish_ads(

--- a/tests/unit/test_login_flow.py
+++ b/tests/unit/test_login_flow.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
+from kleinanzeigen_bot import login_flow
 from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.login_flow import (
     LoginDetectionReason,
@@ -397,7 +398,13 @@ class TestKleinanzeigenBotAuthentication:
         test_bot.page = page
 
         with patch("kleinanzeigen_bot.utils.diagnostics.capture_diagnostics", new_callable = AsyncMock) as mock_capture:
-            await test_bot._capture_login_detection_diagnostics_if_enabled(base_prefix = "login_detection_test")
+            await login_flow.capture_login_detection_diagnostics_if_enabled(
+                web = test_bot,
+                base_prefix = "login_detection_test",
+                diagnostics_config = test_bot.config.diagnostics,
+                diagnostics_output_dir_fn = test_bot._diagnostics_output_dir,
+                log_file_path = test_bot.log_file_path,
+            )
 
             mock_capture.assert_awaited_once()
             assert mock_capture.await_args is not None
@@ -420,7 +427,13 @@ class TestKleinanzeigenBotAuthentication:
         test_bot.page = cast(Any, None)
 
         with patch("kleinanzeigen_bot.utils.diagnostics.capture_diagnostics", new_callable = AsyncMock) as mock_capture:
-            await test_bot._capture_login_detection_diagnostics_if_enabled(base_prefix = "login_detection_test")
+            await login_flow.capture_login_detection_diagnostics_if_enabled(
+                web = test_bot,
+                base_prefix = "login_detection_test",
+                diagnostics_config = test_bot.config.diagnostics,
+                diagnostics_output_dir_fn = test_bot._diagnostics_output_dir,
+                log_file_path = test_bot.log_file_path,
+            )
 
             mock_capture.assert_awaited_once()
             assert mock_capture.await_args is not None
@@ -442,10 +455,15 @@ class TestKleinanzeigenBotAuthentication:
         test_bot.page = MagicMock()
 
         with (
-            patch.object(test_bot, "_diagnostics_output_dir", side_effect = RuntimeError("dir error")),
             patch("kleinanzeigen_bot.utils.diagnostics.capture_diagnostics", new_callable = AsyncMock) as mock_capture,
         ):
-            await test_bot._capture_login_detection_diagnostics_if_enabled(base_prefix = "login_detection_test")
+            await login_flow.capture_login_detection_diagnostics_if_enabled(
+                web = test_bot,
+                base_prefix = "login_detection_test",
+                diagnostics_config = test_bot.config.diagnostics,
+                diagnostics_output_dir_fn = MagicMock(side_effect = RuntimeError("dir error")),
+                log_file_path = test_bot.log_file_path,
+            )
 
             mock_capture.assert_not_awaited()
             assert test_bot._login_detection_diagnostics_captured is False
@@ -467,7 +485,13 @@ class TestKleinanzeigenBotAuthentication:
             new_callable = AsyncMock,
             side_effect = RuntimeError("capture error"),
         ):
-            await test_bot._capture_login_detection_diagnostics_if_enabled(base_prefix = "login_detection_test")
+            await login_flow.capture_login_detection_diagnostics_if_enabled(
+                web = test_bot,
+                base_prefix = "login_detection_test",
+                diagnostics_config = test_bot.config.diagnostics,
+                diagnostics_output_dir_fn = test_bot._diagnostics_output_dir,
+                log_file_path = test_bot.log_file_path,
+            )
 
             assert test_bot._login_detection_diagnostics_captured is False
 


### PR DESCRIPTION
## ℹ️ Description

Remove four private wrapper methods on `KleinanzeigenBot` in `app.py` that wrap public module-level functions but have zero production call sites. This is a cleanup-only change with no behavioral impact.

## 📋 Changes Summary

- **Remove** `_has_logged_in_marker` — delegates to `login_flow.has_logged_in_marker`
- **Remove** `_check_publishing_result` — delegates to `publishing_workflow.check_publishing_result`
- **Remove** `_delete_old_ad_if_needed` — delegates to `publishing_workflow.delete_old_ad_if_needed`
- **Remove** `_capture_login_detection_diagnostics_if_enabled` — delegates to `login_flow.capture_login_detection_diagnostics_if_enabled`
- **Remove** unused `Literal` import
- **Retarget** 4 helper-detail tests that called the deleted wrapper directly to the real `login_flow.capture_login_detection_diagnostics_if_enabled` function

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized login detection diagnostics functionality for improved accessibility
  * Simplified login status verification logic within the authentication system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->