### PR TITLE
fix: resize viewport after opening page

### DIFF
--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -823,9 +823,18 @@ kleinanzeigen_bot/utils/web_scraping_mixin.py:
     " -> Randomized browser window size: %s": " -> Zufällige Browser-Fenstergröße: %s"
     "Ignoring empty --user-data-dir= argument; falling back to configured user_data_dir.": "Ignoriere leeres --user-data-dir= Argument; verwende konfiguriertes user_data_dir."
 
-  _select_viewport_size:
-    "Screen-aware viewport: %s jittered to %dx%d (avail %dx%d)": "Bildschirmgerechte Fenstergröße: %s mit Zufallsabweichung auf %dx%d (verfügbar: %dx%d)"
-    "No configured viewport fits %dx%d screen; omitting --window-size": "Keine konfigurierte Fenstergröße passt in den verfügbaren Bildschirmbereich %dx%d; --window-size wird weggelassen"
+  _select_viewport_size_for_metrics:
+    "Screen metrics unavailable or invalid; omitting viewport resize": "Bildschirmdaten nicht verfügbar oder ungültig; Größenänderung des Browserfensters wird ausgelassen"
+    "No configured viewport fits %dx%d screen; omitting viewport resize": "Keine konfigurierte Fenstergröße passt in den verfügbaren Bildschirmbereich %dx%d; Größenänderung des Browserfensters wird ausgelassen"
+    "Selected viewport size became invalid during parsing: %s": "Ausgewählte Fenstergröße wurde beim Auswerten ungültig: %s"
+    "Screen-aware viewport: %s jittered to %s (avail %dx%d)": "Bildschirmgerechte Fenstergröße: %s mit Zufallsabweichung auf %s (verfügbar: %dx%d)"
+
+  _apply_viewport_size:
+    "Applied randomized browser window size: %dx%d": "Zufällige Browser-Fenstergröße angewendet: %dx%d"
+    "Viewport resize failed via CDP: %s": "Größenänderung des Browserfensters über CDP fehlgeschlagen: %s"
+
+  _resize_viewport_after_open:
+    "Viewport resize skipped: %s": "Größenänderung des Browserfensters übersprungen: %s"
 
   _resolve_effective_user_data_dir:
     "Configured browser.user_data_dir (%s) does not match --user-data-dir argument (%s); using the argument value.": "Konfiguriertes browser.user_data_dir (%s) stimmt nicht mit --user-data-dir Argument (%s) überein; verwende Argument-Wert."

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © Sebastian Thomschke and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
-import asyncio, enum, inspect, json, math, os, platform, secrets, shutil, subprocess, tempfile  # isort: skip # noqa: S404
+import asyncio, enum, inspect, json, math, os, platform, secrets, shutil, subprocess  # isort: skip # noqa: S404
 from collections.abc import Awaitable, Callable, Coroutine, Iterable, Sequence
 from gettext import gettext as _
 from pathlib import Path, PureWindowsPath
 from typing import Any, Final, Optional, cast
+from urllib.parse import urlparse
 
 try:
     from typing import Never  # type: ignore[attr-defined,unused-ignore] # mypy
@@ -13,7 +14,7 @@ except ImportError:
     from typing import NoReturn as Never  # Python <3.11
 
 import nodriver, psutil  # isort: skip
-from nodriver.cdp import input_ as cdp_input  # isort: skip
+from nodriver.cdp import browser as cdp_browser, input_ as cdp_input  # isort: skip
 from typing import TYPE_CHECKING, TypeGuard
 
 from nodriver.core.browser import Browser
@@ -55,6 +56,14 @@ _BACKUP_SELECTOR_BUDGET_FLOOR_SECONDS:Final[float] = 0.25
 # available screen area so the window never exceeds what the display can show.
 _VIEWPORT_JITTER_W:Final[int] = 24
 _VIEWPORT_JITTER_H:Final[int] = 16
+_VIEWPORT_RESIZE_STATUS_NOT_ATTEMPTED:Final[str] = "not-attempted"
+_VIEWPORT_RESIZE_STATUS_APPLIED:Final[str] = "applied"
+_VIEWPORT_RESIZE_STATUS_SKIPPED:Final[str] = "skipped"
+_VIEWPORT_RESIZE_STATUS_UNAVAILABLE:Final[str] = "unavailable"
+_VIEWPORT_RESIZE_STATUS_INVALID_METRICS:Final[str] = "invalid-metrics"
+_VIEWPORT_RESIZE_STATUS_NO_FIT:Final[str] = "no-fitting-size"
+_VIEWPORT_RESIZE_STATUS_FAILED:Final[str] = "failed"
+_VIEWPORT_RESIZE_STATUS_UNAVAILABLE_PAGE:Final[str] = "unavailable-page"
 
 
 def _resolve_user_data_dir_paths(arg_value:str, config_value:str) -> tuple[Any, Any]:
