### PR TITLE
fix: await browser session cleanup

### DIFF
--- a/src/kleinanzeigen_bot/app.py
+++ b/src/kleinanzeigen_bot/app.py
@@ -74,7 +74,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         if self.file_log:
             self.file_log.close()
             self.file_log = None
-        self.close_browser_session()
+        self._close_browser_session_nowait()
 
     def get_version(self) -> str:
         return __version__
@@ -152,7 +152,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     LOG.error("Unknown command: %s", self.command)
                     sys.exit(2)
         finally:
-            self.close_browser_session()
+            await self.close_browser_session()
             if self._timing_collector is not None:
                 try:
                     loop = asyncio.get_running_loop()

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -50,6 +50,8 @@ _KEY_VALUE_PAIR_SIZE = 2
 _PRIMARY_SELECTOR_BUDGET_RATIO:Final[float] = 0.70
 _BACKUP_SELECTOR_BUDGET_CAP_SECONDS:Final[float] = 0.75
 _BACKUP_SELECTOR_BUDGET_FLOOR_SECONDS:Final[float] = 0.25
+_BROWSER_PROCESS_EXIT_TIMEOUT_SECONDS:Final[float] = 5.0
+_BROWSER_PROCESS_KILL_TIMEOUT_SECONDS:Final[float] = 2.0
 
 # Viewport jitter bounds applied when the real screen is probed successfully.
 # The base size is jittered uniformly within these ranges, capped by the
@@ -740,7 +742,7 @@ class WebScrapingMixin:  # noqa: PLR0904
             await self.page.send(cdp_browser.set_window_bounds(window_id, bounds = new_bounds))
             LOG.info("Applied randomized browser window size: %dx%d", width, height)
             return True
-        except Exception as exc:  # noqa: BLE001
+        except (TimeoutError, ProtocolException, RuntimeError, OSError) as exc:
             LOG.debug("Viewport resize failed via CDP: %s", exc)
             return False
 
@@ -935,12 +937,36 @@ class WebScrapingMixin:  # noqa: PLR0904
             try:
                 browser.stop()
                 if isinstance(browser_process, asyncio.subprocess.Process):
-                    await browser_process.wait()
+                    await self._wait_for_browser_process_exit(browser_process)
                 # Browser.stop() schedules one final, idempotent aclose() call.
                 await asyncio.sleep(0)
                 self._kill_orphaned_browser_children(browser_pid)
             finally:
                 self.browser = None  # pyright: ignore[reportAttributeAccessIssue]
+
+    async def _wait_for_browser_process_exit(self, browser_process:asyncio.subprocess.Process) -> None:
+        try:
+            await asyncio.wait_for(
+                browser_process.wait(),
+                timeout = _BROWSER_PROCESS_EXIT_TIMEOUT_SECONDS,
+            )
+            return
+        except (TimeoutError, OSError) as exc:
+            LOG.debug("Browser process did not exit cleanly: %s", exc)
+
+        try:
+            if browser_process.returncode is None:
+                browser_process.kill()
+        except OSError as exc:
+            LOG.debug("Browser process could not be killed: %s", exc)
+
+        try:
+            await asyncio.wait_for(
+                browser_process.wait(),
+                timeout = _BROWSER_PROCESS_KILL_TIMEOUT_SECONDS,
+            )
+        except (TimeoutError, OSError) as exc:
+            LOG.debug("Browser process could not be reaped after being killed: %s", exc)
 
     def _close_browser_session_nowait(self) -> None:
         """Best-effort browser cleanup for destructors, where awaiting is impossible."""

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -916,7 +916,7 @@ class WebScrapingMixin:  # noqa: PLR0904
             get_compatible_browser = self.get_compatible_browser,
         )
 
-    def close_browser_session(self) -> None:
+    async def close_browser_session(self) -> None:
         if not self.browser:
             return
 
@@ -926,7 +926,31 @@ class WebScrapingMixin:  # noqa: PLR0904
         # Safely read private nodriver PID. In tests/mocked sessions this can be non-int,
         # and in externally managed browser sessions it can be None.
         browser_pid = getattr(browser, "_process_pid", None)
