### PR TITLE
fix: target visible Auth0 submit button and broaden captcha detection (#1120)

### DIFF
--- a/src/kleinanzeigen_bot/captcha_flow.py
+++ b/src/kleinanzeigen_bot/captcha_flow.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 from gettext import gettext as _
+from typing import Final
 
 from .model.config_model import CaptchaConfig
 from .utils import loggers as _loggers
@@ -10,7 +11,42 @@ from .utils.exceptions import CaptchaEncountered
 from .utils.misc import ainput
 from .utils.web_scraping_mixin import By, WebScrapingMixin
 
+# Combined CSS selector covering all Auth0-supported captcha/challenge providers
+# that inject a detectable iframe. We do not know which specific provider
+# Kleinanzeigen.de uses; this set covers every iframe-based provider Auth0
+# supports (reCAPTCHA v2/Enterprise, hCaptcha, Cloudflare Turnstile, Arkose,
+# FunCaptcha). Excludes Simple CAPTCHA and Auth Challenge — both render
+# inline without an external iframe and cannot be detected by CSS selectors.
+# Single probe call avoids multiplying timeout across N individual selectors.
+_CAPTCHA_IFRAME_SELECTOR:Final[str] = (
+    "iframe[src*='google.com/recaptcha'],"
+    "iframe[src*='recaptcha.net'],"
+    "iframe[src*='hcaptcha.com'],"
+    "iframe[src*='challenges.cloudflare.com'],"
+    "iframe[src*='arkoselabs.com'],"
+    "iframe[src*='funcaptcha.com']"
+)
+
 LOG = _loggers.get_logger(__name__)
+
+
+async def detect_captcha(
+    web:WebScrapingMixin,
+    *,
+    timeout:float | None = None,
+) -> bool:
+    """Detect any supported captcha/challenge iframe on the page.
+
+    Uses a single combined CSS selector probe to avoid multiplying timeout
+    across multiple individual selectors.
+    """
+    effective_timeout = web.timeout("captcha_detection") if timeout is None else timeout
+    elem = await web.web_probe(
+        By.CSS_SELECTOR,
+        _CAPTCHA_IFRAME_SELECTOR,
+        timeout = effective_timeout,
+    )
+    return elem is not None
 
 
 async def check_and_wait_for_captcha(
@@ -20,14 +56,10 @@ async def check_and_wait_for_captcha(
     is_login_page:bool = True,
     page_context:str | None = None,
 ) -> None:
-    captcha_elem = await web.web_probe(
-        By.CSS_SELECTOR,
-        "iframe[name^='a-'][src^='https://www.google.com/recaptcha/api2/anchor?']",
-        timeout = web.timeout("captcha_detection"),
-    )
+    captcha_detected = await detect_captcha(web)
 
     context_label = page_context or ("login page" if is_login_page else "publish operation")
-    if captcha_elem is None:
+    if not captcha_detected:
         LOG.debug("No captcha detected within timeout (page_context=%s)", context_label)
         return
 

--- a/src/kleinanzeigen_bot/login_flow.py
+++ b/src/kleinanzeigen_bot/login_flow.py
@@ -393,10 +393,13 @@ async def handle_identifier_captcha_state(web:WebScrapingMixin) -> None:
             if "/u/login/password" in current_page_url(web):
                 return
             LOG.info("Captcha token ready, clicking submit...")
-            await _click_auth0_submit(web)
-            await web.web_sleep()
-            if "/u/login/password" in current_page_url(web):
-                return
+            try:
+                await _click_auth0_submit(web)
+                await web.web_sleep()
+                if "/u/login/password" in current_page_url(web):
+                    return
+            except TimeoutError:
+                LOG.debug("Visible submit button not clickable after token; falling through to prompt")
         # If token never arrived or click didn't advance, fall through to prompt
 
     # No captcha or token didn't arrive — try clicking visible submit once

--- a/src/kleinanzeigen_bot/login_flow.py
+++ b/src/kleinanzeigen_bot/login_flow.py
@@ -25,7 +25,7 @@ from .model.config_model import CaptchaConfig, DiagnosticsConfig
 from .utils import diagnostics as _diagnostics
 from .utils import loggers as _loggers
 from .utils.misc import ainput
-from .utils.web_scraping_mixin import By, Is, WebScrapingMixin
+from .utils.web_scraping_mixin import By, WebScrapingMixin
 
 LOG:Final[_loggers.Logger] = _loggers.get_logger(__name__)
 
@@ -37,6 +37,32 @@ _LOGGED_OUT_CTA_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CSS_SELECTOR, 'a[href*="einloggen"]'),
     (By.CSS_SELECTOR, 'a[href*="/m-einloggen"]'),
 ]
