### PR TITLE
fix: handle DOM retry and button combobox selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ Die Nutzung erfolgt auf eigenes Risiko. Jede rechtswidrige Verwendung ist unters
    pdm install
    ```
 
+   > **Note for pip-only users:** Running `pip install .` from a source checkout
+   > skips the PDM `post_install` hook that patches nodriver for
+   > Chromium flat-mode sessions. If you see repeated
+   > `Re-attaching CDP session after -32601` messages at startup, use
+   > `pdm install` instead, or run `python scripts/fix_nodriver.py` from the
+   > repository checkout. The app also checks for this nodriver patch at
+   > startup and warns if it appears missing; keep this note in sync with
+   > `scripts/fix_nodriver.py` and the CLI guard.
+
 1. Run the app:
 
    ```bash

--- a/scripts/fix_nodriver.py
+++ b/scripts/fix_nodriver.py
@@ -75,21 +75,28 @@ def _fix_network_encoding(path:Path) -> str:
 
 # ── connection.py flat-mode session retry ──────────────────────────────────
 
+# Keep this marker and guidance in sync with the CLI runtime guard in
+# src/kleinanzeigen_bot/cli.py and the README source-install caveat.
+_CONNECTION_SEND_PATCH_MARKER = "KLEINANZEIGEN_BOT_NODEDRIVER_CDP_REATTACH_PATCH_V1"
+
 _SEND_START = "        if not _attach:"
 _SEND_ERR_END = "            raise exception"
 
-_NEW_SEND = """\
+_MARKER_COMMENT_LINE = f"        # {_CONNECTION_SEND_PATCH_MARKER}: re-attach/retry CDP -32601 for Chromium flat-mode sessions."
+
+_NEW_SEND = f"""\
         method, *params = next(cdp_obj).values()
         if params:
             params = params.pop()
 
+{_MARKER_COMMENT_LINE}
         for _retry in range(2):
             if not _attach:
                 if not self.attached or not self.socket:
                     await self.attach()
 
             _id = next(self.__count__)
-            message = {"method": method, "params": params, "id": _id}
+            message = {{"method": method, "params": params, "id": _id}}
             if not _attach:
                 message["sessionId"] = self.session_id
             message.update(kwargs)
@@ -136,6 +143,9 @@ _NEW_SEND = """\
                 raise exception
             break"""
 
+# Derive the old markerless body from _NEW_SEND for legacy normalization.
+_OLD_SEND = _NEW_SEND.replace(f"{_MARKER_COMMENT_LINE}\n", "")
+
 
 def _fix_connection_send(path:Path) -> str:
     try:
@@ -144,21 +154,32 @@ def _fix_connection_send(path:Path) -> str:
         print(f"fix_nodriver: cannot read {path}: {exc}", file = sys.stderr)
         sys.exit(1)
 
-    if "for _retry in range(2):" in text:
+    # Marker-based idempotency check.
+    if _CONNECTION_SEND_PATCH_MARKER in text:
         return "already-ok"
 
+    # Check for old markerless patched body (marker absent, _SEND_START may be
+    # gone because the original patch replaced it).  _OLD_SEND uses 8-space
+    # template indent matching nodriver's coding style.
+    if _OLD_SEND in text:
+        # Exact old markerless body found — normalize by replacing with _NEW_SEND.
+        text = text.replace(_OLD_SEND, _NEW_SEND)
+        path.write_text(text, "utf-8")
+        return "updated"
+
+    # Fresh patch: find the original unpatched send-method body.
     start = text.find(_SEND_START)
     if start == -1:
         print("fix_nodriver: send start marker not found", file = sys.stderr)
         sys.exit(1)
 
+    indent = text[text.rfind("\n", 0, start) + 1: start]
     err = text.find(_SEND_ERR_END, start)
     if err == -1:
         print("fix_nodriver: send error end not found", file = sys.stderr)
         sys.exit(1)
 
     err_end = text.index("\n", err)
-    indent = text[text.rfind("\n", 0, start) + 1: start]
     body = textwrap.indent(_NEW_SEND, indent).removeprefix("\n")
     result = text[:start] + body + text[err_end:]
     path.write_text(result, "utf-8")

--- a/src/kleinanzeigen_bot/cli.py
+++ b/src/kleinanzeigen_bot/cli.py
@@ -41,7 +41,7 @@ LOG.setLevel(_loggers.INFO)
 # Keep this marker and warning guidance in sync with scripts/fix_nodriver.py
 # and the README source-install caveat.
 _NODRIVER_PATCH_MARKER:Final[str] = "KLEINANZEIGEN_BOT_NODEDRIVER_CDP_REATTACH_PATCH_V1"
-_warned_nodriver_patch:bool = False
+_warned_nodriver_patch:list[bool] = [False]
 
 
 @dataclass(slots = True)
@@ -66,8 +66,7 @@ def _warn_unpatched_nodriver() -> None:
     Silent on frozen builds, uninstalled nodriver, missing/unreadable files,
     or any metadata weirdness.
     """
-    global _warned_nodriver_patch  # noqa: PLW0603
-    if _warned_nodriver_patch or is_frozen():
+    if _warned_nodriver_patch[0] or is_frozen():
         return
 
     try:
@@ -101,7 +100,7 @@ def _warn_unpatched_nodriver() -> None:
     if _NODRIVER_PATCH_MARKER in text:
         return
 
-    _warned_nodriver_patch = True
+    _warned_nodriver_patch[0] = True
     LOG.warning(
         "nodriver CDP re-attach patch not found: installed nodriver may miss the flat-mode fix. "
         "Plain pip installs skip the PDM post_install hook; run `pdm install` from a source "

--- a/src/kleinanzeigen_bot/cli.py
+++ b/src/kleinanzeigen_bot/cli.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 
 import atexit
 import getopt
+import importlib.metadata
 import os
 import signal
 import sys
 import textwrap
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Final, Sequence
 
 import colorama
@@ -36,6 +38,11 @@ from kleinanzeigen_bot.utils.misc import is_frozen
 LOG:Final[_loggers.Logger] = _loggers.get_logger(__name__)
 LOG.setLevel(_loggers.INFO)
 
+# Keep this marker and warning guidance in sync with scripts/fix_nodriver.py
+# and the README source-install caveat.
+_NODRIVER_PATCH_MARKER:Final[str] = "KLEINANZEIGEN_BOT_NODEDRIVER_CDP_REATTACH_PATCH_V1"
+_warned_nodriver_patch:bool = False
+
 
 @dataclass(slots = True)
 class ParsedArgs:
@@ -50,6 +57,57 @@ class ParsedArgs:
     log_file_path:str | None = None
     logfile_explicitly_provided:bool = False
     workspace_mode:str | None = None
+
+
+def _warn_unpatched_nodriver() -> None:
+    """Check installed nodriver for the CDP re-attach patch marker and warn if missing.
+
+    Keeps a module-level flag so repeated ``main()`` calls only warn once.
+    Silent on frozen builds, uninstalled nodriver, missing/unreadable files,
+    or any metadata weirdness.
+    """
+    global _warned_nodriver_patch  # noqa: PLW0603
+    if _warned_nodriver_patch or is_frozen():
+        return
+
+    try:
+        dist = importlib.metadata.distribution("nodriver")
+    except importlib.metadata.PackageNotFoundError:
+        return
+    except Exception:
+        if _loggers.is_debug(LOG):
+            LOG.debug("nodriver patch check: metadata lookup failed", exc_info = True)
+        return
+
+    try:
+        try:
+            connection_path = Path(dist.locate_file("nodriver/core/connection.py"))  # type: ignore[arg-type]
+        except AttributeError:
+            # Fallback for older Python/importlib_metadata.
+            site_packages = Path(dist._path).parent  # type: ignore[attr-defined]  # noqa: SLF001
+            connection_path = site_packages / "nodriver/core/connection.py"
+    except Exception:
+        if _loggers.is_debug(LOG):
+            LOG.debug("nodriver patch check: path resolution failed", exc_info = True)
+        return
+
+    if not connection_path.is_file():
+        return
+    try:
+        text = connection_path.read_text("utf-8")
+    except OSError:
+        return
+
+    if _NODRIVER_PATCH_MARKER in text:
+        return
+
+    _warned_nodriver_patch = True
+    LOG.warning(
+        "nodriver CDP re-attach patch not found: installed nodriver may miss the flat-mode fix. "
+        "Plain pip installs skip the PDM post_install hook; run `pdm install` from a source "
+        "checkout or `python scripts/fix_nodriver.py` from the repository. "
+        "Symptom: repeated `Re-attaching CDP session after -32601`."
+    )
 
 
 def _help_executable() -> str:
@@ -265,6 +323,7 @@ def main(args:Sequence[str]) -> None:
         )  # [1:] removes the first empty blank line
 
     _loggers.configure_console_logging()
+    _warn_unpatched_nodriver()
     signal.signal(signal.SIGINT, _error_handlers.on_sigint)
     atexit.register(_loggers.flush_all_handlers)
 

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -497,43 +497,81 @@ async def set_pricing_fields(web:WebScrapingMixin, ad_cfg:Ad, ad_defaults:AdDefa
     await web.web_set_input_value("ad-description", description)
 
 
-# TODO: Issue #930 — migrate to web_select_button_combobox (display-text-based, no React fiber)
 async def _select_button_combobox(web:WebScrapingMixin, elem_id:str, value:str) -> None:
     """Select an option from a <button role="combobox"> dropdown by its API value.
 
