### PR TITLE
docs: shorten pip-only install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,14 +141,8 @@ Die Nutzung erfolgt auf eigenes Risiko. Jede rechtswidrige Verwendung ist unters
    pdm install
    ```
 
-   > **Note for pip-only users:** Running `pip install .` from a source checkout
-   > skips the PDM `post_install` hook that patches nodriver for
-   > Chromium flat-mode sessions. If you see repeated
-   > `Re-attaching CDP session after -32601` messages at startup, use
-   > `pdm install` instead, or run `python scripts/fix_nodriver.py` from the
-   > repository checkout. The app also checks for this nodriver patch at
-   > startup and warns if it appears missing; keep this note in sync with
-   > `scripts/fix_nodriver.py` and the CLI guard.
+   > **Pip-only side note:** `pip install .` skips PDM's nodriver patch; prefer
+   > `pdm install` or run `python scripts/fix_nodriver.py` if needed.
 
 1. Run the app:
 


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): N/A
- Shortens the pip-only install note in the README so it is a side note rather than prominent guidance.

## 📋 Changes Summary

- Condensed the pip-only note from a long block to two lines.
- No dependencies, configuration changes, or additional requirements introduced.

### ⚙️ Type of Change

Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass (`pdm run test`). Not run; documentation-only change.
- [ ] I have formatted the code (`pdm run format`). Not run; documentation-only change.
- [ ] I have verified that linting passes (`pdm run lint`). Not run; documentation-only change.
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
