### PR TITLE
chore: remove CodeRabbit keyword ignores

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -133,7 +133,6 @@ reviews:
     enabled: true
     auto_incremental_review: true
     drafts: false
-    ignore_title_keywords: ["wip", "draft", "temp"]
     labels: ["!wip", "!draft"]  # Review all PRs except those with wip or draft labels
 
 


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): N/A
- Remove CodeRabbit title keyword ignores so PRs with matching title words are no longer skipped automatically.

## 📋 Changes Summary

- Removed `ignore_title_keywords` from `.coderabbit.yaml`.
- No runtime dependencies, configuration requirements, or application behavior changes introduced.

### ⚙️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)
- [x] Chore / configuration maintenance

## ✅ Checklist

Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass (`pdm run test`). Not run — CodeRabbit config-only change.
- [ ] I have formatted the code (`pdm run format`). Not run — YAML line deletion only.
- [ ] I have verified that linting passes (`pdm run lint`). Not run — CodeRabbit config-only change.
- [x] I have updated documentation where necessary. No documentation updates needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review settings so keyword-based exclusions are no longer used.
  * Review behavior now relies on existing draft and label checks, which may result in more consistent PR review coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->