-    Clicks the button to open the listbox, reads the options data from the React fiber
-    (which maps API values to display labels), and clicks the matching option.
+    Opens the control with pointerdown/mousedown and selects the matching option
+    in a single async browser script execution.  Uses React fiber matching first,
+    then DOM attribute matching, then normalized text fallback.
     """
-    await web.web_click(By.ID, elem_id)
-    listbox_id = f"{elem_id}-menu"
-    await web.web_find(By.ID, listbox_id)
-    js_btn_id = json.dumps(elem_id)
-    js_listbox_id = json.dumps(listbox_id)
+    js_elem_id = json.dumps(elem_id)
     js_value = json.dumps(value)
-    ok = await web.web_execute(f"""(function() {{
-        const listbox = document.getElementById({js_listbox_id});
-        if (!listbox) return false;
-        const liOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
-        const btnEl = document.getElementById({js_btn_id});
-        if (!btnEl) return false;
-        const fiberKey = Object.keys(btnEl).find(k => k.startsWith('__reactFiber'));
-        let fiber = fiberKey ? btnEl[fiberKey] : null;
-        for (let i = 0; i < 20 && fiber; i++, fiber = fiber.return) {{
+    status = await web.web_execute(f"""(async function() {{
+    var btn = document.getElementById({js_elem_id});
+    if (!btn) return {{ok:false, reason:'Button not found'}};
+    btn.dispatchEvent(new PointerEvent('pointerdown',{{bubbles:true,cancelable:true}}));
+    btn.dispatchEvent(new MouseEvent('mousedown',{{bubbles:true,cancelable:true}}));
+    var listbox = null;
+    var options = null;
+    for (var i = 0; i < 50; i++) {{
+        await new Promise(function(r){{setTimeout(r,20);}});
+        var candidate = document.getElementById({js_elem_id}+'-menu');
+        if (!candidate && btn.parentElement) {{
+            candidate = btn.parentElement.querySelector('[role="listbox"]');
+        }}
+        if (!candidate && btn.parentElement) {{
+            var m = btn.parentElement.querySelector('[role="menu"]');
+            if (m) candidate = m;
+        }}
+        if (candidate) {{
+            options = Array.from(candidate.querySelectorAll('[role="option"]'));
+            if (options.length > 0) break;
+        }}
+    }}
+    if (!options || options.length === 0) {{
+        return {{ok:false, reason:'No options appeared after opening', options:[]}};
+    }}
+    var optionInfo = options.map(function(o){{return o.textContent ? o.textContent.trim() : '';}});
+    var fiberKey = Object.keys(btn).find(function(k){{return k.startsWith('__reactFiber');}});
+    if (fiberKey) {{
+        var fiber = btn[fiberKey];
+        for (var j = 0; j < 20 && fiber; j++, fiber = fiber.return) {{
             if (fiber.memoizedProps && fiber.memoizedProps.options) {{
-                const optionsData = fiber.memoizedProps.options;
-                for (let j = 0; j < optionsData.length; j++) {{
-                    if (optionsData[j].value === {js_value} && liOptions[j]) {{
-                        liOptions[j].click();
-                        return true;
+                var opts = fiber.memoizedProps.options;
+                for (var k = 0; k < opts.length; k++) {{
+                    if (opts[k].value === {js_value} && options[k]) {{
+                        options[k].click();
+                        return {{ok:true}};
                     }}
                 }}
-                return false;
+                break;
             }}
         }}
-        return false;
-    }})()""")
-    if not ok:
-        raise TimeoutError(_("Option '%(value)s' not found in button combobox '%(id)s'") % {"value": value, "id": elem_id})
+    }}
+    for (var k = 0; k < options.length; k++) {{
+        var o = options[k];
+        if (o.getAttribute('value') === {js_value} ||
+            o.getAttribute('data-value') === {js_value} ||
+            o.getAttribute('aria-label') === {js_value} ||
+            o.getAttribute('title') === {js_value}) {{
+            o.click();
+            return {{ok:true}};
+        }}
+        var text = (o.textContent || '').trim().toLowerCase();
+        if (text === {js_value}.toLowerCase()) {{
+            o.click();
+            return {{ok:true}};
+        }}
+    }}
+    return {{ok:false, reason:'Option not found', requested:{js_value}, options:optionInfo}};
+}})()""")
+    if not isinstance(status, dict) or not status.get("ok"):
+        observed = status.get("options", []) if isinstance(status, dict) else []
+        reason = status.get("reason", "unknown") if isinstance(status, dict) else "unknown"
+        raise TimeoutError(
+            _("Option '%(value)s' not found in button combobox '%(id)s': %(reason)s (observed: %(options)s)")
+            % {"value": value, "id": elem_id, "reason": reason, "options": observed}
+        )
 
 
 async def set_shipping_form(web:WebScrapingMixin, ad_cfg:Ad, mode:AdUpdateStrategy = AdUpdateStrategy.REPLACE) -> None:

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -510,7 +510,7 @@ async def _select_button_combobox(web:WebScrapingMixin, elem_id:str, value:str) 
     poll_deadline_ms = int(web.timeout("quick_dom") * 1000)
     status = await web.web_execute(f"""(async function() {{
     var btn = document.getElementById({js_elem_id});
-    if (!btn) return {{ok:false, reason:'Button not found'}};
+    if (!btn) return {{ok:false, reason:'button_not_found'}};
     btn.dispatchEvent(new PointerEvent('pointerdown',{{bubbles:true,cancelable:true}}));
     btn.dispatchEvent(new MouseEvent('mousedown',{{bubbles:true,cancelable:true}}));
     var listbox = null;
@@ -532,7 +532,7 @@ async def _select_button_combobox(web:WebScrapingMixin, elem_id:str, value:str) 
         }}
     }}
     if (!options || options.length === 0) {{
-        return {{ok:false, reason:'No options appeared after opening', options:[]}};
+        return {{ok:false, reason:'no_options_after_opening', options:[]}};
     }}
     var optionInfo = options.map(function(o){{return o.textContent ? o.textContent.trim() : '';}});
     var fiberKey = Object.keys(btn).find(function(k){{return k.startsWith('__reactFiber');}});
