### PR TITLE
fix: catch ProtocolException in login detection selectors

### DIFF
--- a/src/kleinanzeigen_bot/login_flow.py
+++ b/src/kleinanzeigen_bot/login_flow.py
@@ -861,7 +861,7 @@ async def has_logged_in_marker(web:WebScrapingMixin, *, username:str) -> bool:
             LOG.debug("Login detected via login detection selector '%s'", matched_selector_display)
             return True
     except (TimeoutError, ProtocolException):
-        LOG.debug("Timeout waiting for login detection selector group after %.1fs", effective_timeout)
+        LOG.debug("No login detected via selector group after %.1fs (timeout or stale node)", effective_timeout)
 
     return False
 

--- a/src/kleinanzeigen_bot/login_flow.py
+++ b/src/kleinanzeigen_bot/login_flow.py
@@ -20,6 +20,8 @@ from gettext import gettext as _
 from pathlib import Path
 from typing import Final, Sequence
 
+from nodriver.core.connection import ProtocolException
+
 from . import captcha_flow
 from .model.config_model import CaptchaConfig, DiagnosticsConfig
 from .utils import diagnostics as _diagnostics
@@ -840,7 +842,7 @@ async def has_logged_in_marker(web:WebScrapingMixin, *, username:str) -> bool:
             )
             LOG.debug("Login detected via login detection selector '%s'", matched_selector_display)
             return True
-    except TimeoutError:
+    except (TimeoutError, ProtocolException):
         LOG.debug("No login detected via configured login detection selectors (%s)", tried_login_selectors)
 
     try:
@@ -858,7 +860,7 @@ async def has_logged_in_marker(web:WebScrapingMixin, *, username:str) -> bool:
             )
             LOG.debug("Login detected via login detection selector '%s'", matched_selector_display)
             return True
-    except TimeoutError:
+    except (TimeoutError, ProtocolException):
         LOG.debug("Timeout waiting for login detection selector group after %.1fs", effective_timeout)
 
     return False
@@ -903,7 +905,7 @@ async def has_logged_out_cta(web:WebScrapingMixin, *, log_timeout:bool = True) -
                 return True
             LOG.debug("Fast logged-out pre-check got unexpected selector index '%s'; failing closed", cta_index)
             return False
-    except TimeoutError:
+    except (TimeoutError, ProtocolException):
         if log_timeout:
             LOG.debug(
                 "Fast logged-out pre-check found no login CTA (%s) within %.1fs",

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -169,7 +169,7 @@ kleinanzeigen_bot/login_flow.py:
   has_logged_in_marker:
     "Starting login detection (timeout: %.1fs base, %.1fs effective with multiplier/backoff)": "Starte Login-Erkennung (Timeout: %.1fs Basis, %.1fs effektiv mit Multiplikator/Backoff)"
     "Login detected via login detection selector '%s'": "Login erkannt über Login-Erkennungs-Selektor '%s'"
-    "Timeout waiting for login detection selector group after %.1fs": "Timeout beim Warten auf die Login-Erkennungs-Selektorgruppe nach %.1fs"
+    "No login detected via selector group after %.1fs (timeout or stale node)": "Kein Login erkannt über Selektorgruppe nach %.1fs (Timeout oder veralteter Knoten)"
 
   handle_after_login_logic:
     "Handling GDPR disclaimer...": "Verarbeite DSGVO-Hinweis..."


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): none (no existing issue found)
- Describe the motivation and context for this change.

When kleinanzeigen.de's dynamic JavaScript removes a DOM node after nodriver has acquired a CDP reference to it, the DevTools protocol raises `ProtocolException("Could not find node with given id", code=-32000)` instead of a `TimeoutError`. The login detection functions `has_logged_in_marker()` and `has_logged_out_cta()` in `login_flow.py` only caught `TimeoutError`, causing the bot to crash during the `"Checking if already logged in..."` phase — even when the user is successfully logged in and their ads are visible.

This is reproducible with Chromium 150 + nodriver 0.50.3 on kleinanzeigen.de's current page layout, where SPA-style rerenders invalidate node references between `web_text_first_available()` finding an element and reading its text content.

## 📋 Changes Summary

- Import `ProtocolException` from `nodriver.core.connection` in `login_flow.py`
- Add `ProtocolException` to the `except` clauses in `has_logged_in_marker()` (two try blocks: quick_dom and login_detection selector groups)
- Add `ProtocolException` to the `except` clause in `has_logged_out_cta()` (quick_dom selector group)
- Stale-node errors are now treated identically to timeouts: the detection gracefully falls through to the next selector or returns `False`

No dependencies, configuration, or API surface changes.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test` — 87 login-related unit tests pass; full dev deps not installed locally but `ruff check --preview` passes clean).
- [x] I have formatted the code (`ruff check --fix` applied for import sorting).
- [x] I have verified that linting passes (`ruff check --preview` — all checks passed).
- [ ] I have updated documentation where necessary. _(No doc changes needed — internal error handling fix only.)_

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login-state detection by handling additional connection errors gracefully during both logged-in and logged-out checks.
  * Reduced incorrect sign-in/sign-out outcomes by treating these errors as inconclusive rather than blocking the flow.
  * Preserved existing fallback behavior when a reliable match can’t be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->