@@ -231,19 +240,38 @@ def _build_nodriver_config(browser_path:str, browser_args:list[str], user_data_d
     return cfg
 
 
-def _filter_viewport_sizes(sizes:list[str], avail_w:int, avail_h:int) -> list[str]:
+def _parse_viewport_size(size:str) -> tuple[int, int] | None:
+    """Parse a ``WxH`` viewport string into ``(width, height)`` integers."""
+    if not isinstance(size, str):
+        return None
+
+    parts = size.lower().split("x")
+    if len(parts) != _KEY_VALUE_PAIR_SIZE:
+        return None
+
+    try:
+        w = int(parts[0].strip())
+        h = int(parts[1].strip())
+    except ValueError:
+        return None
+
+    if w <= 0 or h <= 0:
+        return None
+    return w, h
+
+
+def _filter_viewport_sizes(sizes:Sequence[str], avail_w:int, avail_h:int) -> list[str]:
     """Return viewport sizes whose width/height both fit within the given available screen area."""
     fitting:list[str] = []
     for size in sizes:
-        try:
-            parts = size.lower().split("x")
-            w = int(parts[0].strip())
-            h = int(parts[1].strip())
-            if w <= avail_w and h <= avail_h:
-                fitting.append(size)
-        except (ValueError, IndexError):
+        parsed = _parse_viewport_size(size)
+        if parsed is None:
             LOG.debug("Skipping unparseable viewport size during filtering: %s", size)
             continue
+
+        w, h = parsed
+        if w <= avail_w and h <= avail_h:
+            fitting.append(size)
     return fitting
 
 
@@ -292,9 +320,11 @@ class WebScrapingMixin:  # noqa: PLR0904
         self.browser_config:Final[BrowserConfig] = BrowserConfig()
         self.browser:Browser = None  # pyright: ignore[reportAttributeAccessIssue]
         self.page:Page = None  # pyright: ignore[reportAttributeAccessIssue]
+        self._browser_session_is_remote:bool = False
+        self._viewport_resize_attempted:bool = False
+        self._viewport_resize_status:dict[str, Any] = {"status": _VIEWPORT_RESIZE_STATUS_NOT_ATTEMPTED, "attempted": False, "applied": False}
         self._default_timeout_config:TimeoutConfig | None = None
         self._default_humanization_config:HumanizationConfig | None = None
-        self._screen_metrics_cache:tuple[int, int] | None = None
         self.config:BotConfig = cast(BotConfig, None)
 
     def _get_humanization_config(self) -> HumanizationConfig:
@@ -503,6 +533,9 @@ class WebScrapingMixin:  # noqa: PLR0904
 
     async def create_browser_session(self) -> None:
         LOG.info("Creating Browser session...")
+        self._viewport_resize_attempted = False
+        self._set_viewport_resize_status(_VIEWPORT_RESIZE_STATUS_NOT_ATTEMPTED, attempted = False)
+        self._browser_session_is_remote = False
 
         if self.browser_config.binary_location:
             ensure(await files.exists(self.browser_config.binary_location), f"Specified browser binary [{self.browser_config.binary_location}] does not exist.")
@@ -538,27 +571,15 @@ class WebScrapingMixin:  # noqa: PLR0904
         if remote_port > 0:
             self.browser = await self._connect_to_remote_browser(remote_host, remote_port)
             LOG.info("New Browser session is %s", self.browser.websocket_url)
+            self._browser_session_is_remote = True
             return
 
         ########################################################
         # configure and initialize new browser instance...
         ########################################################
 
-        # Screen-aware viewport selection — probe is skipped when the user already
-        # supplies --window-size or when humanization / randomization is disabled.
-        # Computed locally to avoid stale state across repeated sessions.
-        humanization = self._get_humanization_config()
-        selected_viewport_size:str | None = None
-        if (
-            humanization.enabled
-            and humanization.randomize_viewport
-            and humanization.viewport_sizes
-            and not any(arg.startswith("--window-size") for arg in self.browser_config.arguments)
-        ):
-            selected_viewport_size = await self._select_viewport_size()
-
         browser_args, user_data_dir_from_args = self._build_new_browser_launch_args(
-            selected_viewport_size = selected_viewport_size
+            selected_viewport_size = None
         )
         effective_user_data_dir = await self._resolve_effective_user_data_dir(user_data_dir_from_args)
 
@@ -581,6 +602,7 @@ class WebScrapingMixin:  # noqa: PLR0904
         try:
             self.browser = await nodriver.start(cfg)  # type: ignore[attr-defined]
             LOG.info("New Browser session is %s", self.browser.websocket_url)
+            self._browser_session_is_remote = False
         except Exception as e:
             # Clean up any resources that were created during setup
             self._cleanup_session_resources()
@@ -636,144 +658,191 @@ class WebScrapingMixin:  # noqa: PLR0904
                 LOG.error("4. Check if any antivirus or security software is blocking the connection")
             raise
 
-    async def _probe_screen_metrics(self) -> tuple[int, int] | None:
-        """Start a temporary isolated browser to probe CSS-pixel screen dimensions.
+    def _set_viewport_resize_status(
+        self,
+        status:str,
+        *,
+        attempted:bool | None = None,
+        applied:bool = False,
+        reason:str | None = None,
+        selected_viewport:str | None = None,
+        error:str | None = None,
+    ) -> None:
+        attempted_value = self._viewport_resize_attempted if attempted is None else attempted
+        self._viewport_resize_attempted = attempted_value
+        result:dict[str, Any] = {"status": status, "attempted": attempted_value, "applied": applied}
+        if reason is not None:
+            result["reason"] = reason
+        if selected_viewport is not None:
+            result["selected_viewport"] = selected_viewport
+        if error is not None:
+            result["error"] = error
+        self._viewport_resize_status = result
 
-        Returns ``(availWidth, availHeight)`` from ``window.screen``, or ``None`` if
-        the probe browser could not be started or the metrics are unavailable.
-        The probe browser uses a temporary user data directory and its own lifecycle
-        — it never touches ``self.browser`` or ``self.page``.
-        """
-        if self._screen_metrics_cache is not None:
-            return self._screen_metrics_cache
+    def get_viewport_resize_status(self) -> dict[str, Any]:
+        """Return diagnostics for the post-open screen-aware viewport resize."""
+        return dict(self._viewport_resize_status)
 
-        binary = self.browser_config.binary_location
-        if not binary:
-            return None
-
-        tmp_dir:str | None = None
-        browser:Browser | None = None
+    def _is_kleinanzeigen_page(self, url:str | None) -> bool:
+        if not url:
+            return False
         try:
-            tmp_dir = tempfile.mkdtemp(prefix = "kbb-probe-")
-
-            # Strip flags that would tie the probe to the user's profile, alter its
-            # window, or load extensions.  Critical generic flags (--no-sandbox, …)
-            # are preserved.  --disable-extensions is kept as a safety/noise-reduction
-            # flag, not an extension-load flag.
-            skip_prefixes = ("--user-data-dir=", "--profile-directory=", "--window-size", "--load-extension=")
-            probe_args = [a for a in self.browser_config.arguments if not any(a.startswith(p) for p in skip_prefixes)]
-
-            cfg = _build_nodriver_config(binary, probe_args, tmp_dir)
-
-            async def run_probe() -> Any:
-                nonlocal browser
-                browser = await nodriver.start(cfg)  # type: ignore[attr-defined]
-                page = await browser.get("about:blank")
-                # Give the page a moment to stabilise before querying screen metrics.
-                await asyncio.sleep(0.5)
-
-                return await page.evaluate(
-                    "({availWidth: window.screen.availWidth, availHeight: window.screen.availHeight})",
-                    await_promise = True,
-                    return_by_value = True,
-                )
-
-            result = await asyncio.wait_for(run_probe(), timeout = self.effective_timeout("chrome_remote_probe"))
-
-            # Normalize nodriver RemoteObject to a plain dict when
-            # return_by_value is not honoured by the runtime.
-            if _is_remote_object(result):
-                try:
-                    remote_obj:"RemoteObject" = result  # noqa: F841
-                    if hasattr(remote_obj, "deep_serialized_value") and remote_obj.deep_serialized_value:
-                        result = self._convert_remote_object_value(remote_obj.deep_serialized_value.value)
-                    elif hasattr(remote_obj, "value") and remote_obj.value is not None:
-                        result = remote_obj.value
-                except Exception as exc:
-                    LOG.debug("Metrics RemoteObject extraction failed: %s", exc)
-                    return None
-
-            if isinstance(result, dict):
-                w = result.get("availWidth")
-                h = result.get("availHeight")
-                if isinstance(w, (int, float)) and isinstance(h, (int, float)) and w > 0 and h > 0:
-                    LOG.debug("Screen metrics probed: %dx%d", int(w), int(h))
-                    self._screen_metrics_cache = (int(w), int(h))
-                    return self._screen_metrics_cache
-            LOG.debug("Unexpected probe result: %r", result)
-            return None
-        except TimeoutError:
-            LOG.debug("Screen metrics probe timed out", exc_info = True)
-            return None
+            host = (urlparse(url).hostname or "").lower()
         except Exception:
-            LOG.debug("Screen metrics probe failed", exc_info = True)
-            return None
-        finally:
-            if browser is not None:
-                try:
-                    browser_pid = getattr(browser, "_process_pid", None)
-                    stop_result = cast(Any, browser.stop)()
-                    if inspect.isawaitable(stop_result):
-                        await stop_result
-                    # Mirror close_browser_session() orphan child cleanup
-                    if isinstance(browser_pid, int) and browser_pid > 0:
-                        self._kill_orphaned_browser_children(browser_pid)
-                except Exception as exc:
-                    LOG.debug("Probe browser stop ignored: %s", exc)
-            if tmp_dir is not None:
-                try:
-                    shutil.rmtree(tmp_dir, ignore_errors = True)
-                except Exception as exc:
-                    LOG.debug("Probe temp directory cleanup ignored: %s", exc)
+            return False
+        return host.endswith("kleinanzeigen.de")
 
-    async def _select_viewport_size(self) -> str | None:
-        """Screen-aware viewport selection.
-
-        Returns a ``WxH`` string or ``None`` (meaning *omit --window-size*).
-
-        Decision logic, in order:
-        1. Skip headless or no-display environments.
-        2. Probe the real screen via an isolated browser.
-        3. If metrics are obtained, pick randomly among configured sizes that fit,
-           then apply bounded jitter (±24px width, ±16px height) capped by the
-           available screen.
-        4. If nothing fits, return ``None`` — let the browser/window-manager choose.
-        5. If the probe fails or reports invalid metrics, return ``None``.
-        """
+    def _viewport_resize_skip_reason(self, url:str | None) -> str | None:
         humanization = self._get_humanization_config()
-        sizes = humanization.viewport_sizes
-        if not sizes:
-            return None
+        skip_checks:tuple[tuple[bool, str], ...] = (
+            (not self._is_kleinanzeigen_page(url), "non-kleinanzeigen-url"),
+            (self._browser_session_is_remote, "remote-browser"),
+            (any(arg.startswith("--window-size") for arg in self.browser_config.arguments), "user-window-size"),
+            (not humanization.enabled, "humanization-disabled"),
+            (not humanization.randomize_viewport, "randomize-viewport-disabled"),
+            (not humanization.viewport_sizes, "no-viewport-sizes"),
+            (any(_is_headless_browser_arg(arg) for arg in self.browser_config.arguments), "headless"),
+            (not _has_display_available(), "no-display"),
+        )
+        for should_skip, reason in skip_checks:
+            if should_skip:
+                return reason
+        return None
 
-        if any(_is_headless_browser_arg(arg) for arg in self.browser_config.arguments):
-            LOG.debug("Skipping randomized viewport sizing for headless browser args")
-            return None
-
-        if not _has_display_available():
-            LOG.debug("Skipping randomized viewport sizing because no real display is available")
-            return None
-
-        metrics = await self._probe_screen_metrics()
+    def _select_viewport_size_for_metrics(self, metrics:Any) -> str | None:
+        """Select a configured viewport size from already available screen metrics."""
         normalized_metrics = _normalize_viewport_metrics(metrics)
         if normalized_metrics is None:
-            LOG.debug("Screen metrics unavailable or invalid; omitting --window-size")
+            LOG.debug("Screen metrics unavailable or invalid; omitting viewport resize")
             return None
 
         avail_w, avail_h = normalized_metrics
-        fitting = _filter_viewport_sizes(sizes, avail_w, avail_h)
-        if fitting:
-            chosen = _rng.choice(fitting)
-            parts = chosen.lower().split("x")
-            base_w = int(parts[0].strip())
-            base_h = int(parts[1].strip())
-            jw, jh = _jitter_viewport(base_w, base_h, avail_w, avail_h)
-            LOG.info(
-                "Screen-aware viewport: %s jittered to %dx%d (avail %dx%d)",
-                chosen, jw, jh, avail_w, avail_h,
+        fitting = _filter_viewport_sizes(self._get_humanization_config().viewport_sizes, avail_w, avail_h)
+        if not fitting:
+            LOG.debug("No configured viewport fits %dx%d screen; omitting viewport resize", avail_w, avail_h)
+            return None
+
+        chosen = _rng.choice(fitting)
+        parsed = _parse_viewport_size(chosen)
+        if parsed is None:
+            LOG.debug("Selected viewport size became invalid during parsing: %s", chosen)
+            return None
+
+        base_w, base_h = parsed
+        jw, jh = _jitter_viewport(base_w, base_h, avail_w, avail_h)
+        selected = f"{jw}x{jh}"
+        LOG.info("Screen-aware viewport: %s jittered to %s (avail %dx%d)", chosen, selected, avail_w, avail_h)
+        return selected
+
+    async def _collect_current_viewport_metrics(self) -> dict[str, Any] | None:
+        if not self.page:
+            return None
+        metrics = await self.web_execute(
+            "({"
+            "availWidth: window.screen.availWidth, "
+            "availHeight: window.screen.availHeight, "
+            "outerWidth: window.outerWidth, "
+            "outerHeight: window.outerHeight, "
+            "innerWidth: window.innerWidth, "
+            "innerHeight: window.innerHeight, "
+            "devicePixelRatio: window.devicePixelRatio, "
+            "url: location.href, "
+            "title: document.title"
+            "})"
+        )
+        if not isinstance(metrics, dict):
+            return None
+        return metrics
+
+    async def _apply_viewport_size(self, selected_viewport_size:str) -> str | None:
+        """Apply viewport dimensions via CDP window bounds, preserving position.
+
+        Returns ``None`` on success or a human-readable error message on failure.
+        """
+        if not self.page:
+            return "page unavailable"
+
+        parsed = _parse_viewport_size(selected_viewport_size)
+        if parsed is None:
+            return f"invalid viewport size: {selected_viewport_size!r}"
+
+        width, height = parsed
+        try:
+            window_id, bounds = await self.page.get_window()
+            left = getattr(bounds, "left", None)
+            top = getattr(bounds, "top", None)
+            new_bounds = cdp_browser.Bounds(
+                left = left if isinstance(left, int) else 0,
+                top = top if isinstance(top, int) else 0,
+                width = width,
+                height = height,
+                window_state = cdp_browser.WindowState.NORMAL,
             )
-            return f"{jw}x{jh}"
-        LOG.debug("No configured viewport fits %dx%d screen; omitting --window-size", avail_w, avail_h)
-        return None
+            await self.page.send(cdp_browser.set_window_bounds(window_id, bounds = new_bounds))
+            LOG.info("Applied randomized browser window size: %dx%d", width, height)
+            return None
+        except Exception as exc:  # noqa: BLE001
+            LOG.debug("Viewport resize failed via CDP: %s", exc)
+            return str(exc)
+
+    async def _resize_viewport_after_open(self) -> None:
+        if not self.page or self._viewport_resize_attempted:
+            return
+
+        url = getattr(self.page, "url", None)
+        if not self._is_kleinanzeigen_page(url):
+            return
+
+        skip_reason = self._viewport_resize_skip_reason(url)
+        if skip_reason is not None:
+            LOG.debug("Viewport resize skipped: %s", skip_reason)
+            self._set_viewport_resize_status(_VIEWPORT_RESIZE_STATUS_SKIPPED, attempted = True, reason = skip_reason)
+            return
+
+        before_metrics = await self._collect_current_viewport_metrics()
+        if before_metrics is None:
+            self._set_viewport_resize_status(
+                _VIEWPORT_RESIZE_STATUS_UNAVAILABLE_PAGE,
+                attempted = True,
+                reason = "metrics-unavailable",
+            )
+            return
+
+        normalized_metrics = _normalize_viewport_metrics((before_metrics.get("availWidth"), before_metrics.get("availHeight")))
+        if normalized_metrics is None:
+            self._set_viewport_resize_status(
+                _VIEWPORT_RESIZE_STATUS_INVALID_METRICS,
+                attempted = True,
+                reason = "invalid-screen-metrics",
+            )
+            return
+
+        selected_viewport_size = self._select_viewport_size_for_metrics(normalized_metrics)
+        if selected_viewport_size is None:
+            self._set_viewport_resize_status(
+                _VIEWPORT_RESIZE_STATUS_NO_FIT,
+                attempted = True,
+                reason = "no-configured-size-fits",
+            )
+            return
+
+        error = await self._apply_viewport_size(selected_viewport_size)
+        if error is None:
+            self._set_viewport_resize_status(
+                _VIEWPORT_RESIZE_STATUS_APPLIED,
+                attempted = True,
+                applied = True,
+                selected_viewport = selected_viewport_size,
+            )
+            return
+
+        self._set_viewport_resize_status(
+            _VIEWPORT_RESIZE_STATUS_FAILED,
+            attempted = True,
+            reason = "cdp-window-bounds-failed",
+            selected_viewport = selected_viewport_size,
+            error = error,
+        )
 
     def _build_new_browser_launch_args(self, selected_viewport_size:str | None = None) -> tuple[list[str], str | None]:
         """Build browser launch arguments and extract user_data_dir from custom args.
@@ -828,7 +897,7 @@ class WebScrapingMixin:  # noqa: PLR0904
             browser_args.append(browser_arg)
 
         if selected_viewport_size:
-            # Selected by _select_viewport_size() — already screen-filtered.
+            # Selected by the screen-aware viewport logic — already screen-filtered.
             width, height = selected_viewport_size.lower().split("x")
             window_size = f"--window-size={width.strip()},{height.strip()}"
             LOG.info(" -> Randomized browser window size: %s", window_size)
@@ -1509,6 +1578,8 @@ class WebScrapingMixin:  # noqa: PLR0904
             timeout_error_message = f"Page did not finish loading within {page_timeout} seconds.",
             apply_multiplier = False,
         )
+
+        await self._resize_viewport_after_open()
         await self.perform_random_human_actions()
 
     async def web_text(self, selector_type:By, selector_value:str, *, parent:Element | None = None, timeout:int | float | None = None) -> str:

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -59,7 +59,6 @@ _VIEWPORT_JITTER_H:Final[int] = 16
 _VIEWPORT_RESIZE_STATUS_NOT_ATTEMPTED:Final[str] = "not-attempted"
 _VIEWPORT_RESIZE_STATUS_APPLIED:Final[str] = "applied"
 _VIEWPORT_RESIZE_STATUS_SKIPPED:Final[str] = "skipped"
-_VIEWPORT_RESIZE_STATUS_UNAVAILABLE:Final[str] = "unavailable"
 _VIEWPORT_RESIZE_STATUS_INVALID_METRICS:Final[str] = "invalid-metrics"
 _VIEWPORT_RESIZE_STATUS_NO_FIT:Final[str] = "no-fitting-size"
 _VIEWPORT_RESIZE_STATUS_FAILED:Final[str] = "failed"
@@ -799,7 +798,18 @@ class WebScrapingMixin:  # noqa: PLR0904
             self._set_viewport_resize_status(_VIEWPORT_RESIZE_STATUS_SKIPPED, attempted = True, reason = skip_reason)
             return
 
-        before_metrics = await self._collect_current_viewport_metrics()
+        try:
+            before_metrics = await self._collect_current_viewport_metrics()
+        except Exception as exc:  # noqa: BLE001
+            LOG.debug("Screen metrics unavailable or invalid; omitting viewport resize: %s", exc)
+            self._set_viewport_resize_status(
+                _VIEWPORT_RESIZE_STATUS_UNAVAILABLE_PAGE,
+                attempted = True,
+                reason = "metrics-unavailable",
+                error = str(exc),
+            )
+            return
+
         if before_metrics is None:
             self._set_viewport_resize_status(
                 _VIEWPORT_RESIZE_STATUS_UNAVAILABLE_PAGE,

--- a/tests/integration/test_viewport_sizing.py
+++ b/tests/integration/test_viewport_sizing.py
@@ -18,6 +18,7 @@ import os
 import platform
 import shutil
 import tempfile
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -61,185 +62,77 @@ def _display_available() -> bool:
     return True
 
 
-async def _probe_or_skip_metrics(mixin:WebScrapingMixin) -> tuple[int, int]:
-    metrics = await mixin._probe_screen_metrics()
-    if metrics is None:
+async def _collect_or_skip_metrics(mixin:WebScrapingMixin) -> tuple[int, int]:
+    metrics = await mixin._collect_current_viewport_metrics()
+    if not isinstance(metrics, dict):
         pytest.skip("Screen metrics unavailable")
-    return metrics
-
-
-def _viewport_fits(size:str, avail_w:int, avail_h:int) -> bool:
-    """Return True if the WxH string fits within the given available area."""
-    try:
-        parts = size.lower().split("x")
-        w = int(parts[0].strip())
-        h = int(parts[1].strip())
-        return w <= avail_w and h <= avail_h
-    except (ValueError, IndexError):
-        return False
+    avail_w = metrics.get("availWidth")
+    avail_h = metrics.get("availHeight")
+    if not isinstance(avail_w, (int, float)) or not isinstance(avail_h, (int, float)) or avail_w <= 0 or avail_h <= 0:
+        pytest.skip(f"Screen metrics unavailable: {metrics!r}")
+    return int(avail_w), int(avail_h)
 
 
 # ---------------------------------------------------------------------------
-# helper: probe screen metrics in an isolated browser
+# post-open viewport resize
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not _has_browser(), reason = "No compatible browser binary detected")
 @pytest.mark.skipif(not _display_available(), reason = "No real display/window manager available")
-async def test_probe_screen_metrics_returns_positive_dimensions() -> None:
-    """The probe browser must report positive CSS-pixel availWidth/availHeight."""
+async def test_web_open_triggers_post_open_viewport_resize() -> None:
+    """A real browser is resized after page open, with no temporary probe browser."""
     mixin = _setup_mixin()
-    avail_w, avail_h = await _probe_or_skip_metrics(mixin)
-    assert isinstance(avail_w, int)
-    assert avail_w > 0, f"availWidth must be positive, got {avail_w!r}"
-    assert isinstance(avail_h, int)
-    assert avail_h > 0, f"availHeight must be positive, got {avail_h!r}"
-    # Sanity: modern displays are usually at least 720p
-    assert avail_h >= 720 or avail_w >= 1280, f"Screen seems too small: {avail_w}x{avail_h}"
 
-
-# ---------------------------------------------------------------------------
-# viewport selection: runtime filtering path
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-@pytest.mark.skipif(not _has_browser(), reason = "No compatible browser binary detected")
-@pytest.mark.skipif(not _display_available(), reason = "No real display/window manager available")
-async def test_viewport_selection_respects_screen_size() -> None:
-    """Configure one oversized and one fitting viewport; verify the oversized
-    candidate is excluded by the runtime filtering path.
-    """
-    mixin = _setup_mixin()
-    avail_w, avail_h = await _probe_or_skip_metrics(mixin)
-
-    # 2. Build a viewport list with exactly one oversized candidate (> screen)
-    #    and one that clearly fits (0.7 × screen).
-    oversized = f"{avail_w + 200}x{avail_h + 100}"
-    fitting = f"{int(avail_w * 0.7)}x{int(avail_h * 0.7)}"
-    sizes = [oversized, fitting]
-
-    # 3. Verify the static filter matches expectations.
-    fitting_result = [s for s in sizes if _viewport_fits(s, avail_w, avail_h)]
-    assert oversized not in fitting_result, f"{oversized} should be filtered out for {avail_w}x{avail_h} screen"
-    assert fitting in fitting_result, f"{fitting} should fit {avail_w}x{avail_h} screen"
-
-    # 4. Configure the mixin with these sizes and run the selection logic.
-    mixin.config = _make_bare_config(HumanizationConfig(randomize_viewport = True, viewport_sizes = sizes))
-
-    with patch.object(mixin, "_probe_screen_metrics", return_value = (avail_w, avail_h)):
-        selected = await mixin._select_viewport_size()
-    assert selected is not None, "At least the fitting size should be selected"
-    # The selected viewport must fit within available screen when parsed.
-    # (Jitter is bounded by avail so this always holds.)
-    parts = selected.lower().split("x")
-    sel_w, sel_h = int(parts[0].strip()), int(parts[1].strip())
-    assert sel_w <= avail_w, f"Selected width {sel_w} exceeds available {avail_w}"
-    assert sel_h <= avail_h, f"Selected height {sel_h} exceeds available {avail_h}"
-
-
-@pytest.mark.asyncio
-@pytest.mark.skipif(not _has_browser(), reason = "No compatible browser binary detected")
-@pytest.mark.skipif(not _display_available(), reason = "No real display/window manager available")
-async def test_viewport_selection_returns_none_when_all_oversized() -> None:
-    """When *all* configured viewports exceed the available screen, selection
-    must return ``None`` (meaning omit ``--window-size``).
-    """
-    mixin = _setup_mixin()
-    avail_w, avail_h = await _probe_or_skip_metrics(mixin)
-
-    # All sizes are way oversized.
-    sizes = [f"{avail_w + 500}x{avail_h + 500}", f"{avail_w + 1000}x{avail_h + 1000}"]
-
-    # Static filter must return empty.
-    assert not any(_viewport_fits(s, avail_w, avail_h) for s in sizes)
-
-    mixin.config = _make_bare_config(HumanizationConfig(randomize_viewport = True, viewport_sizes = sizes))
-    with patch.object(mixin, "_probe_screen_metrics", return_value = (avail_w, avail_h)):
-        selected = await mixin._select_viewport_size()
-    assert selected is None, f"Expected None (no sizes fit {avail_w}x{avail_h}), got {selected!r}"
-
-
-# ---------------------------------------------------------------------------
-# full launch path: create_browser_session with screen-aware viewport
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-@pytest.mark.skipif(not _has_browser(), reason = "No compatible browser binary detected")
-@pytest.mark.skipif(not _display_available(), reason = "No real display/window manager available")
-async def test_create_browser_session_selects_fitting_viewport() -> None:
-    """Start a browser via create_browser_session() with one oversized and one
-    fitting viewport candidate, and verify the final window fits within the
-    available screen area.  This exercises the complete launch path: probing,
-    filtering, jitter, and ``--window-size`` injection.
-    """
-    mixin = _setup_mixin()
-    avail_w, avail_h = await _probe_or_skip_metrics(mixin)
-
-    # 2. Build viewport list: one oversized (exceeds screen), one clearly fitting.
-    oversized = f"{avail_w + 200}x{avail_h + 100}"
-    fitting = f"{int(avail_w * 0.7)}x{int(avail_h * 0.7)}"
-
-    # 3. Assign a temporary user-data-dir and configure humanization.
     ud_dir = tempfile.mkdtemp(prefix = "kbb-vptest-")
     mixin.browser_config.user_data_dir = ud_dir
     mixin.config = _make_bare_config(HumanizationConfig(
         randomize_viewport = True,
-        viewport_sizes = [oversized, fitting],
+        viewport_sizes = ["32000x32000", "900x700"],
     ))
 
     try:
-        # 4. Start the browser through the full session-creation path, reusing
-        #    the already-probed metrics so a second flaky probe cannot fail CI.
-        with patch.object(mixin, "_probe_screen_metrics", return_value = (avail_w, avail_h)):
+        try:
             await mixin.create_browser_session()
+        except Exception as exc:  # noqa: BLE001
+            pytest.skip(f"Browser failed to start in this environment: {exc}")
+        with patch.object(mixin, "_is_kleinanzeigen_page", return_value = True):
+            await mixin.web_open(_HTML_BLANK)
 
-        # 5. Navigate to about:blank and read the actual inner window size.
-        #    Uses web_execute() which normalizes nodriver RemoteObject values.
-        await mixin.web_open(_HTML_BLANK)
-        dims = await mixin.web_execute(
-            "({w: window.innerWidth, h: window.innerHeight})"
-        )
-        assert isinstance(dims, dict), f"Unexpected dimensions result: {dims!r}"
-        w = dims.get("w", 0)
-        h = dims.get("h", 0)
-        assert isinstance(w, (int, float)), f"Inner width has unexpected type: {type(w).__name__}"
-        assert w > 0, f"Inner width must be positive, got {w}"
-        assert isinstance(h, (int, float)), f"Inner height has unexpected type: {type(h).__name__}"
-        assert h > 0, f"Inner height must be positive, got {h}"
-
-        # 6. The window must never exceed the available screen area.
-        assert w <= avail_w, f"Window width {w} exceeds available {avail_w}"
-        assert h <= avail_h, f"Window height {h} exceeds available {avail_h}"
+        status = mixin.get_viewport_resize_status()
+        assert status["status"] in {"applied", "no-fitting-size"}
+        assert status["attempted"] is True
+        if status["status"] == "applied":
+            assert status["applied"] is True
+            assert status["selected_viewport"]
+            avail_w, avail_h = await _collect_or_skip_metrics(mixin)
+            assert avail_w > 0
+            assert avail_h > 0
     finally:
         mixin.close_browser_session()
         shutil.rmtree(ud_dir, ignore_errors = True)
 
 
-# ---------------------------------------------------------------------------
-# fallback behaviour: probe failure picks smallest
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
-async def test_select_viewport_size_fallback_to_smallest_on_probe_failure() -> None:
-    """When _probe_screen_metrics fails, _select_viewport_size must return None."""
+async def test_select_viewport_size_for_metrics_returns_none_when_all_oversized() -> None:
+    """When all configured viewports exceed screen metrics, no fallback size is selected."""
     mixin = WebScrapingMixin()
-    sizes = ["2560x1440", "1920x1080", "1366x768"]
-    mixin.config = _make_bare_config(HumanizationConfig(randomize_viewport = True, viewport_sizes = sizes))
+    mixin.config = _make_bare_config(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["5000x5000", "6000x6000"]))
 
-    with patch.object(mixin, "_probe_screen_metrics", return_value = None):
-        selected = await mixin._select_viewport_size()
+    selected = mixin._select_viewport_size_for_metrics((1920, 1080))
 
     assert selected is None
 
 
 @pytest.mark.asyncio
-async def test_select_viewport_size_returns_none_for_empty_sizes() -> None:
-    """When viewport_sizes is empty, _select_viewport_size must return None."""
+async def test_resize_status_remains_not_attempted_for_non_matching_url() -> None:
+    """The post-open hook ignores non-kleinanzeigen pages without marking an attempt."""
     mixin = WebScrapingMixin()
-    mixin.config = _make_bare_config(HumanizationConfig(randomize_viewport = True, viewport_sizes = []))
-    selected = await mixin._select_viewport_size()
-    assert selected is None
+    mixin.config = _make_bare_config(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["900x700"]))
+    mixin.page = cast(Any, type("Page", (), {"url": "about:blank"})())
+
+    await mixin._resize_viewport_after_open()
+
+    assert mixin.get_viewport_resize_status()["status"] == "not-attempted"
+    assert mixin.get_viewport_resize_status()["attempted"] is False

--- a/tests/integration/test_viewport_sizing.py
+++ b/tests/integration/test_viewport_sizing.py
@@ -62,7 +62,7 @@ def _display_available() -> bool:
     return True
 
 
-async def _collect_or_skip_metrics(mixin:WebScrapingMixin) -> tuple[int, int]:
+async def _collect_or_skip_metrics(mixin:WebScrapingMixin) -> dict[str, object]:
     metrics = await mixin._collect_current_viewport_metrics()
     if not isinstance(metrics, dict):
         pytest.skip("Screen metrics unavailable")
@@ -70,7 +70,7 @@ async def _collect_or_skip_metrics(mixin:WebScrapingMixin) -> tuple[int, int]:
     avail_h = metrics.get("availHeight")
     if not isinstance(avail_w, (int, float)) or not isinstance(avail_h, (int, float)) or avail_w <= 0 or avail_h <= 0:
         pytest.skip(f"Screen metrics unavailable: {metrics!r}")
-    return int(avail_w), int(avail_h)
+    return metrics
 
 
 # ---------------------------------------------------------------------------
@@ -106,23 +106,15 @@ async def test_web_open_triggers_post_open_viewport_resize() -> None:
         if status["status"] == "applied":
             assert status["applied"] is True
             assert status["selected_viewport"]
-            avail_w, avail_h = await _collect_or_skip_metrics(mixin)
-            assert avail_w > 0
-            assert avail_h > 0
+            metrics = await _collect_or_skip_metrics(mixin)
+            outer_w = metrics.get("outerWidth")
+            outer_h = metrics.get("outerHeight")
+            assert isinstance(outer_w, (int, float))
+            assert isinstance(outer_h, (int, float))
+            assert f"{int(outer_w)}x{int(outer_h)}" == status["selected_viewport"]
     finally:
         mixin.close_browser_session()
         shutil.rmtree(ud_dir, ignore_errors = True)
-
-
-@pytest.mark.asyncio
-async def test_select_viewport_size_for_metrics_returns_none_when_all_oversized() -> None:
-    """When all configured viewports exceed screen metrics, no fallback size is selected."""
-    mixin = WebScrapingMixin()
-    mixin.config = _make_bare_config(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["5000x5000", "6000x6000"]))
-
-    selected = mixin._select_viewport_size_for_metrics((1920, 1080))
-
-    assert selected is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_humanization.py
+++ b/tests/unit/test_humanization.py
@@ -4,8 +4,8 @@
 """Tests for the human-like interaction behavior in WebScrapingMixin (bot-detection evasion)."""
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -17,6 +17,7 @@ from kleinanzeigen_bot.utils.web_scraping_mixin import (
     WebScrapingMixin,
     _filter_viewport_sizes,  # noqa: PLC2701 # type: ignore[attr-defined]
     _jitter_viewport,  # noqa: PLC2701 # type: ignore[attr-defined]
+    _parse_viewport_size,  # noqa: PLC2701 # type: ignore[attr-defined]
 )
 
 
@@ -400,6 +401,19 @@ def test_filter_viewport_sizes_empty_list() -> None:
     assert _filter_viewport_sizes([], 1920, 1080) == []
 
 
+def test_parse_viewport_size() -> None:
+    assert _parse_viewport_size("1920x1080") == (1920, 1080)
+    assert _parse_viewport_size(" 1366x 768 ") == (1366, 768)
+    assert _parse_viewport_size("1366X768") == (1366, 768)
+
+
+def test_parse_viewport_size_rejects_invalid_values() -> None:
+    assert _parse_viewport_size("invalid") is None
+    assert _parse_viewport_size("1920x") is None
+    assert _parse_viewport_size("1920xabc") is None
+    assert _parse_viewport_size("0x720") is None
+
+
 # ---------------------------------------------------------------------------
 # _jitter_viewport
 # ---------------------------------------------------------------------------
@@ -438,12 +452,12 @@ def test_jitter_viewport_floor_at_one() -> None:
 
 
 # ---------------------------------------------------------------------------
-# integration-level: _select_viewport_size with jitter
+# post-open viewport resize
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_select_viewport_size_applies_jitter_when_metrics_known() -> None:
+async def test_select_viewport_size_for_metrics_applies_jitter() -> None:
     """When metrics are available, a fitting base is jittered before returning."""
     scraper = WebScrapingMixin()
     scraper.config = Config.model_validate({
@@ -451,78 +465,11 @@ async def test_select_viewport_size_applies_jitter_when_metrics_known() -> None:
         "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1600x900", "1920x1080"]).model_dump(),
     })
     with (
-        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
-        patch.object(scraper, "_probe_screen_metrics", return_value = (1920, 1080)),
         patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.choice", return_value = "1600x900"),
         patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.randint", side_effect = [1590, 890]),
     ):
-        result = await scraper._select_viewport_size()
-    # Jitter applied: base 1600x900 → ~1590x890
+        result = scraper._select_viewport_size_for_metrics((1920, 1080))
     assert result == "1590x890"
-
-
-@pytest.mark.asyncio
-async def test_select_viewport_size_skips_headless_without_probe() -> None:
-    scraper = WebScrapingMixin()
-    scraper.browser_config.arguments = ["--headless=new"]
-    scraper.config = Config.model_validate({
-        "login": {"username": "u", "password": "p"},  # noqa: S106
-        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1600x900"]).model_dump(),
-    })
-    with patch.object(scraper, "_probe_screen_metrics", new_callable = AsyncMock) as probe:
-        result = await scraper._select_viewport_size()
-    probe.assert_not_awaited()
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_select_viewport_size_skips_no_display_on_linux_without_probe() -> None:
-    scraper = WebScrapingMixin()
-    scraper.config = Config.model_validate({
-        "login": {"username": "u", "password": "p"},  # noqa: S106
-        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1600x900"]).model_dump(),
-    })
-    with (
-        patch("kleinanzeigen_bot.utils.web_scraping_mixin.platform.system", return_value = "Linux"),
-        patch.dict("kleinanzeigen_bot.utils.web_scraping_mixin.os.environ", {}, clear = True),
-        patch.object(scraper, "_probe_screen_metrics", new_callable = AsyncMock) as probe,
-    ):
-        result = await scraper._select_viewport_size()
-    probe.assert_not_awaited()
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_select_viewport_size_skips_ci_without_display_without_probe() -> None:
-    scraper = WebScrapingMixin()
-    scraper.config = Config.model_validate({
-        "login": {"username": "u", "password": "p"},  # noqa: S106
-        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1600x900"]).model_dump(),
-    })
-    with (
-        patch("kleinanzeigen_bot.utils.web_scraping_mixin.platform.system", return_value = "Darwin"),
-        patch.dict("kleinanzeigen_bot.utils.web_scraping_mixin.os.environ", {"CI": "true"}, clear = True),
-        patch.object(scraper, "_probe_screen_metrics", new_callable = AsyncMock) as probe,
-    ):
-        result = await scraper._select_viewport_size()
-    probe.assert_not_awaited()
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_select_viewport_size_omits_when_none_fit() -> None:
-    """When all sizes exceed avail, returns None regardless of jitter."""
-    scraper = WebScrapingMixin()
-    scraper.config = Config.model_validate({
-        "login": {"username": "u", "password": "p"},  # noqa: S106
-        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["2560x1440"]).model_dump(),
-    })
-    with (
-        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
-        patch.object(scraper, "_probe_screen_metrics", return_value = (1920, 1080)),
-    ):
-        result = await scraper._select_viewport_size()
-    assert result is None
 
 
 @pytest.mark.asyncio
@@ -544,80 +491,202 @@ async def test_select_viewport_size_omits_when_none_fit() -> None:
         (float("inf"), 1080),
     ],
 )
-async def test_select_viewport_size_returns_none_for_invalid_metrics(metrics:object) -> None:
+async def test_select_viewport_size_for_metrics_returns_none_for_invalid_metrics(metrics:object) -> None:
     scraper = WebScrapingMixin()
     scraper.config = Config.model_validate({
         "login": {"username": "u", "password": "p"},  # noqa: S106
         "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["2560x1440", "1366x768"]).model_dump(),
     })
-    with (
-        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
-        patch.object(scraper, "_probe_screen_metrics", return_value = metrics),
-    ):
-        result = await scraper._select_viewport_size()
+    with patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.choice", autospec = True) as choice_mock:
+        result = scraper._select_viewport_size_for_metrics(metrics)
     assert result is None
+    choice_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_select_viewport_size_user_window_size_bypasses_selection() -> None:
-    """User-supplied --window-size in browser_config.arguments prevents _select_viewport_size
-    from being called at all (tested via the guard in create_browser_session)."""
+async def test_select_viewport_size_for_metrics_returns_none_when_none_fit() -> None:
     scraper = WebScrapingMixin()
-    scraper.browser_config.binary_location = "fake-browser"
-    scraper.browser_config.arguments = ["--window-size=800,600"]
     scraper.config = Config.model_validate({
         "login": {"username": "u", "password": "p"},  # noqa: S106
-        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1920x1080"]).model_dump(),
+        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["2560x1440"]).model_dump(),
     })
-    fake_browser = SimpleNamespace(websocket_url = "ws://test")
+    assert scraper._select_viewport_size_for_metrics((1920, 1080)) is None
+
+
+@pytest.mark.asyncio
+async def test_create_browser_session_no_prelaunch_viewport_probe() -> None:
+    scraper = WebScrapingMixin()
+    scraper.browser_config.binary_location = "fake-browser"
+    scraper.browser_config.arguments = ["--timeout=1"]
+    scraper.config = Config.model_validate({
+        "login": {"username": "u", "password": "p"},  # noqa: S106
+        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]).model_dump(),
+    })
+
+    main_browser = SimpleNamespace(websocket_url = "ws://test")
+
     with (
         patch.object(scraper, "_validate_chrome_version_configuration", new_callable = AsyncMock),
-        patch.object(scraper, "_select_viewport_size", new_callable = AsyncMock) as select_viewport,
         patch.object(scraper, "_resolve_effective_user_data_dir", new_callable = AsyncMock, return_value = None),
         patch.object(scraper, "_add_browser_extensions", new_callable = AsyncMock),
         patch("kleinanzeigen_bot.utils.web_scraping_mixin.files.exists", new_callable = AsyncMock, return_value = True),
-        patch("kleinanzeigen_bot.utils.web_scraping_mixin.nodriver.start", new_callable = AsyncMock, return_value = fake_browser),
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin.nodriver.start", new_callable = AsyncMock, return_value = main_browser) as start,
     ):
         await scraper.create_browser_session()
-    select_viewport.assert_not_awaited()
+
+    assert start.await_count == 1
+    cfg_arg = start.call_args_list[0].args[0]
+    assert "--timeout=1" in cfg_arg.browser_args
+    assert not any(arg.startswith("--window-size") for arg in cfg_arg.browser_args)
 
 
 @pytest.mark.asyncio
-async def test_probe_screen_metrics_times_out() -> None:
-    scraper = WebScrapingMixin()
-    scraper.browser_config.binary_location = "fake-browser"
-    scraper.config = Config.model_validate({
-        "login": {"username": "u", "password": "p"},  # noqa: S106
-        "timeouts": {"chrome_remote_probe": 0.1},
-    })
-
-    async def slow_start(_cfg:object) -> object:
-        await asyncio.sleep(1)
-        return SimpleNamespace()
-
-    with patch("kleinanzeigen_bot.utils.web_scraping_mixin.nodriver.start", side_effect = slow_start):
-        result = await scraper._probe_screen_metrics()
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_probe_screen_metrics_reuses_successful_probe() -> None:
-    scraper = WebScrapingMixin()
-    scraper.browser_config.binary_location = "fake-browser"
-    page = SimpleNamespace(evaluate = AsyncMock(return_value = {"availWidth": 111, "availHeight": 222}))
-    browser = SimpleNamespace(get = AsyncMock(return_value = page), stop = lambda: None)
+async def test_resize_viewport_after_open_skips_user_window_size() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]))
+    scraper.browser_config.arguments = ["--window-size=800,600"]
+    scraper.page = cast(Any, SimpleNamespace(url = "https://www.kleinanzeigen.de/"))
 
     with (
-        patch("kleinanzeigen_bot.utils.web_scraping_mixin.asyncio.sleep", new_callable = AsyncMock),
-        patch("kleinanzeigen_bot.utils.web_scraping_mixin.nodriver.start", new_callable = AsyncMock, return_value = browser) as start,
+        patch.object(scraper, "_collect_current_viewport_metrics", new_callable = AsyncMock) as collect_metrics,
+        patch.object(scraper, "_apply_viewport_size", new_callable = AsyncMock) as apply_size,
     ):
-        first = await scraper._probe_screen_metrics()
-        second = await scraper._probe_screen_metrics()
+        await scraper._resize_viewport_after_open()
 
-    assert first == (111, 222)
-    assert second == (111, 222)
-    start.assert_awaited_once()
+    collect_metrics.assert_not_awaited()
+    apply_size.assert_not_awaited()
+    assert scraper.get_viewport_resize_status()["status"] == "skipped"
+    assert scraper.get_viewport_resize_status()["reason"] == "user-window-size"
+
+
+@pytest.mark.asyncio
+async def test_resize_viewport_after_open_ignores_non_kleinanzeigen_page() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]))
+    scraper.page = cast(Any, SimpleNamespace(url = "about:blank"))
+
+    await scraper._resize_viewport_after_open()
+
+    assert scraper.get_viewport_resize_status()["status"] == "not-attempted"
+    assert scraper.get_viewport_resize_status()["attempted"] is False
+
+
+@pytest.mark.asyncio
+async def test_resize_viewport_after_open_applies_once_with_status() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]))
+    scraper.page = cast(Any, SimpleNamespace(url = "https://www.kleinanzeigen.de/"))
+    before_metrics = {
+        "availWidth": 1920,
+        "availHeight": 1080,
+        "outerWidth": 1200,
+        "outerHeight": 900,
+        "innerWidth": 1180,
+        "innerHeight": 820,
+        "devicePixelRatio": 2,
+    }
+    with (
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
+        patch.object(scraper, "_collect_current_viewport_metrics", new_callable = AsyncMock, return_value = before_metrics) as collect_metrics,
+        patch.object(scraper, "_apply_viewport_size", new_callable = AsyncMock, return_value = None) as apply_size,
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.choice", return_value = "1366x768"),
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.randint", side_effect = [1377, 777]),
+    ):
+        await scraper._resize_viewport_after_open()
+        await scraper._resize_viewport_after_open()
+
+    assert collect_metrics.await_count == 1
+    apply_size.assert_awaited_once_with("1377x777")
+    status = scraper.get_viewport_resize_status()
+    assert status["status"] == "applied"
+    assert status["attempted"] is True
+    assert status["applied"] is True
+    assert status["selected_viewport"] == "1377x777"
+
+
+@pytest.mark.asyncio
+async def test_resize_viewport_after_open_records_invalid_metrics() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]))
+    scraper.page = cast(Any, SimpleNamespace(url = "https://www.kleinanzeigen.de/"))
+    metrics = {"availWidth": True, "availHeight": 1080}
+
+    with (
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
+        patch.object(scraper, "_collect_current_viewport_metrics", new_callable = AsyncMock, return_value = metrics),
+    ):
+        await scraper._resize_viewport_after_open()
+
+    status = scraper.get_viewport_resize_status()
+    assert status["status"] == "invalid-metrics"
+    assert status["reason"] == "invalid-screen-metrics"
+
+
+@pytest.mark.asyncio
+async def test_apply_viewport_size_preserves_window_position() -> None:
+    scraper = make_scraper()
+    bounds = SimpleNamespace(left = 12, top = 34)
+    page = SimpleNamespace(
+        get_window = AsyncMock(return_value = (7, bounds)),
+        send = AsyncMock(),
+    )
+    scraper.page = cast(Any, page)
+
+    with patch("kleinanzeigen_bot.utils.web_scraping_mixin.cdp_browser.set_window_bounds", return_value = "set-bounds") as set_bounds:
+        error = await scraper._apply_viewport_size("1377x777")
+
+    assert error is None
+    page.get_window.assert_awaited_once()
+    page.send.assert_awaited_once_with("set-bounds")
+    assert set_bounds.call_args.args[0] == 7
+    new_bounds = set_bounds.call_args.kwargs["bounds"]
+    assert new_bounds.left == 12
+    assert new_bounds.top == 34
+    assert new_bounds.width == 1377
+    assert new_bounds.height == 777
+
+
+@pytest.mark.asyncio
+async def test_resize_viewport_after_open_records_cdp_failure() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]))
+    scraper.page = cast(Any, SimpleNamespace(url = "https://www.kleinanzeigen.de/"))
+    metrics = {"availWidth": 1920, "availHeight": 1080}
+
+    with (
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
+        patch.object(scraper, "_collect_current_viewport_metrics", new_callable = AsyncMock, return_value = metrics),
+        patch.object(scraper, "_apply_viewport_size", new_callable = AsyncMock, return_value = "broken"),
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.choice", return_value = "1366x768"),
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.randint", side_effect = [1366, 768]),
+    ):
+        await scraper._resize_viewport_after_open()
+
+    status = scraper.get_viewport_resize_status()
+    assert status["status"] == "failed"
+    assert status["reason"] == "cdp-window-bounds-failed"
+    assert status["error"] == "broken"
+
+
+@pytest.mark.asyncio
+async def test_web_open_triggers_resize_before_random_actions() -> None:
+    scraper = make_scraper()
+    page = SimpleNamespace(url = "https://www.kleinanzeigen.de/")
+    scraper.browser = cast(Any, SimpleNamespace(get = AsyncMock(return_value = page)))
+
+    calls:list[str] = []
+
+    async def resize() -> None:
+        calls.append("resize")
+
+    async def random_actions() -> None:
+        calls.append("random-actions")
+
+    with (
+        patch.object(scraper, "web_await", new_callable = AsyncMock),
+        patch.object(scraper, "_resize_viewport_after_open", side_effect = resize) as resize_mock,
+        patch.object(scraper, "perform_random_human_actions", side_effect = random_actions) as random_actions_mock,
+    ):
+        await scraper.web_open("https://www.kleinanzeigen.de/")
+
+    resize_mock.assert_awaited_once()
+    random_actions_mock.assert_awaited_once()
+    assert calls == ["resize", "random-actions"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_humanization.py
+++ b/tests/unit/test_humanization.py
@@ -408,6 +408,7 @@ def test_parse_viewport_size() -> None:
 
 
 def test_parse_viewport_size_rejects_invalid_values() -> None:
+    assert _parse_viewport_size(cast(Any, None)) is None
     assert _parse_viewport_size("invalid") is None
     assert _parse_viewport_size("1920x") is None
     assert _parse_viewport_size("1920xabc") is None
@@ -502,6 +503,14 @@ async def test_select_viewport_size_for_metrics_returns_none_when_none_fit() -> 
 
 
 @pytest.mark.asyncio
+async def test_select_viewport_size_for_metrics_handles_invalid_chosen_size() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]))
+
+    with patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.choice", return_value = "invalid"):
+        assert scraper._select_viewport_size_for_metrics((1920, 1080)) is None
+
+
+@pytest.mark.asyncio
 async def test_create_browser_session_no_prelaunch_viewport_probe() -> None:
     scraper = WebScrapingMixin()
     scraper.browser_config.binary_location = "fake-browser"
@@ -526,6 +535,47 @@ async def test_create_browser_session_no_prelaunch_viewport_probe() -> None:
     cfg_arg = start.call_args_list[0].args[0]
     assert "--timeout=1" in cfg_arg.browser_args
     assert not any(arg.startswith("--window-size") for arg in cfg_arg.browser_args)
+
+
+@pytest.mark.asyncio
+async def test_create_browser_session_marks_remote_sessions() -> None:
+    scraper = WebScrapingMixin()
+    scraper.browser_config.binary_location = "fake-browser"
+    scraper.browser_config.arguments = ["--remote-debugging-port=9222"]
+    scraper.config = Config.model_validate({
+        "login": {"username": "u", "password": "p"},  # noqa: S106
+        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]).model_dump(),
+    })
+    remote_browser = SimpleNamespace(websocket_url = "ws://remote")
+
+    with (
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin.files.exists", new_callable = AsyncMock, return_value = True),
+        patch.object(scraper, "_validate_chrome_version_configuration", new_callable = AsyncMock),
+        patch.object(scraper, "_connect_to_remote_browser", new_callable = AsyncMock, return_value = remote_browser),
+    ):
+        await scraper.create_browser_session()
+
+    assert scraper.browser is remote_browser
+    assert scraper._browser_session_is_remote is True
+
+
+def test_is_kleinanzeigen_page_rejects_missing_and_unparseable_urls() -> None:
+    scraper = make_scraper()
+
+    assert scraper._is_kleinanzeigen_page(None) is False
+    with patch("kleinanzeigen_bot.utils.web_scraping_mixin.urlparse", side_effect = ValueError("bad url")):
+        assert scraper._is_kleinanzeigen_page("https://www.kleinanzeigen.de/") is False
+
+
+@pytest.mark.asyncio
+async def test_collect_current_viewport_metrics_handles_missing_page_and_non_dict() -> None:
+    scraper = make_scraper()
+
+    assert await scraper._collect_current_viewport_metrics() is None
+
+    scraper.page = cast(Any, SimpleNamespace(url = "https://www.kleinanzeigen.de/"))
+    with patch.object(scraper, "web_execute", new_callable = AsyncMock, return_value = "not-a-dict"):
+        assert await scraper._collect_current_viewport_metrics() is None
 
 
 @pytest.mark.asyncio
@@ -607,6 +657,56 @@ async def test_resize_viewport_after_open_records_invalid_metrics() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resize_viewport_after_open_records_unavailable_metrics() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]))
+    scraper.page = cast(Any, SimpleNamespace(url = "https://www.kleinanzeigen.de/"))
+
+    with (
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
+        patch.object(scraper, "_collect_current_viewport_metrics", new_callable = AsyncMock, return_value = None),
+    ):
+        await scraper._resize_viewport_after_open()
+
+    status = scraper.get_viewport_resize_status()
+    assert status["status"] == "unavailable-page"
+    assert status["reason"] == "metrics-unavailable"
+
+
+@pytest.mark.asyncio
+async def test_resize_viewport_after_open_records_metrics_collection_error() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1366x768"]))
+    scraper.page = cast(Any, SimpleNamespace(url = "https://www.kleinanzeigen.de/"))
+
+    with (
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
+        patch.object(scraper, "_collect_current_viewport_metrics", new_callable = AsyncMock, side_effect = RuntimeError("page gone")),
+    ):
+        await scraper._resize_viewport_after_open()
+
+    status = scraper.get_viewport_resize_status()
+    assert status["status"] == "unavailable-page"
+    assert status["reason"] == "metrics-unavailable"
+    assert status["error"] == "page gone"
+
+
+@pytest.mark.asyncio
+async def test_resize_viewport_after_open_records_no_fitting_size() -> None:
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["2560x1440"]))
+    scraper.page = cast(Any, SimpleNamespace(url = "https://www.kleinanzeigen.de/"))
+    metrics = {"availWidth": 1920, "availHeight": 1080}
+
+    with (
+        patch("kleinanzeigen_bot.utils.web_scraping_mixin._has_display_available", return_value = True),
+        patch.object(scraper, "_collect_current_viewport_metrics", new_callable = AsyncMock, return_value = metrics),
+    ):
+        await scraper._resize_viewport_after_open()
+
+    status = scraper.get_viewport_resize_status()
+    assert status["status"] == "no-fitting-size"
+    assert status["reason"] == "no-configured-size-fits"
+
+
+@pytest.mark.asyncio
 async def test_apply_viewport_size_preserves_window_position() -> None:
     scraper = make_scraper()
     bounds = SimpleNamespace(left = 12, top = 34)
@@ -628,6 +728,17 @@ async def test_apply_viewport_size_preserves_window_position() -> None:
     assert new_bounds.top == 34
     assert new_bounds.width == 1377
     assert new_bounds.height == 777
+
+
+@pytest.mark.asyncio
+async def test_apply_viewport_size_reports_invalid_inputs_and_cdp_errors() -> None:
+    scraper = make_scraper()
+
+    assert await scraper._apply_viewport_size("1377x777") == "page unavailable"
+
+    scraper.page = cast(Any, SimpleNamespace(get_window = AsyncMock(side_effect = RuntimeError("no window"))))
+    assert await scraper._apply_viewport_size("invalid") == "invalid viewport size: 'invalid'"
+    assert await scraper._apply_viewport_size("1377x777") == "no window"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_humanization.py
+++ b/tests/unit/test_humanization.py
@@ -459,11 +459,7 @@ def test_jitter_viewport_floor_at_one() -> None:
 @pytest.mark.asyncio
 async def test_select_viewport_size_for_metrics_applies_jitter() -> None:
     """When metrics are available, a fitting base is jittered before returning."""
-    scraper = WebScrapingMixin()
-    scraper.config = Config.model_validate({
-        "login": {"username": "u", "password": "p"},  # noqa: S106
-        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1600x900", "1920x1080"]).model_dump(),
-    })
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["1600x900", "1920x1080"]))
     with (
         patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.choice", return_value = "1600x900"),
         patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.randint", side_effect = [1590, 890]),
@@ -492,11 +488,7 @@ async def test_select_viewport_size_for_metrics_applies_jitter() -> None:
     ],
 )
 async def test_select_viewport_size_for_metrics_returns_none_for_invalid_metrics(metrics:object) -> None:
-    scraper = WebScrapingMixin()
-    scraper.config = Config.model_validate({
-        "login": {"username": "u", "password": "p"},  # noqa: S106
-        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["2560x1440", "1366x768"]).model_dump(),
-    })
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["2560x1440", "1366x768"]))
     with patch("kleinanzeigen_bot.utils.web_scraping_mixin._rng.choice", autospec = True) as choice_mock:
         result = scraper._select_viewport_size_for_metrics(metrics)
     assert result is None
@@ -505,11 +497,7 @@ async def test_select_viewport_size_for_metrics_returns_none_for_invalid_metrics
 
 @pytest.mark.asyncio
 async def test_select_viewport_size_for_metrics_returns_none_when_none_fit() -> None:
-    scraper = WebScrapingMixin()
-    scraper.config = Config.model_validate({
-        "login": {"username": "u", "password": "p"},  # noqa: S106
-        "humanization": HumanizationConfig(randomize_viewport = True, viewport_sizes = ["2560x1440"]).model_dump(),
-    })
+    scraper = make_scraper(HumanizationConfig(randomize_viewport = True, viewport_sizes = ["2560x1440"]))
     assert scraper._select_viewport_size_for_metrics((1920, 1080)) is None
 
 


### PR DESCRIPTION
## ℹ️ Description

- Related issue(s): none.
- Fixes the screen-aware viewport regression by removing the temporary pre-launch screen probe and resizing the already-open browser window after the first kleinanzeigen.de page load.

## 📋 Changes Summary

- Remove the isolated probe browser path that could time out or appear on a different screen.
- Open the main browser without bot-added `--window-size`, then resize once after the first eligible kleinanzeigen.de page opens.
- Preserve user-supplied `--window-size` and skip remote/headless/no-display or disabled randomization cases.
- Keep no-fallback behavior when screen metrics are invalid or no configured viewport fits.
- Update viewport tests and German translations for moved log messages.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

Validation run locally: `pdm run format && pdm run lint && pdm run test` — 1470 passed, 4 skipped.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically resizes the browser window after a page loads, using screen-aware metrics from the current page.
  * Selects from configured viewport sizes that fit the available screen area, with bounded variation.
  * Adds runtime diagnostics for viewport resize (attempted/applied), including skip reasons and failure details.

* **Bug Fixes**
  * Improves resilience when URL/metrics are missing, malformed, or don’t include valid dimensions.
  * Prevents resize for non-eligible pages and when a user-supplied window size is present; resize now occurs before human-like actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->