### PR TITLE
fix: support redesigned shipping dialog actions

### DIFF
--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -35,6 +35,11 @@ from .utils.misc import ensure
 from .utils.web_scraping_mixin import By, Element, Is, WebScrapingMixin
 
 LOG:Final[_loggers.Logger] = _loggers.get_logger(__name__)
+_OTHER_SHIPPING_METHODS_XPATH:Final[str] = (
+    '//*[self::dialog[@open] or (@role="dialog" and not(@aria-hidden="true"))]'
+    '//*[contains(normalize-space(.), "Andere Versandmethoden")'
+    ' and not(.//*[contains(normalize-space(.), "Andere Versandmethoden")])]'
+)
 
 
 async def set_category(web:WebScrapingMixin, *, root_url:str, category:str | None, ad_file:str) -> None:
@@ -727,15 +732,18 @@ async def _set_configured_shipping_options(
 
     if mode == AdUpdateStrategy.MODIFY:
         try:
-            await web.web_find(By.XPATH, '//button[contains(., "Andere Versandmethoden")]', timeout = short_timeout)
+            await web.web_find(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = short_timeout)
         except TimeoutError:
             await web.web_click(By.XPATH, '//button[contains(., "Zurück")]')
             try:
-                await web.web_find(By.XPATH, '//button[contains(., "Andere Versandmethoden")]', timeout = short_timeout)
+                await web.web_find(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = short_timeout)
             except TimeoutError:
                 await web.web_click(By.XPATH, '//button[contains(., "Zurück")]')
 
-    await web.web_click(By.XPATH, '//button[contains(., "Andere Versandmethoden")]')
+    # The redesign has rendered this action as different element types. Click
+    # its deepest text-bearing node so the event bubbles to whichever clickable
+    # ancestor the current dialog uses.
+    await web.web_click(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
     await set_shipping_options(web, ad_cfg, mode)
 
 

--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -734,16 +734,16 @@ async def _set_configured_shipping_options(
         try:
             await web.web_find(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = short_timeout)
         except TimeoutError:
-            await web.web_click(By.XPATH, '//button[contains(., "Zurück")]')
+            await web.web_click(By.XPATH, '//button[contains(., "Zurück")]', timeout = short_timeout)
             try:
                 await web.web_find(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = short_timeout)
             except TimeoutError:
-                await web.web_click(By.XPATH, '//button[contains(., "Zurück")]')
+                await web.web_click(By.XPATH, '//button[contains(., "Zurück")]', timeout = short_timeout)
 
     # The redesign has rendered this action as different element types. Click
     # its deepest text-bearing node so the event bubbles to whichever clickable
     # ancestor the current dialog uses.
-    await web.web_click(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
+    await web.web_click(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = short_timeout)
     await set_shipping_options(web, ad_cfg, mode)
 
 

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -20,8 +20,10 @@ from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.model.config_model import PublishingConfig
 from kleinanzeigen_bot.publishing_form import (
+    _OTHER_SHIPPING_METHODS_XPATH,  # noqa: PLC2701
     _select_button_combobox,  # noqa: PLC2701 - needed for coverage of React fiber selection
     _set_condition,  # noqa: PLC2701
+    _set_configured_shipping_options,  # noqa: PLC2701
     _special_attribute_candidate_priority,  # noqa: PLC2701
     city_option_text,
     fill_image_section,
@@ -1520,6 +1522,32 @@ class TestShippingOptionsDialog:
         else:
             el.attrs = {}
         return el
+
+    @pytest.mark.asyncio
+    async def test_open_dialog_action_is_tag_agnostic(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """The shipping action may be a button, link, span, or another clickable element."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, ["DHL_5"])
+
+        with (
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_shipping_options", new_callable = AsyncMock),
+        ):
+            await _set_configured_shipping_options(
+                test_bot,
+                ad_cfg,
+                AdUpdateStrategy.REPLACE,
+                test_bot.timeout("quick_dom"),
+            )
+
+        assert "self::dialog[@open]" in _OTHER_SHIPPING_METHODS_XPATH
+        assert "self::button" not in _OTHER_SHIPPING_METHODS_XPATH
+        assert "not(.//*[" in _OTHER_SHIPPING_METHODS_XPATH
+        mock_click.assert_any_await(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
 
     @pytest.mark.parametrize(
         "case",

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Awaitable, Iterator
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1547,7 +1547,10 @@ class TestShippingOptionsDialog:
         assert "self::dialog[@open]" in _OTHER_SHIPPING_METHODS_XPATH
         assert "self::button" not in _OTHER_SHIPPING_METHODS_XPATH
         assert "not(.//*[" in _OTHER_SHIPPING_METHODS_XPATH
-        mock_click.assert_any_await(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
+        assert any(
+            click.args == (By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
+            for click in mock_click.await_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_modify_navigates_back_to_tag_agnostic_dialog_action(
@@ -1558,15 +1561,30 @@ class TestShippingOptionsDialog:
         """MODIFY mode retries the tag-agnostic action after navigating back one dialog step."""
         ad_cfg = self._make_ad_with_options(base_ad_config, ["DHL_5"])
         action = MagicMock()
+        events:list[str] = []
+
+        async def find_action(*_:Any, **__:Any) -> MagicMock:
+            events.append("find")
+            if events.count("find") == 1:
+                raise TimeoutError("action not on current step")
+            return action
+
+        async def record_click(selector_type:By, selector_value:str, **_:Any) -> None:
+            if selector_type != By.XPATH:
+                return
+            if selector_value == '//button[contains(., "Zurück")]':
+                events.append("back")
+            elif selector_value == _OTHER_SHIPPING_METHODS_XPATH:
+                events.append("action")
 
         with (
             patch.object(
                 test_bot,
                 "web_find",
                 new_callable = AsyncMock,
-                side_effect = [TimeoutError("action not on current step"), action],
-            ) as mock_find,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+                side_effect = find_action,
+            ),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = record_click),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.publishing_form.set_shipping_options", new_callable = AsyncMock),
         ):
@@ -1577,12 +1595,7 @@ class TestShippingOptionsDialog:
                 test_bot.timeout("quick_dom"),
             )
 
-        assert mock_find.await_args_list == [
-            call(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = test_bot.timeout("quick_dom")),
-            call(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = test_bot.timeout("quick_dom")),
-        ]
-        mock_click.assert_any_await(By.XPATH, '//button[contains(., "Zurück")]')
-        mock_click.assert_any_await(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
+        assert events == ["find", "back", "find", "action"]
 
     @pytest.mark.parametrize(
         "case",

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Awaitable, Iterator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -1547,6 +1547,41 @@ class TestShippingOptionsDialog:
         assert "self::dialog[@open]" in _OTHER_SHIPPING_METHODS_XPATH
         assert "self::button" not in _OTHER_SHIPPING_METHODS_XPATH
         assert "not(.//*[" in _OTHER_SHIPPING_METHODS_XPATH
+        mock_click.assert_any_await(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
+
+    @pytest.mark.asyncio
+    async def test_modify_navigates_back_to_tag_agnostic_dialog_action(
+        self,
+        test_bot:KleinanzeigenBot,
+        base_ad_config:dict[str, Any],
+    ) -> None:
+        """MODIFY mode retries the tag-agnostic action after navigating back one dialog step."""
+        ad_cfg = self._make_ad_with_options(base_ad_config, ["DHL_5"])
+        action = MagicMock()
+
+        with (
+            patch.object(
+                test_bot,
+                "web_find",
+                new_callable = AsyncMock,
+                side_effect = [TimeoutError("action not on current step"), action],
+            ) as mock_find,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.publishing_form.set_shipping_options", new_callable = AsyncMock),
+        ):
+            await _set_configured_shipping_options(
+                test_bot,
+                ad_cfg,
+                AdUpdateStrategy.MODIFY,
+                test_bot.timeout("quick_dom"),
+            )
+
+        assert mock_find.await_args_list == [
+            call(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = test_bot.timeout("quick_dom")),
+            call(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH, timeout = test_bot.timeout("quick_dom")),
+        ]
+        mock_click.assert_any_await(By.XPATH, '//button[contains(., "Zurück")]')
         mock_click.assert_any_await(By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -1560,14 +1560,11 @@ class TestShippingOptionsDialog:
     ) -> None:
         """MODIFY mode retries the tag-agnostic action after navigating back one dialog step."""
         ad_cfg = self._make_ad_with_options(base_ad_config, ["DHL_5"])
-        action = MagicMock()
         events:list[str] = []
 
-        async def find_action(*_:Any, **__:Any) -> MagicMock:
+        async def find_action(*_:Any, **__:Any) -> None:
             events.append("find")
-            if events.count("find") == 1:
-                raise TimeoutError("action not on current step")
-            return action
+            raise TimeoutError("action not on current step")
 
         async def record_click(selector_type:By, selector_value:str, **_:Any) -> None:
             if selector_type != By.XPATH:
@@ -1595,7 +1592,7 @@ class TestShippingOptionsDialog:
                 test_bot.timeout("quick_dom"),
             )
 
-        assert events == ["find", "back", "find", "action"]
+        assert events == ["find", "back", "find", "back", "action"]
 
     @pytest.mark.parametrize(
         "case",


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): N/A
- Make the shipping-options flow resilient to Kleinanzeigen rendering “Andere Versandmethoden” as a button, link, span, or another clickable wrapper.
- The previous XPath required a `<button>`, although the redesigned UI may use different element types.

## 📋 Changes Summary

- Scope the action lookup to an open or visible shipping dialog.
- Select the deepest text-bearing “Andere Versandmethoden” node so its click bubbles to the current clickable ancestor.
- Reuse the selector during modify-mode back navigation.
- Add regression coverage for tag-agnostic dialog interaction.
- No dependencies or configuration changes.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`: 1494 passed, 4 skipped).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary (not applicable; no user-facing configuration or workflow changes).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Andere Versandmethoden” selection to be tag-agnostic and avoid duplicate/nested matches.
  * Added a back-and-retry flow when the desired shipping option isn’t available on the current dialog step.
  * Updated the final selection to click the deepest matching text element within the dialog.

* **Tests**
  * Added regression tests covering tag-independent dialog actions and retry navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->