-        # Let nodriver perform graceful shutdown first; only force-kill leftovers afterwards.
+        browser_process = getattr(browser, "_process", None)
+        # Close nodriver's websocket tasks before stopping the event loop. Browser.stop()
+        # schedules this cleanup without awaiting it, which can leave pending tasks behind.
+        try:
+            await browser.aclose()
+        finally:
+            try:
+                browser.stop()
+                if isinstance(browser_process, asyncio.subprocess.Process):
+                    await browser_process.wait()
+                # Browser.stop() schedules one final, idempotent aclose() call.
+                await asyncio.sleep(0)
+                self._kill_orphaned_browser_children(browser_pid)
+            finally:
+                self.browser = None  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _close_browser_session_nowait(self) -> None:
+        """Best-effort browser cleanup for destructors, where awaiting is impossible."""
+        if not self.browser:
+            return
+
+        LOG.debug("Closing Browser session...")
+        browser = self.browser
+        self.page = None  # pyright: ignore[reportAttributeAccessIssue]
+        browser_pid = getattr(browser, "_process_pid", None)
         try:
             browser.stop()
             self._kill_orphaned_browser_children(browser_pid)

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -951,7 +951,7 @@ class WebScrapingMixin:  # noqa: PLR0904
                 timeout = _BROWSER_PROCESS_EXIT_TIMEOUT_SECONDS,
             )
             return
-        except (TimeoutError, OSError) as exc:
+        except (TimeoutError, asyncio.TimeoutError, OSError) as exc:
             LOG.debug("Browser process did not exit cleanly: %s", exc)
 
         try:
@@ -965,7 +965,7 @@ class WebScrapingMixin:  # noqa: PLR0904
                 browser_process.wait(),
                 timeout = _BROWSER_PROCESS_KILL_TIMEOUT_SECONDS,
             )
