### PR TITLE
fix: use Python 3.12 for local act runs

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -6,4 +6,4 @@
 -W .github/workflows/build.yml
 -j build
 --matrix os:ubuntu-latest
---matrix PYTHON_VERSION:3.15
+--matrix PYTHON_VERSION:3.12


### PR DESCRIPTION
## ℹ️ Description

- Follow-up to #1235.
- Align local `act` runs with Python 3.12, the stable minimum version used for local development, release artifacts, and Docker builds.

## 📋 Changes Summary

- Select the Ubuntu/Python 3.12 build-matrix entry in `.actrc`.
- Keep Python 3.15 prerelease compatibility testing in the full GitHub Actions matrix.
- Introduce no dependency or runtime changes.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

Validation details:

- 1507 tests passed, 4 skipped
- 93.07% total coverage
- `.actrc` selects an existing `ubuntu-latest` / Python 3.12 matrix entry
- The `act` executable was not available for a local dry run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
