### PR TITLE
docs: clarify download shipping inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Options:
 
 > **Note:** The output of `kleinanzeigen-bot help` is always the most up-to-date reference for available commands and options.
 
-Limitation of `download`: It's only possible to extract the cheapest given shipping option.
+Shipping inference during `download`: the bot reads the public ad shipping state. Pickups are recorded as `PICKUP`; `Versand möglich` without a visible price is recorded as `SHIPPING` without costs or options. Visible "shipping from" prices are stored as `shipping_costs` and, when a current predefined gateway option with that price is found, mapped to one `shipping_options` entry by default. Set `download.include_all_matching_shipping_options: true` to include all non-excluded options with the same package size. Direct-buy eligibility (`sell_directly`) comes from cached manage-ads data, so it is only resolved for ads owned by the current profile.
 
 ## <a name="config"></a>Configuration
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Options:
 
 > **Note:** The output of `kleinanzeigen-bot help` is always the most up-to-date reference for available commands and options.
 
-Shipping inference during `download`: the bot reads the public ad shipping state. Pickups are recorded as `PICKUP`; `Versand möglich` without a visible price is recorded as `SHIPPING` without costs or options. Visible "shipping from" prices are stored as `shipping_costs` and, when a current predefined gateway option with that price is found, mapped to one `shipping_options` entry by default. Set `download.include_all_matching_shipping_options: true` to include all non-excluded options with the same package size. Direct-buy eligibility (`sell_directly`) comes from cached manage-ads data, so it is only resolved for ads owned by the current profile.
+Shipping inference during `download`: the bot reads the public ad shipping state. Pickup becomes `PICKUP`; `Versand möglich` without a price becomes `SHIPPING` without costs/options. Visible "shipping from" prices are kept as deprecated `shipping_costs` metadata and, when they match a current gateway option, infer one [`shipping_options`](docs/AD_CONFIGURATION.md#shipping-options-reference) entry by default. Set `download.include_all_matching_shipping_options: true` to include all non-excluded options with the same package size. `sell_directly` is resolved only for current-profile ads from cached manage-ads data.
 
 ## <a name="config"></a>Configuration
 


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #
- Clarifies what `download` can infer for shipping options after the old cheapest-option limitation became inaccurate.

## 📋 Changes Summary

- Replaces the outdated README limitation with the current download shipping inference behavior.
- Documents pickup handling, `Versand möglich` without price, visible shipping prices, inferred `shipping_options`, `download.include_all_matching_shipping_options`, and `sell_directly` scope.
- No dependency or configuration changes.

### ⚙️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README “download” limitations to clarify that shipping details are inferred dynamically.
  * Added a detailed explanation of how pickup vs. “Versand möglich” listings are handled, how “shipping from” prices map to shipping costs and options, and how direct-buy eligibility is determined.
  * Documented the option to include all matching non-excluded shipping options during download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->