-        except (TimeoutError, OSError) as exc:
+        except (TimeoutError, asyncio.TimeoutError, OSError) as exc:
             LOG.debug("Browser process could not be reaped after being killed: %s", exc)
 
     def _close_browser_session_nowait(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,8 @@ from kleinanzeigen_bot.model.config_model import Config
 from kleinanzeigen_bot.utils import i18n, loggers
 from kleinanzeigen_bot.utils.web_scraping_mixin import Browser
 
-loggers.configure_console_logging()
-
+# Let pytest own the logging handlers so late teardown records remain captured
+# instead of being written directly to the worker's original stderr stream.
 LOG:Final[loggers.Logger] = loggers.get_logger("kleinanzeigen_bot")
 LOG.setLevel(loggers.DEBUG)
 
@@ -268,7 +268,7 @@ class SmokeKleinanzeigenBot(KleinanzeigenBot):
         # Use cast to satisfy type checker for browser attribute
         self.browser = cast(Browser, DummyBrowser())
 
-    def close_browser_session(self) -> None:
+    async def close_browser_session(self) -> None:
         # Override to avoid psutil.Process logic in tests
         self.page = None  # pyright: ignore[reportAttributeAccessIssue]
         if self.browser:

--- a/tests/integration/test_web_scraping_mixin_integration.py
+++ b/tests/integration/test_web_scraping_mixin_integration.py
@@ -3,7 +3,6 @@
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 import platform
 
-import nodriver
 import pytest
 
 from kleinanzeigen_bot.utils.misc import ensure
@@ -16,7 +15,10 @@ pytestmark = pytest.mark.slow
 # and pytest handles verbosity with -v flag automatically
 
 
-async def atest_init() -> None:
+@pytest.mark.flaky(reruns = 5, reruns_delay = 10)
+@pytest.mark.itest
+@pytest.mark.asyncio
+async def test_init() -> None:
     web_scraping_mixin = WebScrapingMixin()
     if platform.system() == "Linux":
         # required for Ubuntu 24.04 or newer
@@ -25,14 +27,7 @@ async def atest_init() -> None:
     browser_path = web_scraping_mixin.get_compatible_browser()
     ensure(browser_path is not None, "Browser not auto-detected")
 
-    web_scraping_mixin.close_browser_session()
     try:
         await web_scraping_mixin.create_browser_session()
     finally:
-        web_scraping_mixin.close_browser_session()
-
-
-@pytest.mark.flaky(reruns = 5, reruns_delay = 10)
-@pytest.mark.itest
-def test_init() -> None:
-    nodriver.loop().run_until_complete(atest_init())  # type: ignore[attr-defined]
+        await web_scraping_mixin.close_browser_session()

--- a/tests/unit/test_ad_status.py
+++ b/tests/unit/test_ad_status.py
@@ -9,7 +9,7 @@ import copy
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -671,7 +671,7 @@ async def test_status_guardrails(
         patch.object(bot, "load_ads", side_effect = _track_load_ads),
         patch.object(bot, "create_browser_session", side_effect = _track_browser),
         patch.object(bot, "login", side_effect = _track_browser),
-        patch.object(bot, "close_browser_session"),
+        patch.object(bot, "close_browser_session", new_callable = AsyncMock),
         patch(
             "kleinanzeigen_bot.ad_loading.load_ad_configs",
             return_value = [("/abs/a.yaml", "ads/a.yaml", _ad(id = 1), _raw())],

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -70,7 +70,7 @@ class TestKleinanzeigenBotInitialization:
             patch("kleinanzeigen_bot.download_flow.download_ads", new_callable = AsyncMock),
 
 
-            patch.object(test_bot, "close_browser_session"),
+            patch.object(test_bot, "close_browser_session", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.update_checker.UpdateChecker", DummyUpdateChecker),
         ):
             await test_bot.run(["app", command])

--- a/tests/unit/test_color.py
+++ b/tests/unit/test_color.py
@@ -24,11 +24,11 @@ class TestShouldUseColor:
 
     def test_tty_true_enables_color(self) -> None:
         """TTY stream with no env overrides → colour enabled."""
-        assert should_use_color(stream = _tty(True))
+        assert should_use_color(stream = _tty(True), env = {})
 
     def test_tty_false_disables_color(self) -> None:
         """Non-TTY stream with no env overrides → colour disabled."""
-        assert not should_use_color(stream = _tty(False))
+        assert not should_use_color(stream = _tty(False), env = {})
 
     def test_tty_oserror_disables_color(self) -> None:
         """Stream.isatty() raising OSError → colour disabled."""
@@ -38,11 +38,11 @@ class TestShouldUseColor:
                 msg = "boom"
                 raise OSError(msg)
 
-        assert not should_use_color(stream = _Boom())  # type: ignore[arg-type]
+        assert not should_use_color(stream = _Boom(), env = {})  # type: ignore[arg-type]
 
     def test_tty_attributeerror_disables_color(self) -> None:
         """Stream without isatty() → colour disabled."""
-        assert not should_use_color(stream = _NoIsATTY())  # type: ignore[arg-type]
+        assert not should_use_color(stream = _NoIsATTY(), env = {})  # type: ignore[arg-type]
 
     # ------------------------------------------------------------------ #
     # NO_COLOR

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -912,11 +912,13 @@ class TestSelectorTimeoutMessages:
 class TestWebScrapingSessionManagement:
     """Test session management edge cases in WebScrapingMixin."""
 
-    def test_close_browser_session_cleans_up_resources(self) -> None:
+    @pytest.mark.asyncio
+    async def test_close_browser_session_cleans_up_resources(self) -> None:
         """Ensure browser and page references are cleared and child processes are killed."""
         scraper = WebScrapingMixin()
         scraper.browser = MagicMock()
         scraper.browser._process_pid = 42
+        aclose_mock = scraper.browser.aclose = AsyncMock()
         stop_mock = scraper.browser.stop = MagicMock()
         scraper.page = MagicMock(spec = Page)
 
@@ -925,31 +927,36 @@ class TestWebScrapingSessionManagement:
             mock_child.is_running.return_value = True
             mock_proc.return_value.children.return_value = [mock_child]
 
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         mock_proc.assert_called_once_with(42)
+        aclose_mock.assert_awaited_once()
         stop_mock.assert_called_once()
         mock_child.kill.assert_called_once()
         assert scraper.browser is None
         assert scraper.page is None
 
-    def test_close_browser_session_idempotent(self) -> None:
+    @pytest.mark.asyncio
+    async def test_close_browser_session_idempotent(self) -> None:
         """Repeated calls should leave the state clean without re-running cleanup logic."""
         scraper = WebScrapingMixin()
         scraper.browser = MagicMock()
         scraper.browser._process_pid = 99
+        aclose_mock = scraper.browser.aclose = AsyncMock()
         stop_mock = scraper.browser.stop = MagicMock()
         scraper.page = MagicMock(spec = Page)
 
         with patch("psutil.Process") as mock_proc:
             mock_proc.return_value.children.return_value = []
-            scraper.close_browser_session()
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         mock_proc.assert_called_once()
+        aclose_mock.assert_awaited_once()
         stop_mock.assert_called_once()
 
-    def test_close_browser_session_without_browser_skips_inspection(self) -> None:
+    @pytest.mark.asyncio
+    async def test_close_browser_session_without_browser_skips_inspection(self) -> None:
         """When no browser exists, no process inspection should run and the page should stay untouched."""
         scraper = WebScrapingMixin()
         scraper.browser = None  # type: ignore[unused-ignore,reportAttributeAccessIssue]
@@ -957,47 +964,53 @@ class TestWebScrapingSessionManagement:
         scraper.page = preserved_page
 
         with patch("psutil.Process") as mock_proc:
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         mock_proc.assert_not_called()
         assert scraper.page is preserved_page
 
-    def test_close_browser_session_handles_missing_children(self) -> None:
+    @pytest.mark.asyncio
+    async def test_close_browser_session_handles_missing_children(self) -> None:
         """Child-less browsers should still stop cleanly without raising."""
         scraper = WebScrapingMixin()
         scraper.browser = MagicMock()
         scraper.browser._process_pid = 123
+        scraper.browser.aclose = AsyncMock()
         stop_mock = scraper.browser.stop = MagicMock()
         scraper.page = MagicMock(spec = Page)
 
         with patch("psutil.Process") as mock_proc:
             mock_proc.return_value.children.return_value = []
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         mock_proc.assert_called_once()
         stop_mock.assert_called_once()
 
-    def test_close_browser_session_handles_parent_process_disappearing_after_stop(self) -> None:
+    @pytest.mark.asyncio
+    async def test_close_browser_session_handles_parent_process_disappearing_after_stop(self) -> None:
         """A browser that exits during stop() should still leave shutdown state clean."""
         scraper = WebScrapingMixin()
         scraper.browser = MagicMock()
         scraper.browser._process_pid = 777
+        scraper.browser.aclose = AsyncMock()
         stop_mock = scraper.browser.stop = MagicMock()
         scraper.page = MagicMock(spec = Page)
 
         with patch("psutil.Process", side_effect = psutil.NoSuchProcess(777)) as mock_proc:
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         mock_proc.assert_called_once_with(777)
         stop_mock.assert_called_once()
         assert scraper.browser is None
         assert scraper.page is None
 
-    def test_close_browser_session_skips_killing_stopped_children(self) -> None:
+    @pytest.mark.asyncio
+    async def test_close_browser_session_skips_killing_stopped_children(self) -> None:
         """Stopped child processes should not be force-killed."""
         scraper = WebScrapingMixin()
         scraper.browser = MagicMock()
         scraper.browser._process_pid = 456
+        scraper.browser.aclose = AsyncMock()
         stop_mock = scraper.browser.stop = MagicMock()
         scraper.page = MagicMock(spec = Page)
 
@@ -1005,7 +1018,7 @@ class TestWebScrapingSessionManagement:
             mock_child = MagicMock()
             mock_child.is_running.return_value = False
             mock_proc.return_value.children.return_value = [mock_child]
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         mock_proc.assert_called_once_with(456)
         stop_mock.assert_called_once()
@@ -1013,11 +1026,13 @@ class TestWebScrapingSessionManagement:
         assert scraper.browser is None
         assert scraper.page is None
 
-    def test_close_browser_session_stops_before_force_killing_children(self) -> None:
+    @pytest.mark.asyncio
+    async def test_close_browser_session_stops_before_force_killing_children(self) -> None:
         """Browser stop should run before force-killing child processes."""
         scraper = WebScrapingMixin()
         scraper.browser = MagicMock()
         scraper.browser._process_pid = 321
+        scraper.browser.aclose = AsyncMock()
         stopped = {"value": False}
 
         def mark_stopped() -> None:
@@ -1036,11 +1051,12 @@ class TestWebScrapingSessionManagement:
             mock_child.kill.side_effect = assert_stop_happened
             mock_proc.return_value.children.return_value = [mock_child]
 
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         stop_mock.assert_called_once()
         mock_child.kill.assert_called_once()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "pid_value",
         [
@@ -1048,18 +1064,36 @@ class TestWebScrapingSessionManagement:
             pytest.param(MagicMock(), id = "non-int-pid"),
         ],
     )
-    def test_close_browser_session_skips_psutil_when_pid_is_invalid(self, pid_value:object) -> None:
+    async def test_close_browser_session_skips_psutil_when_pid_is_invalid(self, pid_value:object) -> None:
         """When _process_pid is not a valid int, psutil.Process should not be called but stop() should."""
         scraper = WebScrapingMixin()
         scraper.browser = MagicMock()
         scraper.browser._process_pid = pid_value
+        scraper.browser.aclose = AsyncMock()
         stop_mock = scraper.browser.stop = MagicMock()
         scraper.page = MagicMock(spec = Page)
 
         with patch("psutil.Process") as mock_proc:
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         mock_proc.assert_not_called()
+        stop_mock.assert_called_once()
+        assert scraper.browser is None
+        assert scraper.page is None
+
+    def test_close_browser_session_nowait_cleans_up_resources(self) -> None:
+        """Destructor cleanup should stop the browser without requiring an event loop."""
+        scraper = WebScrapingMixin()
+        scraper.browser = MagicMock()
+        scraper.browser._process_pid = 654
+        stop_mock = scraper.browser.stop = MagicMock()
+        scraper.page = MagicMock(spec = Page)
+
+        with patch("psutil.Process") as mock_proc:
+            mock_proc.return_value.children.return_value = []
+            scraper._close_browser_session_nowait()  # noqa: SLF001
+
+        mock_proc.assert_called_once_with(654)
         stop_mock.assert_called_once()
         assert scraper.browser is None
         assert scraper.page is None
@@ -1133,7 +1167,7 @@ class TestWebScrolling:
             mock_child = MagicMock()
             mock_child.is_running.return_value = True
             mock_proc.return_value.children.return_value = [mock_child]
-            web_scraper.close_browser_session()
+            await web_scraper.close_browser_session()
         assert web_scraper.browser is None
         assert web_scraper.page is None
         # Re-assign browser for new session
@@ -1780,7 +1814,7 @@ class TestWebScrapingBrowserConfiguration:
         scraper.browser.stop = MagicMock()
         with patch("psutil.Process") as mock_proc:
             mock_proc.return_value.children.return_value = []
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         # Second session: read state
         scraper2 = WebScrapingMixin()
@@ -1793,7 +1827,7 @@ class TestWebScrapingBrowserConfiguration:
         scraper2.browser.stop = MagicMock()
         with patch("psutil.Process") as mock_proc:
             mock_proc.return_value.children.return_value = []
-            scraper2.close_browser_session()
+            await scraper2.close_browser_session()
 
     @pytest.mark.asyncio
     async def test_session_creation_error_cleanup(self, tmp_path:Path, monkeypatch:pytest.MonkeyPatch) -> None:
@@ -1909,7 +1943,7 @@ class TestWebScrapingBrowserConfiguration:
 
         with patch("psutil.Process") as mock_proc:
             mock_proc.side_effect = psutil.NoSuchProcess(12345)
-            scraper.close_browser_session()
+            await scraper.close_browser_session()
 
         assert scraper.browser is None
         assert scraper.page is None

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -1082,6 +1082,26 @@ class TestWebScrapingSessionManagement:
         assert scraper.page is None
 
     @pytest.mark.asyncio
+    async def test_close_browser_session_cleans_up_when_aclose_fails(self) -> None:
+        """Cleanup should finish and the original aclose error should propagate."""
+        scraper = WebScrapingMixin()
+        scraper.browser = MagicMock()
+        scraper.browser._process_pid = 999
+        scraper.browser.aclose = AsyncMock(side_effect = RuntimeError("aclose failed"))
+        stop_mock = scraper.browser.stop = MagicMock()
+        scraper.page = MagicMock(spec = Page)
+
+        with patch("psutil.Process") as mock_proc:
+            mock_proc.return_value.children.return_value = []
+            with pytest.raises(RuntimeError, match = "aclose failed"):
+                await scraper.close_browser_session()
+
+        mock_proc.assert_called_once_with(999)
+        stop_mock.assert_called_once()
+        assert scraper.browser is None
+        assert scraper.page is None
+
+    @pytest.mark.asyncio
     async def test_wait_for_browser_process_exit_kills_after_timeout(self) -> None:
         """A browser process that does not exit after stop should be killed and reaped."""
         scraper = WebScrapingMixin()

--- a/tests/unit/test_web_scraping_mixin.py
+++ b/tests/unit/test_web_scraping_mixin.py
@@ -1081,6 +1081,61 @@ class TestWebScrapingSessionManagement:
         assert scraper.browser is None
         assert scraper.page is None
 
+    @pytest.mark.asyncio
+    async def test_wait_for_browser_process_exit_kills_after_timeout(self) -> None:
+        """A browser process that does not exit after stop should be killed and reaped."""
+        scraper = WebScrapingMixin()
+
+        class HangingProcess:
+            returncode:int | None = None
+
+            def __init__(self) -> None:
+                self.killed = False
+                self.wait_calls = 0
+
+            async def wait(self) -> int:
+                self.wait_calls += 1
+                if not self.killed:
+                    await asyncio.Event().wait()
+                self.returncode = -9
+                return self.returncode
+
+            def kill(self) -> None:
+                self.killed = True
+
+        process = HangingProcess()
+        with patch("kleinanzeigen_bot.utils.web_scraping_mixin._BROWSER_PROCESS_EXIT_TIMEOUT_SECONDS", 0.01):
+            await scraper._wait_for_browser_process_exit(cast(asyncio.subprocess.Process, process))  # noqa: SLF001
+
+        assert process.killed
+        assert process.wait_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_for_browser_process_exit_ignores_wait_and_kill_errors(self) -> None:
+        """Process cleanup errors should not prevent the remaining browser cleanup."""
+        scraper = WebScrapingMixin()
+
+        class FailingProcess:
+            returncode:int | None = None
+
+            def __init__(self) -> None:
+                self.wait_calls = 0
+                self.kill_calls = 0
+
+            async def wait(self) -> int:
+                self.wait_calls += 1
+                raise OSError("wait failed")
+
+            def kill(self) -> None:
+                self.kill_calls += 1
+                raise OSError("kill failed")
+
+        process = FailingProcess()
+        await scraper._wait_for_browser_process_exit(cast(asyncio.subprocess.Process, process))  # noqa: SLF001
+
+        assert process.wait_calls == 2
+        assert process.kill_calls == 1
+
     def test_close_browser_session_nowait_cleans_up_resources(self) -> None:
         """Destructor cleanup should stop the browser without requiring an event loop."""
         scraper = WebScrapingMixin()


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): N/A
- Fixes noisy asyncio teardown errors after the test suite by waiting for nodriver websocket tasks and the Chromium subprocess to finish before the event loop closes.
- The root cause was `Browser.stop()` scheduling asynchronous connection cleanup without awaiting it; under fast pytest-xdist teardown, keepalive/listener tasks survived until logging capture had already closed.

## 📋 Changes Summary

- Make browser-session cleanup await nodriver connection shutdown and Chromium process exit.
- Retain best-effort synchronous cleanup for object destruction, where awaiting is impossible.
- Convert the Chromium integration test to pytest-managed async execution and update affected mocks/unit tests.
- Let pytest own test logging handlers so late teardown records do not leak into progress output.
- Isolate terminal-color tests from ambient `NO_COLOR`/`FORCE_COLOR` settings.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`: 1,489 passed, 4 skipped).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary (no documentation changes required).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-session shutdown to use async teardown, including reliable cleanup on normal exit and exceptions.
  * Enhanced browser-process termination handling with configurable timeouts, forced child-process cleanup, and safer exception handling during viewport sizing.
* **Tests**
  * Updated unit and integration tests to await browser-session cleanup and align mocks with async behavior.
  * Expanded async test coverage for process-exit waiting, timeout/kill paths, and resilient teardown edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->