### PR TITLE
fix: narrow stale node protocol error handling

### DIFF
--- a/src/kleinanzeigen_bot/login_flow.py
+++ b/src/kleinanzeigen_bot/login_flow.py
@@ -31,6 +31,9 @@ from .utils.web_scraping_mixin import By, WebScrapingMixin
 
 LOG:Final[_loggers.Logger] = _loggers.get_logger(__name__)
 
+_STALE_NODE_PROTOCOL_ERROR_CODE:Final[int] = -32000
+_STALE_NODE_PROTOCOL_ERROR_MESSAGE:Final[str] = "could not find node with given id"
+
 _LOGIN_DETECTION_SELECTORS:Final[list[tuple["By", str]]] = [
     (By.CLASS_NAME, "mr-medium"),
     (By.ID, "user-email"),
@@ -84,6 +87,17 @@ async def _click_auth0_submit(web:WebScrapingMixin, *, timeout:float | None = No
 
 def _format_login_detection_selectors(selectors:Sequence[tuple["By", str]]) -> str:
     return ", ".join(f"{selector_type.name}={selector_value}" for selector_type, selector_value in selectors)
+
+
+def _is_stale_node_protocol_error(error:ProtocolException) -> bool:
+    if getattr(error, "code", None) != _STALE_NODE_PROTOCOL_ERROR_CODE:
+        return False
+
+    message = getattr(error, "message", None)
+    if not isinstance(message, str):
+        return False
+
+    return message.strip().casefold() == _STALE_NODE_PROTOCOL_ERROR_MESSAGE
 
 
 class LoginDetectionReason(enum.Enum):
@@ -842,8 +856,17 @@ async def has_logged_in_marker(web:WebScrapingMixin, *, username:str) -> bool:
             )
             LOG.debug("Login detected via login detection selector '%s'", matched_selector_display)
             return True
-    except (TimeoutError, ProtocolException):
+    except TimeoutError:
         LOG.debug("No login detected via configured login detection selectors (%s)", tried_login_selectors)
+    except ProtocolException as error:
+        if _is_stale_node_protocol_error(error):
+            LOG.debug(
+                "Suppressing stale node protocol error during quick logged-in lookup (code=%s, message=%s)",
+                error.code,
+                error.message,
+            )
+        else:
+            raise
 
     try:
         user_info, matched_selector = await web.web_text_first_available(
@@ -860,8 +883,17 @@ async def has_logged_in_marker(web:WebScrapingMixin, *, username:str) -> bool:
             )
             LOG.debug("Login detected via login detection selector '%s'", matched_selector_display)
             return True
-    except (TimeoutError, ProtocolException):
+    except TimeoutError:
         LOG.debug("No login detected via selector group after %.1fs (timeout or stale node)", effective_timeout)
+    except ProtocolException as error:
+        if _is_stale_node_protocol_error(error):
+            LOG.debug(
+                "Suppressing stale node protocol error during logged-in selector group lookup (code=%s, message=%s)",
+                error.code,
+                error.message,
+            )
+        else:
+            raise
 
     return False
 
@@ -905,12 +937,21 @@ async def has_logged_out_cta(web:WebScrapingMixin, *, log_timeout:bool = True) -
                 return True
             LOG.debug("Fast logged-out pre-check got unexpected selector index '%s'; failing closed", cta_index)
             return False
-    except (TimeoutError, ProtocolException):
+    except TimeoutError:
         if log_timeout:
             LOG.debug(
                 "Fast logged-out pre-check found no login CTA (%s) within %.1fs",
                 tried_logged_out_selectors,
                 quick_dom_timeout,
             )
+    except ProtocolException as error:
+        if _is_stale_node_protocol_error(error):
+            LOG.debug(
+                "Suppressing stale node protocol error during logged-out CTA check (code=%s, message=%s)",
+                error.code,
+                error.message,
+            )
+        else:
+            raise
 
     return False

--- a/tests/unit/test_login_flow.py
+++ b/tests/unit/test_login_flow.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from nodriver.core.connection import ProtocolException
 
 from kleinanzeigen_bot import login_flow
 from kleinanzeigen_bot.app import KleinanzeigenBot
@@ -21,6 +22,7 @@ from kleinanzeigen_bot.login_flow import (
     current_page_url,
     fill_login_data_and_send,
     handle_identifier_captcha_state,
+    has_logged_in_marker,
     has_logged_out_cta,
     is_valid_post_auth0_destination,
     wait_for_post_auth0_submit_transition,
@@ -78,6 +80,108 @@ class TestKleinanzeigenBotAuthentication:
             patch.object(test_bot, "extract_visible_text", new_callable = AsyncMock, return_value = "Einloggen"),
         ):
             assert await has_logged_out_cta(test_bot) is True
+
+    @pytest.mark.asyncio
+    async def test_has_logged_in_marker_stale_quick_protocol_error_falls_back_to_full_lookup(self, test_bot:KleinanzeigenBot) -> None:
+        stale_error = ProtocolException({"code": -32000, "message": "Could not find node with given id"})
+        with patch.object(
+            test_bot,
+            "web_text_first_available",
+            new_callable = AsyncMock,
+            side_effect = [stale_error, ("Welcome dummy_user", 0)],
+        ) as mock_web_text:
+            assert await has_logged_in_marker(test_bot, username = "dummy_user") is True
+
+        assert mock_web_text.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_has_logged_in_marker_stale_full_protocol_error_after_quick_timeout_returns_false(self, test_bot:KleinanzeigenBot) -> None:
+        stale_error = ProtocolException({"code": -32000, "message": "Could not find node with given id"})
+        with patch.object(
+            test_bot,
+            "web_text_first_available",
+            new_callable = AsyncMock,
+            side_effect = [TimeoutError(), stale_error],
+        ) as mock_web_text:
+            assert await has_logged_in_marker(test_bot, username = "dummy_user") is False
+
+        assert mock_web_text.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_has_logged_out_cta_stale_text_extraction_protocol_error_returns_false(self, test_bot:KleinanzeigenBot) -> None:
+        stale_error = ProtocolException({"code": -32000, "message": "Could not find node with given id"})
+        matched_element = MagicMock(spec = Element)
+
+        with (
+            patch.object(
+                test_bot,
+                "web_find_first_available",
+                new_callable = AsyncMock,
+                return_value = (matched_element, 0),
+            ),
+            patch.object(
+                test_bot,
+                "extract_visible_text",
+                new_callable = AsyncMock,
+                side_effect = stale_error,
+            ),
+        ):
+            assert await has_logged_out_cta(test_bot) is False
+
+    @pytest.mark.asyncio
+    async def test_has_logged_in_marker_unrelated_protocol_error_re_raises_quick_lookup(self, test_bot:KleinanzeigenBot) -> None:
+        unrelated_error = ProtocolException({"code": -32000, "message": "Could not parse JSON"})
+        with (
+            patch.object(test_bot, "web_text_first_available", new_callable = AsyncMock, side_effect = unrelated_error),
+            pytest.raises(ProtocolException),
+        ):
+            await has_logged_in_marker(test_bot, username = "dummy_user")
+
+    @pytest.mark.asyncio
+    async def test_has_logged_in_marker_unrelated_protocol_error_re_raises_selector_group_lookup(self, test_bot:KleinanzeigenBot) -> None:
+        unrelated_error = ProtocolException({"code": -32000, "message": "Could not parse JSON"})
+        with (
+            patch.object(
+                test_bot,
+                "web_text_first_available",
+                new_callable = AsyncMock,
+                side_effect = [TimeoutError(), unrelated_error],
+            ),
+            pytest.raises(ProtocolException),
+        ):
+            await has_logged_in_marker(test_bot, username = "dummy_user")
+
+    @pytest.mark.asyncio
+    async def test_has_logged_out_cta_unrelated_protocol_error_re_raises_text_extraction(self, test_bot:KleinanzeigenBot) -> None:
+        unrelated_error = ProtocolException({"code": -32000, "message": "Could not parse JSON"})
+        matched_element = MagicMock(spec = Element)
+
+        with (
+            patch.object(
+                test_bot,
+                "web_find_first_available",
+                new_callable = AsyncMock,
+                return_value = (matched_element, 0),
+            ),
+            patch.object(
+                test_bot,
+                "extract_visible_text",
+                new_callable = AsyncMock,
+                side_effect = unrelated_error,
+            ),
+            pytest.raises(ProtocolException),
+        ):
+            await has_logged_out_cta(test_bot)
+
+    @pytest.mark.parametrize(
+        ("code", "message"),
+        [
+            pytest.param(-32601, "Could not find node with given id", id = "wrong_code"),
+            pytest.param(-32000, "Could not locate node with given id", id = "wrong_message"),
+        ],
+    )
+    def test_is_stale_node_protocol_error_rejects_non_stale_values(self, code:int, message:str) -> None:
+        assert not login_flow._is_stale_node_protocol_error(ProtocolException({"code": code, "message": message}))
 
     @pytest.mark.asyncio
     async def test_is_logged_in_uses_selector_group_timeout_key(self, test_bot:KleinanzeigenBot) -> None:


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Follow-up to #1209
- Restrict login detection’s `ProtocolException` recovery to the observed stale-DOM-node error so unrelated CDP failures propagate instead of starting unnecessary SSO automation.

## 📋 Changes Summary

- Classify only the known stale-node CDP error by code and message.
- Preserve timeout and known stale-node fallback behavior at all login detection boundaries.
- Re-raise unrelated protocol errors and add focused regression coverage.
- No dependency, configuration, or API changes.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist
- [x] I have reviewed my changes to ensure they meet the project’s standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary. (No documentation change needed.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login-state detection when temporary “stale node” browser errors occur.
  * Prevented these transient errors from incorrectly interrupting login checks.
  * Preserved error reporting for unrelated protocol errors.

* **Tests**
  * Added coverage for stale-node recovery and unrelated protocol error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->