@@ -566,11 +566,17 @@ async def _select_button_combobox(web:WebScrapingMixin, elem_id:str, value:str) 
             return {{ok:true}};
         }}
     }}
-    return {{ok:false, reason:'Option not found', requested:{js_value}, options:optionInfo}};
+    return {{ok:false, reason:'option_not_found', requested:{js_value}, options:optionInfo}};
 }})()""")
     if not isinstance(status, dict) or not status.get("ok"):
         observed = status.get("options", []) if isinstance(status, dict) else []
-        reason = status.get("reason", "unknown") if isinstance(status, dict) else "unknown"
+        reason_code = status.get("reason", "unknown") if isinstance(status, dict) else "unknown"
+        _reason_labels:dict[str, str] = {
+            "button_not_found": _("Button not found"),
+            "no_options_after_opening": _("No options appeared after opening"),
+            "option_not_found": _("Option not found"),
+        }
+        reason = _reason_labels.get(reason_code, _("Unknown failure: %s") % reason_code)
         raise TimeoutError(
             _("Option '%(value)s' not found in button combobox '%(id)s': %(reason)s (observed: %(options)s)")
             % {"value": value, "id": elem_id, "reason": reason, "options": observed}

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -506,6 +506,8 @@ async def _select_button_combobox(web:WebScrapingMixin, elem_id:str, value:str) 
     """
     js_elem_id = json.dumps(elem_id)
     js_value = json.dumps(value)