+
+# Auth0-specific container selectors for captcha detection on the identifier page.
+# Includes container-based providers that don't use external iframes (e.g., Friendly
+# Captcha, built-in image CAPTCHA). We don't know which provider Kleinanzeigen.de
+# uses; this covers every Auth0-supported captcha container class. Used only in
+# handle_identifier_captcha_state, NOT in the shared captcha_flow to avoid false
+# positives during publishing flow.
+_AUTH0_CAPTCHA_CONTAINER_SELECTOR:Final[str] = (
+    # [data-captcha-provider] catches ALL Auth0 captcha providers (most reliable)
+    "[data-captcha-provider],"
+    # Container classes for known providers (substring matching where needed)
+    ".recaptcha, .hcaptcha, .captcha-challenge,"
+    "[class*='auth0-v2'], [class*='auth0_v2'],"
+    ".friendly-captcha, .frc-captcha, .arkose, .cf-turnstile,"
+    ".g-recaptcha"
+)
+
+
+async def _click_auth0_submit(web:WebScrapingMixin, *, timeout:float | None = None) -> None:
+    """Click the visible Auth0 submit button, avoiding the hidden form-submit button."""
+    effective_timeout = web.timeout("quick_dom") if timeout is None else timeout
+    await web.web_click(
+        By.CSS_SELECTOR,
+        "button[type='submit'][data-action-button-primary='true']:not([disabled]):not([aria-disabled='true'])",
+        timeout = effective_timeout,
+    )
 
 
 def _format_login_detection_selectors(selectors:Sequence[tuple["By", str]]) -> str:
@@ -304,46 +330,103 @@ async def wait_for_post_auth0_submit_transition(web:WebScrapingMixin, *, usernam
 # ---------------------------------------------------------------------------
 
 
-async def handle_identifier_captcha_state(web:WebScrapingMixin) -> None:
-    """Handle captcha on the Auth0 identifier page and click Weiter if present.
+async def _detect_auth0_identifier_captcha(web:WebScrapingMixin) -> bool:
+    """Detect captcha on the Auth0 identifier page.
 
-    After submitting the email, a reCAPTCHA may be displayed on the
-    identifier page. If so, this waits for the user to solve it and then
-    probes for a visible Weiter button (not assumed to exist). If present,
-    it is clicked to continue to the password page.
-
-    No-op when the password page is already reached or no captcha is
-    detected, so the normal fast path is unaffected.
+    Checks both iframe-based captchas (shared mechanism) and Auth0-specific
+    container-based captcha elements that don't use iframes.
     """
+    # Shared iframe-based captcha detection (reCAPTCHA, hCaptcha, Turnstile, etc.)
+    if await captcha_flow.detect_captcha(web):
+        return True
+
+    # Auth0-specific container-based captchas without iframes
+    quick_dom = web.timeout("quick_dom")
+    container = await web.web_probe(
+        By.CSS_SELECTOR,
+        _AUTH0_CAPTCHA_CONTAINER_SELECTOR,
+        timeout = quick_dom,
+    )
+    return container is not None
+
+
+async def handle_identifier_captcha_state(web:WebScrapingMixin) -> None:
+    """Handle captcha/challenge on the Auth0 identifier page.
+
+    After submitting the email, a non-interactive captcha (Cloudflare Turnstile
+    via Auth0 v2) may appear. This waits for its token, clicks the visible
+    submit button, and falls back to a user prompt if still stuck.
+    """
+    # Already on password page — nothing to do
     if "/u/login/password" in current_page_url(web):
         return
 
-    captcha_elem = await web.web_probe(
-        By.CSS_SELECTOR,
-        "iframe[name^='a-'][src^='https://www.google.com/recaptcha/api2/anchor?']",
-        timeout = web.timeout("captcha_detection"),
-    )
-    if captcha_elem is None:
+    # Brief grace period for normal navigation
+    await web.web_sleep(1000, 2000)
+    if "/u/login/password" in current_page_url(web):
         return
 
-    LOG.warning("############################################")
-    LOG.warning("# Captcha detected on Auth0 login page. Please solve it in the browser.")
-    LOG.warning("############################################")
-    await ainput(_("Press a key to continue..."))
-
-    # After captcha solving, probe for a visible Weiter button
+    # Detect captcha on the identifier page
+    captcha_detected = await _detect_auth0_identifier_captcha(web)
     quick_dom = web.timeout("quick_dom")
-    weiter_xpath = "//button[contains(., 'Weiter')]"
-    weiter = await web.web_probe(
-        By.XPATH, weiter_xpath,
-        timeout = quick_dom,
-    )
-    if weiter is not None and await web.web_check(By.XPATH, weiter_xpath, Is.DISPLAYED, timeout = quick_dom):
-        LOG.info("Auth0 Weiter button present after captcha, clicking it...")
-        await web.web_click(By.XPATH, weiter_xpath, timeout = quick_dom)
+
+    # Re-check URL: detection may have taken long enough for navigation to complete
+    if "/u/login/password" in current_page_url(web):
+        return
+
+    if captcha_detected:
+        LOG.info("Auth0 captcha detected, waiting for token...")
+        # Wait for Turnstile/other provider to generate a token before clicking
+        try:
+            await web.web_await(
+                lambda: web.web_execute(
+                    "document.querySelector(\"input[name='captcha']\")?.value?.length > 0"
+                ),
+                timeout = quick_dom,
+                timeout_error_message = "Captcha token did not appear",
+                apply_multiplier = False,
+            )
+        except TimeoutError:
+            LOG.debug("No captcha token appeared within quick_dom timeout")
+        else:
+            # Re-check URL: token wait may have taken long enough for navigation
+            if "/u/login/password" in current_page_url(web):
+                return
+            LOG.info("Captcha token ready, clicking submit...")
+            await _click_auth0_submit(web)
+            await web.web_sleep()
+            if "/u/login/password" in current_page_url(web):
+                return
+        # If token never arrived or click didn't advance, fall through to prompt
+
+    # No captcha or token didn't arrive — try clicking visible submit once
+    if not captcha_detected:
+        if "/u/login/password" in current_page_url(web):
+            return
+        try:
+            await _click_auth0_submit(web, timeout = quick_dom)
+            await web.web_sleep()
+            if "/u/login/password" in current_page_url(web):
+                return
+        except TimeoutError:
+            pass
+
+    # Still stuck — prompt user for any undetected challenge
+    LOG.warning("############################################")
+    LOG.warning("# Auth0 identifier page is still waiting.")
+    LOG.warning("# If a security challenge is visible, please solve it.")
+    LOG.warning("############################################")
+    await ainput(_("Press a key after solving the challenge..."))
+
+    if "/u/login/password" in current_page_url(web):
+        return
+
+    # Final attempt
+    try:
+        await _click_auth0_submit(web, timeout = quick_dom)
         await web.web_sleep()
-    else:
-        LOG.debug("No Weiter button after captcha — continuing to wait for password page")
+    except TimeoutError:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -369,7 +452,7 @@ async def fill_login_data_and_send(
     # Step 1: email identifier
     LOG.debug("Auth0 Step 1: entering email...")
     await web.web_input(By.ID, "username", username)
-    await web.web_click(By.CSS_SELECTOR, "button[type='submit']")
+    await _click_auth0_submit(web)
 
     # Captcha-solving branch: captcha can appear on the identifier page
     # after email submit. After solving, a visible Weiter button may need
@@ -383,7 +466,7 @@ async def fill_login_data_and_send(
     LOG.debug("Auth0 Step 2: entering password...")
     await web.web_input(By.CSS_SELECTOR, "input[type='password']", password)
     await captcha_flow.check_and_wait_for_captcha(web, captcha_config, is_login_page = True)
-    await web.web_click(By.CSS_SELECTOR, "button[type='submit']")
+    await _click_auth0_submit(web)
     await wait_for_post_auth0_submit_transition(web, username = username)
     LOG.debug("Auth0 login submitted.")
 

--- a/src/kleinanzeigen_bot/login_flow.py
+++ b/src/kleinanzeigen_bot/login_flow.py
@@ -409,7 +409,7 @@ async def handle_identifier_captcha_state(web:WebScrapingMixin) -> None:
             if "/u/login/password" in current_page_url(web):
                 return
         except TimeoutError:
-            pass
+            LOG.debug("Visible submit button not found — falling through to user prompt")
 
     # Still stuck — prompt user for any undetected challenge
     LOG.warning("############################################")
@@ -426,7 +426,7 @@ async def handle_identifier_captcha_state(web:WebScrapingMixin) -> None:
         await _click_auth0_submit(web, timeout = quick_dom)
         await web.web_sleep()
     except TimeoutError:
-        pass
+        LOG.debug("Final submit button not found — giving up")
 
 
 # ---------------------------------------------------------------------------

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -143,9 +143,11 @@ kleinanzeigen_bot/login_flow.py:
 
   handle_identifier_captcha_state:
     "############################################": "############################################"
-    "# Captcha detected on Auth0 login page. Please solve it in the browser.": "# Captcha auf der Auth0-Anmeldeseite erkannt. Bitte loesen Sie das Captcha im Browser."
-    "Auth0 Weiter button present after captcha, clicking it...": "Auth0-Weiter-Button nach Captcha vorhanden, klicke ihn..."
-    "Press a key to continue...": "Eine Taste drücken, um fortzufahren..."
+    "# Auth0 identifier page is still waiting.": "# Auth0-Identifikationsseite wartet noch."
+    "# If a security challenge is visible, please solve it.": "# Falls eine Sicherheitsabfrage sichtbar ist, bitte lösen."
+    "Auth0 captcha detected, waiting for token...": "Auth0-Captcha erkannt, warte auf Token..."
+    "Captcha token ready, clicking submit...": "Captcha-Token bereit, sende ab..."
+    "Press a key after solving the challenge...": "Eine Taste drücken, nachdem die Herausforderung gelöst wurde..."
 
   check_sms_verification:
     "############################################": "############################################"

--- a/tests/unit/test_login_flow.py
+++ b/tests/unit/test_login_flow.py
@@ -566,8 +566,16 @@ class TestKleinanzeigenBotAuthentication:
                 call(By.CSS_SELECTOR, "input[type='password']", test_bot.config.login.password),
             ]
             assert mock_click.call_args_list == [
-                call(By.CSS_SELECTOR, "button[type='submit']"),
-                call(By.CSS_SELECTOR, "button[type='submit']"),
+                call(
+                    By.CSS_SELECTOR,
+                    "button[type='submit'][data-action-button-primary='true']:not([disabled]):not([aria-disabled='true'])",
+                    timeout = 2.0,
+                ),
+                call(
+                    By.CSS_SELECTOR,
+                    "button[type='submit'][data-action-button-primary='true']:not([disabled]):not([aria-disabled='true'])",
+                    timeout = 2.0,
+                ),
             ]
 
     @pytest.mark.asyncio

--- a/tests/unit/test_login_flow.py
+++ b/tests/unit/test_login_flow.py
@@ -548,7 +548,7 @@ class TestKleinanzeigenBotAuthentication:
             patch("kleinanzeigen_bot.login_flow.wait_for_auth0_password_step", new_callable = AsyncMock) as wait_password,
             patch("kleinanzeigen_bot.login_flow.wait_for_post_auth0_submit_transition", new_callable = AsyncMock) as wait_transition,
             patch.object(test_bot, "web_input") as mock_input,
-            patch.object(test_bot, "web_click") as mock_click,
+            patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
             patch("kleinanzeigen_bot.captcha_flow.check_and_wait_for_captcha", new_callable = AsyncMock) as mock_captcha,
         ):
             await fill_login_data_and_send(
@@ -566,18 +566,7 @@ class TestKleinanzeigenBotAuthentication:
                 call(By.ID, "username", test_bot.config.login.username),
                 call(By.CSS_SELECTOR, "input[type='password']", test_bot.config.login.password),
             ]
-            assert mock_click.call_args_list == [
-                call(
-                    By.CSS_SELECTOR,
-                    "button[type='submit'][data-action-button-primary='true']:not([disabled]):not([aria-disabled='true'])",
-                    timeout = 2.0,
-                ),
-                call(
-                    By.CSS_SELECTOR,
-                    "button[type='submit'][data-action-button-primary='true']:not([disabled]):not([aria-disabled='true'])",
-                    timeout = 2.0,
-                ),
-            ]
+            assert mock_submit.await_count == 2  # identifier submit + password submit
 
     @pytest.mark.asyncio
     async def test_fill_login_data_and_send_fails_when_password_step_missing(self, test_bot:KleinanzeigenBot) -> None:
@@ -587,7 +576,7 @@ class TestKleinanzeigenBotAuthentication:
             patch("kleinanzeigen_bot.login_flow.handle_identifier_captcha_state", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.login_flow.wait_for_auth0_password_step", new_callable = AsyncMock, side_effect = AssertionError("missing password")),
             patch.object(test_bot, "web_input") as mock_input,
-            patch.object(test_bot, "web_click") as mock_click,
+            patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
         ):
             with pytest.raises(AssertionError, match = "missing password"):
                 await fill_login_data_and_send(
@@ -598,7 +587,7 @@ class TestKleinanzeigenBotAuthentication:
                 )
 
             assert mock_input.call_count == 1
-            assert mock_click.call_count == 1
+            assert mock_submit.await_count == 1
 
     @pytest.mark.asyncio
     async def test_wait_for_post_auth0_submit_transition_url_branch(self, test_bot:KleinanzeigenBot) -> None:

--- a/tests/unit/test_login_flow.py
+++ b/tests/unit/test_login_flow.py
@@ -782,7 +782,7 @@ class TestKleinanzeigenBotAuthentication:
     async def test_handle_identifier_already_on_password_page(self, test_bot:KleinanzeigenBot) -> None:
         """Early return when already on the password page — no sleep, no detection, no submit."""
         with (
-            patch("kleinanzeigen_bot.login_flow.current_page_url", return_value = "https://login.kleinanzeigen.de/u/login/password"),
+            patch("kleinanzeigen_bot.login_flow.current_page_url", return_value = "https://auth.example.com/u/login/password"),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
             patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock) as mock_detect,
             patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
@@ -802,8 +802,8 @@ class TestKleinanzeigenBotAuthentication:
             patch(
                 "kleinanzeigen_bot.login_flow.current_page_url",
                 side_effect = [
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/login/password",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/login/password",
                 ],
             ),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
@@ -825,11 +825,11 @@ class TestKleinanzeigenBotAuthentication:
             patch(
                 "kleinanzeigen_bot.login_flow.current_page_url",
                 side_effect = [
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/login/password",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/login/password",
                 ],
             ),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
@@ -853,10 +853,10 @@ class TestKleinanzeigenBotAuthentication:
             patch(
                 "kleinanzeigen_bot.login_flow.current_page_url",
                 side_effect = [
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/login/password",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/login/password",
                 ],
             ),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
@@ -879,11 +879,11 @@ class TestKleinanzeigenBotAuthentication:
             patch(
                 "kleinanzeigen_bot.login_flow.current_page_url",
                 side_effect = [
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/login/password",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/login/password",
                 ],
             ),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
@@ -905,11 +905,11 @@ class TestKleinanzeigenBotAuthentication:
             patch(
                 "kleinanzeigen_bot.login_flow.current_page_url",
                 side_effect = [
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/login/password",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/login/password",
                 ],
             ),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
@@ -934,9 +934,9 @@ class TestKleinanzeigenBotAuthentication:
             patch(
                 "kleinanzeigen_bot.login_flow.current_page_url",
                 side_effect = [
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/identifier",
-                    "https://login.kleinanzeigen.de/u/login/password",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/identifier",
+                    "https://auth.example.com/u/login/password",
                 ],
             ),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,

--- a/tests/unit/test_login_flow.py
+++ b/tests/unit/test_login_flow.py
@@ -18,6 +18,7 @@ from kleinanzeigen_bot.login_flow import (
     click_gdpr_banner,
     current_page_url,
     fill_login_data_and_send,
+    handle_identifier_captcha_state,
     has_logged_out_cta,
     is_valid_post_auth0_destination,
     wait_for_post_auth0_submit_transition,
@@ -721,3 +722,231 @@ class TestKleinanzeigenBotAuthentication:
 
             mock_probe.assert_awaited_once()
             mock_ainput.assert_not_awaited()
+
+    # ------------------------------------------------------------------
+    # _detect_auth0_identifier_captcha
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("detect_result", "probe_result", "expected"),
+        [
+            pytest.param(True, None, True, id = "iframe_detected"),
+            pytest.param(False, MagicMock(spec = Element), True, id = "container_detected"),
+            pytest.param(False, None, False, id = "nothing_found"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_detect_auth0_identifier_captcha(
+        self, test_bot:KleinanzeigenBot, detect_result:bool, probe_result:Any, expected:bool
+    ) -> None:
+        """Returns True when captcha is detected (iframe or container), False otherwise."""
+        with (
+            patch("kleinanzeigen_bot.login_flow.captcha_flow.detect_captcha", new_callable = AsyncMock, return_value = detect_result),
+            patch.object(test_bot, "timeout", return_value = 2.0),
+            patch.object(test_bot, "web_probe", new_callable = AsyncMock, return_value = probe_result) as mock_probe,
+        ):
+            result = await login_flow._detect_auth0_identifier_captcha(test_bot)
+
+        assert result is expected
+        if detect_result:
+            mock_probe.assert_not_called()
+        else:
+            mock_probe.assert_awaited_once()
+            if probe_result is not None:
+                selector = mock_probe.call_args.args[1]
+                assert "[data-captcha-provider]" in selector
+                assert "[class*='auth0-v2']" in selector
+
+    # ------------------------------------------------------------------
+    # _click_auth0_submit
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_click_auth0_submit(self, test_bot:KleinanzeigenBot) -> None:
+        """Clicks the Auth0 primary submit button with the correct selector."""
+        expected_selector = "button[type='submit'][data-action-button-primary='true']:not([disabled]):not([aria-disabled='true'])"
+
+        with patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click:
+            await login_flow._click_auth0_submit(test_bot)
+
+        mock_click.assert_awaited_once()
+        assert mock_click.call_args is not None
+        assert mock_click.call_args.args[0] == By.CSS_SELECTOR
+        assert mock_click.call_args.args[1] == expected_selector
+
+    # ------------------------------------------------------------------
+    # handle_identifier_captcha_state
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_handle_identifier_already_on_password_page(self, test_bot:KleinanzeigenBot) -> None:
+        """Early return when already on the password page — no sleep, no detection, no submit."""
+        with (
+            patch("kleinanzeigen_bot.login_flow.current_page_url", return_value = "https://login.kleinanzeigen.de/u/login/password"),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock) as mock_detect,
+            patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
+            patch("kleinanzeigen_bot.login_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+        ):
+            await handle_identifier_captcha_state(test_bot)
+
+        mock_sleep.assert_not_called()
+        mock_detect.assert_not_called()
+        mock_submit.assert_not_called()
+        mock_ainput.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_identifier_navigates_during_grace_period(self, test_bot:KleinanzeigenBot) -> None:
+        """Navigation completes during grace-period sleep — returns early, no detection/submit."""
+        with (
+            patch(
+                "kleinanzeigen_bot.login_flow.current_page_url",
+                side_effect = [
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/login/password",
+                ],
+            ),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock) as mock_detect,
+            patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
+            patch("kleinanzeigen_bot.login_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+        ):
+            await handle_identifier_captcha_state(test_bot)
+
+        mock_sleep.assert_awaited_once()
+        mock_detect.assert_not_called()
+        mock_submit.assert_not_called()
+        mock_ainput.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_identifier_captcha_token_arrives_submit_succeeds(self, test_bot:KleinanzeigenBot) -> None:
+        """Captcha detected, token arrives, submit click advances to password page."""
+        with (
+            patch(
+                "kleinanzeigen_bot.login_flow.current_page_url",
+                side_effect = [
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/login/password",
+                ],
+            ),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, return_value = True) as mock_await,
+            patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock, return_value = True),
+            patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
+            patch("kleinanzeigen_bot.login_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+        ):
+            await handle_identifier_captcha_state(test_bot)
+
+        mock_sleep.assert_awaited()
+        assert mock_sleep.await_count == 2  # grace period + after submit
+        mock_await.assert_awaited_once()  # token was waited for
+        mock_submit.assert_awaited_once()  # submit was clicked
+        mock_ainput.assert_not_called()  # no prompt shown
+
+    @pytest.mark.asyncio
+    async def test_handle_identifier_captcha_token_times_out_prompt_solves(self, test_bot:KleinanzeigenBot) -> None:
+        """Captcha detected, token wait times out, user prompted, then navigates to password."""
+        with (
+            patch(
+                "kleinanzeigen_bot.login_flow.current_page_url",
+                side_effect = [
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/login/password",
+                ],
+            ),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            patch.object(test_bot, "web_await", new_callable = AsyncMock, side_effect = TimeoutError) as mock_await,
+            patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock, return_value = True),
+            patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
+            patch("kleinanzeigen_bot.login_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+        ):
+            await handle_identifier_captcha_state(test_bot)
+
+        mock_sleep.assert_awaited_once()  # grace period only
+        mock_await.assert_awaited_once()  # token wait was attempted (timed out)
+        mock_submit.assert_not_called()  # no submit in the token branch
+        mock_ainput.assert_awaited_once()  # prompt was shown
+
+    @pytest.mark.asyncio
+    async def test_handle_identifier_no_captcha_submit_succeeds(self, test_bot:KleinanzeigenBot) -> None:
+        """No captcha detected, submit click advances to password page."""
+        with (
+            patch(
+                "kleinanzeigen_bot.login_flow.current_page_url",
+                side_effect = [
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/login/password",
+                ],
+            ),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock, return_value = False),
+            patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
+            patch("kleinanzeigen_bot.login_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+        ):
+            await handle_identifier_captcha_state(test_bot)
+
+        mock_sleep.assert_awaited()
+        assert mock_sleep.await_count == 2  # grace period + after submit
+        mock_submit.assert_awaited_once()  # submit was clicked
+        mock_ainput.assert_not_called()  # no prompt shown
+
+    @pytest.mark.asyncio
+    async def test_handle_identifier_no_captcha_submit_fails_prompt_solves(self, test_bot:KleinanzeigenBot) -> None:
+        """No captcha detected, submit fails, user prompted, then navigates to password."""
+        with (
+            patch(
+                "kleinanzeigen_bot.login_flow.current_page_url",
+                side_effect = [
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/login/password",
+                ],
+            ),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock, return_value = False),
+            patch(
+                "kleinanzeigen_bot.login_flow._click_auth0_submit",
+                new_callable = AsyncMock,
+                side_effect = TimeoutError,
+            ) as mock_submit,
+            patch("kleinanzeigen_bot.login_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+        ):
+            await handle_identifier_captcha_state(test_bot)
+
+        mock_sleep.assert_awaited_once()  # grace period only (submit failed, no post-submit sleep)
+        mock_submit.assert_awaited_once()  # submit was attempted
+        mock_ainput.assert_awaited_once()  # prompt was shown
+
+    @pytest.mark.asyncio
+    async def test_handle_identifier_url_changes_during_detection(self, test_bot:KleinanzeigenBot) -> None:
+        """URL switches to password during captcha detection — returns early, no submit/prompt."""
+        with (
+            patch(
+                "kleinanzeigen_bot.login_flow.current_page_url",
+                side_effect = [
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/identifier",
+                    "https://login.kleinanzeigen.de/u/login/password",
+                ],
+            ),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock) as mock_detect,
+            patch("kleinanzeigen_bot.login_flow._click_auth0_submit", new_callable = AsyncMock) as mock_submit,
+            patch("kleinanzeigen_bot.login_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+        ):
+            await handle_identifier_captcha_state(test_bot)
+
+        mock_sleep.assert_awaited_once()  # grace period
+        mock_detect.assert_awaited_once()  # detection was called
+        mock_submit.assert_not_called()  # no submit
+        mock_ainput.assert_not_called()  # no prompt

--- a/tests/unit/test_login_flow.py
+++ b/tests/unit/test_login_flow.py
@@ -950,3 +950,33 @@ class TestKleinanzeigenBotAuthentication:
         mock_detect.assert_awaited_once()  # detection was called
         mock_submit.assert_not_called()  # no submit
         mock_ainput.assert_not_called()  # no prompt
+
+    @pytest.mark.asyncio
+    async def test_handle_identifier_prompt_final_attempt_succeeds(self, test_bot:KleinanzeigenBot) -> None:
+        """No captcha, submit fails, user prompted, final attempt navigates to password."""
+        with (
+            patch(
+                "kleinanzeigen_bot.login_flow.current_page_url",
+                side_effect = [
+                    "https://auth.example.com/u/identifier",     # initial check
+                    "https://auth.example.com/u/identifier",     # after grace period
+                    "https://auth.example.com/u/identifier",     # after detection
+                    "https://auth.example.com/u/identifier",     # before no-captcha submit
+                    "https://auth.example.com/u/identifier",     # after prompt — still stuck
+                    "https://auth.example.com/u/login/password",  # after final attempt
+                ],
+            ),
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as mock_sleep,
+            patch("kleinanzeigen_bot.login_flow._detect_auth0_identifier_captcha", new_callable = AsyncMock, return_value = False),
+            patch(
+                "kleinanzeigen_bot.login_flow._click_auth0_submit",
+                new_callable = AsyncMock,
+                side_effect = [TimeoutError, None],  # first submit times out, final succeeds
+            ) as mock_submit,
+            patch("kleinanzeigen_bot.login_flow.ainput", new_callable = AsyncMock) as mock_ainput,
+        ):
+            await handle_identifier_captcha_state(test_bot)
+
+        assert mock_submit.await_count == 2  # first submit + final attempt
+        mock_ainput.assert_awaited_once()  # prompt was shown
+        mock_sleep.assert_awaited()  # grace period sleep happened


### PR DESCRIPTION
## ℹ️ Description

Fixes #1120 — Auth0 login fails after email submit because the bot clicks a hidden submit button and cannot detect non-reCAPTCHA captcha providers.

**Root causes:**
1. **Hidden submit button** — Auth0 renders two `button[type='submit']` elements. The hidden one (`class=ulp-hidden-form-submit-button`, `aria-hidden=true`) appears first in DOM. `querySelector()` was matching it instead of the visible primary button.
2. **Captcha detection too narrow** — Only matched reCAPTCHA v2 iframes. Kleinanzeigen.de uses Cloudflare Turnstile via Auth0 v2 (`data-captcha-provider='auth0_v2'`), which renders inline without an iframe.

**Evidence:** @jochenberger provided HTML from the identifier page confirming both issues. User CAN manually click 'Weiter' and login succeeds.

## 📋 Changes Summary

- Add `_click_auth0_submit()` helper using `[data-action-button-primary='true']` to target the visible button
- Broaden captcha detection: iframe selector covers 6 providers, container selector uses `[data-captcha-provider]` + substring class matching
- Simplify `handle_identifier_captcha_state()` with Turnstile token wait via JS property check
- Use `_click_auth0_submit()` for both identifier and password submits
- Add Auth0 provider provenance comments to selectors

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved captcha/challenge detection to support both iframe-based providers and Auth0 container-based challenges.
  - Updated the Auth0 login flow to click the correct visible Auth0 primary submit button, avoiding hidden controls for identifier and password steps.
  - Centralized captcha detection timeout to make challenge handling more consistent.

- **Tests**
  - Expanded and tightened unit tests for the Auth0 identifier-step captcha/submit behavior, including selector expectations and control-flow scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->