+    # Use web.timeout("quick_dom") as the JS-side polling budget, converted to milliseconds.
+    poll_deadline_ms = int(web.timeout("quick_dom") * 1000)
     status = await web.web_execute(f"""(async function() {{
     var btn = document.getElementById({js_elem_id});
     if (!btn) return {{ok:false, reason:'Button not found'}};
@@ -513,7 +515,8 @@ async def _select_button_combobox(web:WebScrapingMixin, elem_id:str, value:str) 
     btn.dispatchEvent(new MouseEvent('mousedown',{{bubbles:true,cancelable:true}}));
     var listbox = null;
     var options = null;
-    for (var i = 0; i < 50; i++) {{
+    var pollDeadline = Date.now() + {poll_deadline_ms};
+    while (Date.now() < pollDeadline) {{
         await new Promise(function(r){{setTimeout(r,20);}});
         var candidate = document.getElementById({js_elem_id}+'-menu');
         if (!candidate && btn.parentElement) {{

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -289,7 +289,7 @@ kleinanzeigen_bot/publishing_form.py:
     "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
 
   _select_button_combobox:
-    "Option '%(value)s' not found in button combobox '%(id)s'": "Option '%(value)s' nicht in Button-Combobox '%(id)s' gefunden"
+    "Option '%(value)s' not found in button combobox '%(id)s': %(reason)s (observed: %(options)s)": "Option '%(value)s' nicht in Button-Combobox '%(id)s' gefunden: %(reason)s (beobachtet: %(options)s)"
 
   _select_shipping_combobox_if_present:
     "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -35,6 +35,9 @@ kleinanzeigen_bot/cli.py:
     "Unknown command: %s": "Unbekannter Befehl: %s"
     "More than one command given: %s": "Mehr als ein Befehl angegeben: %s"
     "Invalid --workspace-mode '%s'. Use 'portable' or 'xdg'.": "Ungültiger --workspace-mode '%s'. Verwenden Sie 'portable' oder 'xdg'."
+  _warn_unpatched_nodriver:
+    ? "nodriver CDP re-attach patch not found: installed nodriver may miss the flat-mode fix. Plain pip installs skip the PDM post_install hook; run `pdm install` from a source checkout or `python scripts/fix_nodriver.py` from the repository. Symptom: repeated `Re-attaching CDP session after -32601`."
+    : "nodriver CDP Re-Attach-Patch nicht gefunden: installiertes nodriver hat möglicherweise nicht den Flat-Mode-Fix. Reine pip-Installationen überspringen den PDM post_install-Hook; führen Sie `pdm install` in einem Quell-Checkout aus oder `python scripts/fix_nodriver.py` aus dem Repository. Symptom: wiederholtes `Re-attaching CDP session after -32601`."
 
 #################################################
 kleinanzeigen_bot/runtime_config.py:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -292,6 +292,10 @@ kleinanzeigen_bot/publishing_form.py:
     "Shipping combobox button has no id attribute": "Versand-Combobox-Button hat kein ID-Attribut"
 
   _select_button_combobox:
+    "Button not found": "Button nicht gefunden"
+    "No options appeared after opening": "Keine Optionen nach Öffnen erschienen"
+    "Option not found": "Option nicht gefunden"
+    "Unknown failure: %s": "Unbekannter Fehler: %s"
     "Option '%(value)s' not found in button combobox '%(id)s': %(reason)s (observed: %(options)s)": "Option '%(value)s' nicht in Button-Combobox '%(id)s' gefunden: %(reason)s (beobachtet: %(options)s)"
 
   _select_shipping_combobox_if_present:

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -814,6 +814,11 @@ class WebScrapingMixin:  # noqa: PLR0904
                         await self.page.attach()
                     except Exception as re_exc:  # noqa: S110
                         LOG.debug("Re-attach failed: %s", re_exc)
+                    elapsed = loop.time() - start_at
+                    if elapsed >= effective_timeout:
+                        raise TimeoutError(timeout_error_message or f"Condition not met within {effective_timeout} seconds") from None
+                    remaining_timeout = max(effective_timeout - elapsed, 0.0)
+                    await asyncio.sleep(min(0.05, remaining_timeout))
                     continue
                 ex = ex1
             except Exception as ex1:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 import importlib.metadata
 import runpy
 import sys
-import tempfile
 from datetime import timedelta
-from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import pytest
 
@@ -204,39 +206,39 @@ class TestNodriverPatchGuard:
     """Tests for _warn_unpatched_nodriver runtime guard."""
 
     @staticmethod
-    def _make_mock_dist(connection_text:str) -> tuple[MagicMock, str]:
-        """Build a fake distribution whose locate_file returns a temp file."""
-        with tempfile.NamedTemporaryFile(mode = "w", suffix = ".py", delete = False, encoding = "utf-8") as f:
-            f.write(connection_text)
-            tmpname = f.name
+    def _make_mock_dist(tmp_path:Path, connection_text:str) -> MagicMock:
+        """Build a fake distribution whose locate_file returns a file in tmp_path."""
+        fpath = tmp_path / "connection.py"
+        fpath.write_text(connection_text, encoding = "utf-8")
         dist = MagicMock()
-        dist.locate_file.return_value = Path(tmpname)
-        return dist, tmpname
+        dist.locate_file.return_value = fpath
+        return dist
 
-    def test_no_warning_when_marker_present(self, caplog:pytest.LogCaptureFixture) -> None:
+    def _setup(self) -> None:
+        """Reset the warned flag before each guard test."""
+        cli._warned_nodriver_patch[0] = False  # noqa: SLF001
+
+    def test_no_warning_when_marker_present(self, caplog:pytest.LogCaptureFixture, tmp_path:Path) -> None:
         """Marker present => no warning."""
-        text = "# KLEINANZEIGEN_BOT_NODEDRIVER_CDP_REATTACH_PATCH_V1: retry loop\n...\nfor _retry in range(2):\n"
-        dist, _ = self._make_mock_dist(text)
+        self._setup()
+        dist = self._make_mock_dist(tmp_path, "# KLEINANZEIGEN_BOT_NODEDRIVER_CDP_REATTACH_PATCH_V1: retry loop\n...\nfor _retry in range(2):\n")
         with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
-            cli._warned_nodriver_patch = False  # noqa: SLF001
             cli._warn_unpatched_nodriver()  # noqa: SLF001
         assert "nodriver CDP re-attach patch not found" not in caplog.text
 
-    def test_warning_when_marker_absent(self, caplog:pytest.LogCaptureFixture) -> None:
+    def test_warning_when_marker_absent(self, caplog:pytest.LogCaptureFixture, tmp_path:Path) -> None:
         """Marker absent => warning once."""
-        text = "# original nodriver code\nasync def send(...):\n    pass\n"
-        dist, _ = self._make_mock_dist(text)
+        self._setup()
+        dist = self._make_mock_dist(tmp_path, "# original nodriver code\nasync def send(...):\n    pass\n")
         with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
-            cli._warned_nodriver_patch = False  # noqa: SLF001
             cli._warn_unpatched_nodriver()  # noqa: SLF001
         assert "nodriver CDP re-attach patch not found" in caplog.text
 
-    def test_warning_only_once(self, caplog:pytest.LogCaptureFixture) -> None:
+    def test_warning_only_once(self, caplog:pytest.LogCaptureFixture, tmp_path:Path) -> None:
         """Repeated calls => warned only once."""
-        text = "# unpatched\n"
-        dist, _ = self._make_mock_dist(text)
+        self._setup()
+        dist = self._make_mock_dist(tmp_path, "# unpatched\n")
         with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
-            cli._warned_nodriver_patch = False  # noqa: SLF001
             cli._warn_unpatched_nodriver()  # noqa: SLF001
             cli._warn_unpatched_nodriver()  # noqa: SLF001
             cli._warn_unpatched_nodriver()  # noqa: SLF001
@@ -244,14 +246,14 @@ class TestNodriverPatchGuard:
 
     def test_silent_when_package_not_found(self, caplog:pytest.LogCaptureFixture) -> None:
         """PackageNotFoundError => silent, no warning."""
+        self._setup()
         with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", side_effect = importlib.metadata.PackageNotFoundError):
-            cli._warned_nodriver_patch = False  # noqa: SLF001
             cli._warn_unpatched_nodriver()  # noqa: SLF001
         assert "nodriver CDP re-attach patch not found" not in caplog.text
 
     def test_silent_when_frozen(self, caplog:pytest.LogCaptureFixture) -> None:
         """Frozen build => silent, no warning, never checks."""
+        self._setup()
         with patch("kleinanzeigen_bot.cli.is_frozen", return_value = True):
-            cli._warned_nodriver_patch = False  # noqa: SLF001
             cli._warn_unpatched_nodriver()  # noqa: SLF001
         assert "nodriver CDP re-attach patch not found" not in caplog.text

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,15 +6,13 @@
 from __future__ import annotations
 
 import importlib.metadata
+import logging
 import runpy
 import sys
 from datetime import timedelta
+from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 import pytest
 
@@ -257,3 +255,84 @@ class TestNodriverPatchGuard:
         with patch("kleinanzeigen_bot.cli.is_frozen", return_value = True):
             cli._warn_unpatched_nodriver()  # noqa: SLF001
         assert "nodriver CDP re-attach patch not found" not in caplog.text
+
+    # ── edge-case coverage ─────────────────────────────────────────────────
+
+    def test_silent_when_metadata_generic_exception(self, caplog:pytest.LogCaptureFixture) -> None:
+        """Generic exception during metadata lookup => silent, no warning, flag unchanged."""
+        self._setup()
+        with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", side_effect = ValueError("corrupt")):
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert "nodriver CDP re-attach patch not found" not in caplog.text
+        assert cli._warned_nodriver_patch[0] is False  # noqa: SLF001
+
+    def test_silent_when_metadata_generic_exception_debug_logged(
+        self,
+        caplog:pytest.LogCaptureFixture,
+    ) -> None:
+        """Generic metadata exception writes debug log when LOG is DEBUG."""
+        self._setup()
+        prev_level = cli.LOG.level
+        cli.LOG.setLevel(logging.DEBUG)
+        try:
+            with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", side_effect = ValueError("corrupt")):
+                cli._warn_unpatched_nodriver()  # noqa: SLF001
+            assert "nodriver patch check: metadata lookup failed" in caplog.text
+        finally:
+            cli.LOG.setLevel(prev_level)
+
+    def test_silent_when_locator_fallback_attribute_error(self, caplog:pytest.LogCaptureFixture, tmp_path:Path) -> None:
+        """locate_file() AttributeError => fallback to dist._path works; no warning when marker present."""
+        self._setup()
+        # Fake site-packages tree under tmp_path.
+        site_pkgs = tmp_path / "site-packages"
+        fake_dist_info = site_pkgs / "nodriver-1.0.0.dist-info"
+        fake_dist_info.mkdir(parents = True)
+        conn_py = site_pkgs / "nodriver" / "core" / "connection.py"
+        conn_py.parent.mkdir(parents = True)
+        conn_py.write_text("# KLEINANZEIGEN_BOT_NODEDRIVER_CDP_REATTACH_PATCH_V1\n", encoding = "utf-8")
+
+        dist = MagicMock()
+        dist.locate_file.side_effect = AttributeError("no locate_file")
+        dist._path = fake_dist_info  # noqa: SLF001
+
+        with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        # Fallback resolved to the real file with marker => silent.
+        assert "nodriver CDP re-attach patch not found" not in caplog.text
+        assert cli._warned_nodriver_patch[0] is False  # noqa: SLF001
+
+    def test_silent_when_path_resolution_generic_exception(self, caplog:pytest.LogCaptureFixture) -> None:
+        """Generic exception during path resolution => silent, no warning, flag unchanged."""
+        self._setup()
+        dist = MagicMock()
+        dist.locate_file.side_effect = RuntimeError("unexpected")
+        with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert "nodriver CDP re-attach patch not found" not in caplog.text
+        assert cli._warned_nodriver_patch[0] is False  # noqa: SLF001
+
+    def test_silent_when_connection_path_missing(self, caplog:pytest.LogCaptureFixture, tmp_path:Path) -> None:
+        """Non-existent connection.py => silent, no warning, flag unchanged."""
+        self._setup()
+        dist = MagicMock()
+        dist.locate_file.return_value = tmp_path / "nonexistent" / "connection.py"
+        with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert "nodriver CDP re-attach patch not found" not in caplog.text
+        assert cli._warned_nodriver_patch[0] is False  # noqa: SLF001
+
+    def test_silent_when_read_text_oserror(self, caplog:pytest.LogCaptureFixture, tmp_path:Path) -> None:
+        """read_text OSError => silent, no warning, flag unchanged."""
+        self._setup()
+        conn_py = tmp_path / "connection.py"
+        conn_py.write_text("unpatched content", encoding = "utf-8")
+        dist = MagicMock()
+        dist.locate_file.return_value = conn_py
+        with (
+            patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist),
+            patch.object(Path, "read_text", side_effect = OSError("permission denied")),
+        ):
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert "nodriver CDP re-attach patch not found" not in caplog.text
+        assert cli._warned_nodriver_patch[0] is False  # noqa: SLF001

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5,11 +5,14 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import runpy
 import sys
+import tempfile
 from datetime import timedelta
+from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,9 +21,6 @@ from kleinanzeigen_bot.utils import i18n, loggers
 from kleinanzeigen_bot.utils.exceptions import CaptchaEncountered
 
 pytestmark = pytest.mark.unit
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class TestCliParseArgs:
@@ -198,3 +198,60 @@ class TestCliMain:
 
         assert exc_info.value.code == 0
         assert calls == [["kleinanzeigen-bot", "version"]]
+
+
+class TestNodriverPatchGuard:
+    """Tests for _warn_unpatched_nodriver runtime guard."""
+
+    @staticmethod
+    def _make_mock_dist(connection_text:str) -> tuple[MagicMock, str]:
+        """Build a fake distribution whose locate_file returns a temp file."""
+        with tempfile.NamedTemporaryFile(mode = "w", suffix = ".py", delete = False, encoding = "utf-8") as f:
+            f.write(connection_text)
+            tmpname = f.name
+        dist = MagicMock()
+        dist.locate_file.return_value = Path(tmpname)
+        return dist, tmpname
+
+    def test_no_warning_when_marker_present(self, caplog:pytest.LogCaptureFixture) -> None:
+        """Marker present => no warning."""
+        text = "# KLEINANZEIGEN_BOT_NODEDRIVER_CDP_REATTACH_PATCH_V1: retry loop\n...\nfor _retry in range(2):\n"
+        dist, _ = self._make_mock_dist(text)
+        with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
+            cli._warned_nodriver_patch = False  # noqa: SLF001
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert "nodriver CDP re-attach patch not found" not in caplog.text
+
+    def test_warning_when_marker_absent(self, caplog:pytest.LogCaptureFixture) -> None:
+        """Marker absent => warning once."""
+        text = "# original nodriver code\nasync def send(...):\n    pass\n"
+        dist, _ = self._make_mock_dist(text)
+        with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
+            cli._warned_nodriver_patch = False  # noqa: SLF001
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert "nodriver CDP re-attach patch not found" in caplog.text
+
+    def test_warning_only_once(self, caplog:pytest.LogCaptureFixture) -> None:
+        """Repeated calls => warned only once."""
+        text = "# unpatched\n"
+        dist, _ = self._make_mock_dist(text)
+        with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", return_value = dist):
+            cli._warned_nodriver_patch = False  # noqa: SLF001
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert caplog.text.count("nodriver CDP re-attach patch not found") == 1
+
+    def test_silent_when_package_not_found(self, caplog:pytest.LogCaptureFixture) -> None:
+        """PackageNotFoundError => silent, no warning."""
+        with patch("kleinanzeigen_bot.cli.importlib.metadata.distribution", side_effect = importlib.metadata.PackageNotFoundError):
+            cli._warned_nodriver_patch = False  # noqa: SLF001
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert "nodriver CDP re-attach patch not found" not in caplog.text
+
+    def test_silent_when_frozen(self, caplog:pytest.LogCaptureFixture) -> None:
+        """Frozen build => silent, no warning, never checks."""
+        with patch("kleinanzeigen_bot.cli.is_frozen", return_value = True):
+            cli._warned_nodriver_patch = False  # noqa: SLF001
+            cli._warn_unpatched_nodriver()  # noqa: SLF001
+        assert "nodriver CDP re-attach patch not found" not in caplog.text

--- a/tests/unit/test_fix_nodriver.py
+++ b/tests/unit/test_fix_nodriver.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Unit tests for scripts/fix_nodriver.py _fix_connection_send.
+
+Exercised on temporary files to avoid touching the installed nodriver.
+
+Note: ``fix_nodriver`` is loaded by file path via ``importlib.util``
+to avoid a mypy double-module mapping (*fix_nodriver* vs *scripts.fix_nodriver*)
+that occurs when importing via ``from scripts import fix_nodriver``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent.parent / "scripts" / "fix_nodriver.py"
+_spec = importlib.util.spec_from_file_location("fix_nodriver", _SCRIPT_PATH)
+assert _spec is not None, f"Cannot load spec from {_SCRIPT_PATH}"
+assert _spec.loader is not None, f"No loader for spec from {_SCRIPT_PATH}"
+fix_nodriver = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fix_nodriver)
+
+pytestmark = pytest.mark.unit
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_SEND_START_LINE = "        if not _attach:"
+_SEND_ERR_END_LINE = "            raise exception"
+
+_ORIG_BODY_AFTER_START = """\
+            if not self.attached or not self.socket:
+                await self.attach()
+
+        _id = next(self.__count__)
+        message = {"method": method, "params": params, "id": _id}
+        if not _attach:
+            message["sessionId"] = self.session_id
+
+        tx = Transaction(message)
+        self.transactions.append(tx)
+        self._tx_by_id[_id] = tx
+
+        future = asyncio.get_running_loop().create_future()
+        self._mapper[_id] = future
+
+        while len(self.transactions) > 25:
+            removed_tx = self.transactions.pop(0)
+            if removed_tx.id is not None:
+                self._tx_by_id.pop(removed_tx.id, None)
+
+        ws = self.socket
+        if ws is None:
+            raise RuntimeError("WebSocket is not connected")
+
+        async with self.lock:
+            try:
+                await ws.send(json.dumps(message))
+            except Exception:
+                self._mapper.pop(_id, None)
+                if not future.done():
+                    future.cancel()
+                raise
+
+        try:
+            response_message = await future
+        finally:
+            self._mapper.pop(_id, None)
+
+        if "error" in response_message:
+            exception = ProtocolException(response_message["error"])
+            tx.result = exception
+            raise exception"""
+
+_ORIG_SEND_METHOD = (
+    "    async def send(self, cdp_obj, **kwargs):\n"
+    f"{_SEND_START_LINE}\n"
+    f"{_ORIG_BODY_AFTER_START}\n"
+    "        return response_message"
+)
+
+_UNRELATED_RETRY_BLOCK = (
+    "# Some other function that happens to have for _retry in range(2):\n"
+    "for _retry in range(2):\n"
+    "    pass\n"
+)
+
+
+def _make_connection_py(method_body:str, extra:str = "") -> str:
+    """Build a fake connection.py with a given method body."""
+    lines = [
+        "import json",
+        "import asyncio",
+        "",
+        "class Connection:",
+        method_body,
+        "",
+        "class SomethingElse:",
+        "    pass",
+    ]
+    if extra:
+        lines.extend(["", extra])
+    return "\n".join(lines) + "\n"
+
+
+def _apply_fix(method_body:str, extra:str = "") -> tuple[str, str]:
+    """Write content to a temp file, run _fix_connection_send, return (text, status)."""
+    content = _make_connection_py(method_body, extra)
+    with tempfile.NamedTemporaryFile(mode = "w", suffix = ".py", delete = False, encoding = "utf-8") as f:
+        f.write(content)
+        tmpname = f.name
+    try:
+        status = fix_nodriver._fix_connection_send(Path(tmpname))  # noqa: SLF001
+        return Path(tmpname).read_text("utf-8"), status
+    finally:
+        Path(tmpname).unlink(missing_ok = True)
+
+
+def _markerless_send_method() -> str:
+    """Build a send method body that uses the old markerless patch."""
+    return (
+        "    async def send(self, cdp_obj, **kwargs):\n"
+        f"{fix_nodriver._OLD_SEND.rstrip(chr(10))}\n"  # noqa: SLF001
+        "        return response_message"
+    )
+
+
+def _patched_send_method() -> str:
+    """Build a send method body that uses the new patch (with marker)."""
+    return (
+        "    async def send(self, cdp_obj, **kwargs):\n"
+        f"{fix_nodriver._NEW_SEND.rstrip(chr(10))}\n"  # noqa: SLF001
+        "        return response_message"
+    )
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+
+class TestFixConnectionSend:
+    """Tests for _fix_connection_send on temporary files."""
+
+    def test_fresh_patch_includes_marker(self) -> None:
+        """Fresh patch inserts the marker comment."""
+        text, status = _apply_fix(_ORIG_SEND_METHOD)
+        assert status == "fixed"
+        assert fix_nodriver._CONNECTION_SEND_PATCH_MARKER in text  # noqa: SLF001
+
+    def test_marker_present_is_idempotent(self) -> None:
+        """Marker present → already-ok, no changes."""
+        text, status = _apply_fix(_patched_send_method())
+        assert status == "already-ok"
+        # Marker still present.
+        assert fix_nodriver._CONNECTION_SEND_PATCH_MARKER in text  # noqa: SLF001
+
+    def test_legacy_markerless_body_normalized(self) -> None:
+        """Exact old markerless body gets normalized to _NEW_SEND."""
+        old_markerless = fix_nodriver._OLD_SEND  # noqa: SLF001
+        # Sanity: old body does NOT contain the marker.
+        assert fix_nodriver._CONNECTION_SEND_PATCH_MARKER not in old_markerless  # noqa: SLF001
+        text, status = _apply_fix(_markerless_send_method())
+        assert status == "updated", f"Expected 'updated', got '{status}'"
+        # Now contains marker.
+        assert fix_nodriver._CONNECTION_SEND_PATCH_MARKER in text  # noqa: SLF001
+
+    def test_unrelated_retry_not_normalized(self) -> None:
+        """Arbitrary 'for _retry in range(2):' outside the patch body is NOT normalized."""
+        text, status = _apply_fix(_ORIG_SEND_METHOD, _UNRELATED_RETRY_BLOCK)
+        assert status == "fixed"
+        assert fix_nodriver._CONNECTION_SEND_PATCH_MARKER in text  # noqa: SLF001
+        # The unrelated retry block is still present unchanged AND lacks the marker.
+        marker_prefix = f"# {fix_nodriver._CONNECTION_SEND_PATCH_MARKER}"  # noqa: SLF001
+        # Find all occurrences of "for _retry in range(2):" and verify the
+        # one from the unrelated block is NOT preceded by the marker comment.
+        occ_count = text.count("for _retry in range(2):")
+        assert occ_count >= 2, (
+            f"Expected at least 2 occurrences (patch + unrelated), got {occ_count}"
+        )
+        # The unrelated block comes after the patched send method,
+        # so its "for _retry in range(2):" is NOT preceded by the marker.
+        # Verify by checking that the LAST occurrence lacks the marker prefix.
+        last_retry_pos = text.rfind("for _retry in range(2):")
+        preceding = text[max(0, last_retry_pos - 80):last_retry_pos]
+        assert marker_prefix not in preceding, (
+            "Unrelated retry loop should NOT have the marker comment before it"
+        )

--- a/tests/unit/test_fix_nodriver.py
+++ b/tests/unit/test_fix_nodriver.py
@@ -31,7 +31,6 @@ pytestmark = pytest.mark.unit
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 _SEND_START_LINE = "        if not _attach:"
-_SEND_ERR_END_LINE = "            raise exception"
 
 _ORIG_BODY_AFTER_START = """\
             if not self.attached or not self.socket:

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -2054,12 +2054,12 @@ class TestSelectButtonCombobox:
         self,
         test_bot:KleinanzeigenBot,
     ) -> None:
-        """When JS returns {ok: False, ...}, TimeoutError is raised with context."""
+        """When JS returns {ok: False, reason_code, ...}, TimeoutError contains the mapped label."""
         elem_id = "my-combobox-id"
         option_value = "missing_option"
         js_status = {
             "ok": False,
-            "reason": "Option not found",
+            "reason": "option_not_found",
             "requested": "missing_option",
             "options": ["Option A", "Option B"],
         }
@@ -2073,6 +2073,7 @@ class TestSelectButtonCombobox:
         msg = str(exc_info.value)
         assert "missing_option" in msg
         assert "my-combobox-id" in msg
+        # JS code "option_not_found" is mapped to label "Option not found" via _().
         assert "Option not found" in msg
         assert "Option A" in msg
 

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -2012,55 +2012,102 @@ class TestWantedShippingSelection:
 
 
 class TestSelectButtonCombobox:
-    """Tests for _select_button_combobox (React fiber combobox selection).
+    """Tests for _select_button_combobox (single async script combobox selection).
 
     ``_select_button_combobox`` is the internal helper used for special-attribute
-    comboboxes where the option list is embedded in the React fiber tree. It clicks
-    the button to open the menu, waits for the listbox, then executes JS to find
-    and click the matching option by value.
+    comboboxes where the option list is embedded in the React fiber tree. It executes
+    a single async JS script that opens the control via pointerdown/mousedown,
+    polls for visible options, and clicks the matching option by value.
     """
 
     @pytest.mark.asyncio
-    async def test_select_button_combobox_success(
+    async def test_select_button_combobox_calls_web_execute_directly(
         self,
         test_bot:KleinanzeigenBot,
     ) -> None:
-        """Successful selection: clicks button, waits for listbox, executes JS, returns True."""
+        """Successful selection: calls web_execute directly with no separate click/find."""
         elem_id = "my-combobox-id"
         option_value = "option_value"
 
         with (
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
-            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = True) as mock_execute,
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = {"ok": True}) as mock_execute,
         ):
             await _select_button_combobox(test_bot, elem_id, option_value)
 
-        mock_click.assert_awaited_once_with(By.ID, elem_id)
-        mock_find.assert_awaited_once_with(By.ID, f"{elem_id}-menu")
+        mock_click.assert_not_awaited()
+        mock_find.assert_not_awaited()
         mock_execute.assert_awaited_once()
         assert mock_execute.await_args is not None
         js = str(mock_execute.await_args.args[0])
-        assert "my-combobox-id" in js
-        assert "my-combobox-id-menu" in js
+        # JS key invariants: async IIFE, pointerdown, mousedown, escaped elem_id, escaped value, option query
+        assert "async function" in js or "async(function" in js or js.startswith("(async")
+        assert "pointerdown" in js
+        assert "mousedown" in js
+        assert "document.getElementById(" in js
         assert "option_value" in js
 
     @pytest.mark.asyncio
-    async def test_select_button_combobox_js_returns_false(
+    async def test_select_button_combobox_structured_failure_raises_timeout(
         self,
         test_bot:KleinanzeigenBot,
     ) -> None:
-        """When the JS fiber walk returns False, TimeoutError is raised."""
+        """When JS returns {ok: False, ...}, TimeoutError is raised with context."""
+        elem_id = "my-combobox-id"
+        option_value = "missing_option"
+        js_status = {
+            "ok": False,
+            "reason": "Option not found",
+            "requested": "missing_option",
+            "options": ["Option A", "Option B"],
+        }
+
+        with (
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = js_status),
+            pytest.raises(TimeoutError) as exc_info,
+        ):
+            await _select_button_combobox(test_bot, elem_id, option_value)
+
+        msg = str(exc_info.value)
+        assert "missing_option" in msg
+        assert "my-combobox-id" in msg
+        assert "Option not found" in msg
+        assert "Option A" in msg
+
+    @pytest.mark.asyncio
+    async def test_select_button_combobox_bare_false_raises_timeout(
+        self,
+        test_bot:KleinanzeigenBot,
+    ) -> None:
+        """When JS returns a bare False (legacy fallback), TimeoutError is still raised."""
         elem_id = "my-combobox-id"
         option_value = "missing_option"
 
         with (
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock),
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = False),
-            pytest.raises(TimeoutError, match = "not found in button combobox"),
+            pytest.raises(TimeoutError),
         ):
             await _select_button_combobox(test_bot, elem_id, option_value)
+
+    @pytest.mark.asyncio
+    async def test_select_button_combobox_element_id_escaped_via_json_dumps(
+        self,
+        test_bot:KleinanzeigenBot,
+    ) -> None:
+        """elem_id must be embedded in JS via json.dumps (safe quoting)."""
+        elem_id = 'danger"id'
+        option_value = "val"
+
+        with (
+            patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = {"ok": True}) as mock_execute,
+        ):
+            await _select_button_combobox(test_bot, elem_id, option_value)
+
+        assert mock_execute.await_args is not None
+        js = str(mock_execute.await_args.args[0])
+        # json.dumps('danger"id') == '"danger\\"id"'
+        assert 'danger\\"id' in js or 'danger"' in js
 
 
 class TestSpecialAttributes:

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -2098,7 +2098,7 @@ class TestSelectButtonCombobox:
     ) -> None:
         """elem_id and option_value must be embedded in JS via json.dumps (safe quoting)."""
         elem_id = 'danger"id'
-        option_value = "bad'val"
+        option_value = 'bad"value'
 
         with (
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = {"ok": True}) as mock_execute,

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -2042,12 +2042,10 @@ class TestSelectButtonCombobox:
         mock_execute.assert_awaited_once()
         assert mock_execute.await_args is not None
         js = str(mock_execute.await_args.args[0])
-        # JS key invariants: async IIFE, pointerdown, mousedown, escaped elem_id, escaped value, option query
+        # Stable contract: one async browser script receives safely quoted inputs.
         assert "async function" in js or "async(function" in js or js.startswith("(async")
-        assert "pointerdown" in js
-        assert "mousedown" in js
-        assert "document.getElementById(" in js
-        assert "option_value" in js
+        assert json.dumps(elem_id) in js
+        assert json.dumps(option_value) in js
 
     @pytest.mark.asyncio
     async def test_select_button_combobox_structured_failure_raises_timeout(

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -4,6 +4,7 @@
 """Tests for publishing form operations (contact/location fields, category selection, city selection, pricing)."""
 
 import asyncio
+import json
 import logging
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -2091,13 +2092,13 @@ class TestSelectButtonCombobox:
             await _select_button_combobox(test_bot, elem_id, option_value)
 
     @pytest.mark.asyncio
-    async def test_select_button_combobox_element_id_escaped_via_json_dumps(
+    async def test_select_button_combobox_element_id_and_value_escaped_via_json_dumps(
         self,
         test_bot:KleinanzeigenBot,
     ) -> None:
-        """elem_id must be embedded in JS via json.dumps (safe quoting)."""
+        """elem_id and option_value must be embedded in JS via json.dumps (safe quoting)."""
         elem_id = 'danger"id'
-        option_value = "val"
+        option_value = "bad'val"
 
         with (
             patch.object(test_bot, "web_execute", new_callable = AsyncMock, return_value = {"ok": True}) as mock_execute,
@@ -2106,8 +2107,8 @@ class TestSelectButtonCombobox:
 
         assert mock_execute.await_args is not None
         js = str(mock_execute.await_args.args[0])
-        # json.dumps('danger"id') == '"danger\\"id"'
-        assert 'danger\\"id' in js or 'danger"' in js
+        assert json.dumps(elem_id) in js
+        assert json.dumps(option_value) in js
 
 
 class TestSpecialAttributes:

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -2042,8 +2042,7 @@ class TestSelectButtonCombobox:
         mock_execute.assert_awaited_once()
         assert mock_execute.await_args is not None
         js = str(mock_execute.await_args.args[0])
-        # Stable contract: one async browser script receives safely quoted inputs.
-        assert "async function" in js or "async(function" in js or js.startswith("(async")
+        # Stable contract: a single browser script receives safely quoted inputs.
         assert json.dumps(elem_id) in js
         assert json.dumps(option_value) in js
 

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -1245,10 +1245,8 @@ class TestWebScrolling:
                 await web_scraper.web_await(condition, timeout = 0.2, apply_multiplier = False)
         finally:
             task.cancel()
-            try:
+            with pytest.raises(asyncio.CancelledError):
                 await task
-            except asyncio.CancelledError:
-                ...  # expected: task was cancelled above
 
         assert tick_count[0] > 0, "Background ticker should have advanced while web_await was retrying"
 

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -1245,8 +1245,12 @@ class TestWebScrolling:
                 await web_scraper.web_await(condition, timeout = 0.2, apply_multiplier = False)
         finally:
             task.cancel()
-            with pytest.raises(asyncio.CancelledError):
+            task_was_cancelled = False
+            try:
                 await task
+            except asyncio.CancelledError:
+                task_was_cancelled = True
+            assert task_was_cancelled
 
         assert tick_count[0] > 0, "Background ticker should have advanced while web_await was retrying"
 

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -4,7 +4,6 @@
 """Unit tests for web_scraping_mixin.py focusing on error handling scenarios."""
 
 import asyncio
-import contextlib
 import json
 import logging
 import os
@@ -1221,6 +1220,8 @@ class TestWebScrolling:
         with pytest.raises(TimeoutError):
             await web_scraper.web_await(condition, timeout = 0.05, apply_multiplier = False)
 
+        # The exception triggers re-attach on each retry attempt.
+        assert attach_mock.call_count > 0, "Expected at least one attach attempt"
         # With 50ms retry sleep per iteration and 50ms timeout, at most ~5 iterations.
         # Use a generous threshold to avoid flakiness on busy CI.
         assert attach_mock.call_count < 50, f"Expected < 50 attach calls, got {attach_mock.call_count}"
@@ -1244,8 +1245,10 @@ class TestWebScrolling:
                 await web_scraper.web_await(condition, timeout = 0.2, apply_multiplier = False)
         finally:
             task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            try:
                 await task
+            except asyncio.CancelledError:
+                ...  # expected: task was cancelled above
 
         assert tick_count[0] > 0, "Background ticker should have advanced while web_await was retrying"
 

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -3,6 +3,7 @@
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """Unit tests for web_scraping_mixin.py focusing on error handling scenarios."""
 
+import asyncio
 import json
 import logging
 import os
@@ -1196,6 +1197,58 @@ class TestWebScrolling:
         # so the total elapsed time should be at least the timeout (0.2s) but not wildly exceed it.
         assert elapsed >= 0.15, f"Expected >= 0.15s elapsed, got {elapsed:.3f}s"
         assert elapsed < 1.0, f"Expected < 1.0s elapsed, got {elapsed:.3f}s"
+
+    @pytest.mark.asyncio
+    async def test_web_await_reattach_exhaustion(self, web_scraper:WebScrapingMixin, mock_page:TrulyAwaitableMockPage) -> None:
+        """web_await raises TimeoutError when condition keeps raising ProtocolException(-32601)."""
+
+        async def condition() -> bool:
+            raise ProtocolException({"message": "Method not found", "code": -32601})
+
+        with pytest.raises(TimeoutError):
+            await web_scraper.web_await(condition, timeout = 0.2, apply_multiplier = False)
+
+    @pytest.mark.asyncio
+    async def test_web_await_reattach_bounded(self, web_scraper:WebScrapingMixin, mock_page:TrulyAwaitableMockPage) -> None:
+        """web_await with persistent -32601 should have bounded attach calls, not tight loop."""
+        attach_mock = cast(AsyncMock, mock_page.attach)
+        attach_mock.reset_mock()
+
+        async def condition() -> bool:
+            raise ProtocolException({"message": "Method not found", "code": -32601})
+
+        with pytest.raises(TimeoutError):
+            await web_scraper.web_await(condition, timeout = 0.05, apply_multiplier = False)
+
+        # With 50ms retry sleep per iteration and 50ms timeout, at most ~5 iterations.
+        # Use a generous threshold to avoid flakiness on busy CI.
+        assert attach_mock.call_count < 50, f"Expected < 50 attach calls, got {attach_mock.call_count}"
+
+    @pytest.mark.asyncio
+    async def test_web_await_reattach_background_task_advances(self, web_scraper:WebScrapingMixin, mock_page:TrulyAwaitableMockPage) -> None:
+        """Background tasks should advance while web_await retries -32601."""
+        tick_count:list[int] = [0]
+
+        async def ticker() -> None:
+            while True:
+                await asyncio.sleep(0.001)
+                tick_count[0] += 1
+
+        async def condition() -> bool:
+            raise ProtocolException({"message": "Method not found", "code": -32601})
+
+        task = asyncio.create_task(ticker())
+        try:
+            with pytest.raises(TimeoutError):
+                await web_scraper.web_await(condition, timeout = 0.2, apply_multiplier = False)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert tick_count[0] > 0, "Background ticker should have advanced while web_await was retrying"
 
     @pytest.mark.asyncio
     async def test_web_sleep_produces_real_delay(self, web_scraper:WebScrapingMixin, mock_page:TrulyAwaitableMockPage) -> None:

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -4,6 +4,7 @@
 """Unit tests for web_scraping_mixin.py focusing on error handling scenarios."""
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -1243,10 +1244,8 @@ class TestWebScrolling:
                 await web_scraper.web_await(condition, timeout = 0.2, apply_multiplier = False)
         finally:
             task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await task
-            except asyncio.CancelledError:
-                pass
 
         assert tick_count[0] > 0, "Background ticker should have advanced while web_await was retrying"
 


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #1184
- Fixes two publish-flow failures reported in issue #1184:
  - persistent nodriver `ProtocolException(code=-32601)` could spin forever in `web_await()` while repeatedly re-attaching the CDP session;
  - special-attribute button comboboxes in the Handy & Telefon category needed open/read/select to happen atomically in one browser execution.

## 📋 Changes Summary

- Bound `web_await()` CDP reattach retries by the configured timeout and add a short nonzero retry delay to avoid event-loop starvation.
- Update special-attribute button-combobox selection to use one async `web_execute()` script that opens via pointer/mouse events, discovers options, matches API values, and clicks the selected option before the dropdown can close.
- Add regression tests for bounded `-32601` retry behavior and atomic button-combobox selection.
- Update the German translation for the enhanced combobox failure message.
- Verified with the live `button-combobox` DOM probe.

### ⚙️ Type of Change

Select the type(s) of change(s) included in this pull request:
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist

Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Validation

- `pdm run format`
- `pdm run lint`
- `pdm run test` — 1370 passed, 4 skipped
- `pdm run python data/verify_dom_assumptions.py run --yes --probe button-combobox --report data/.temp/dom-assumptions-issue-1184-button-combobox.json` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown/combobox option selection with stronger matching and more informative timeout/error reporting.
  * Tightened CDP re-attach retry logic to strictly follow the remaining timeout budget.
  * Added a startup runtime warning if the required nodriver CDP re-attach patch isn’t detected.

* **Documentation / Chores**
  * Updated source installation guidance (pip-only users) to ensure the nodriver patch is applied.
  * Made the nodriver fix script marker-based and idempotent, including normalization of legacy patched installs.

* **Tests**
  * Expanded unit tests for combobox selection, re-attach timeout/bounds behavior, CLI patch warning behavior, and the nodriver fix script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->