### PR TITLE
fix: show ad file path in validation errors

### DIFF
--- a/src/kleinanzeigen_bot/ad_loading.py
+++ b/src/kleinanzeigen_bot/ad_loading.py
@@ -73,7 +73,7 @@ def discover_ad_files(
 
 def load_ad(ad_cfg_orig:dict[str, Any], ad_defaults:Any, ad_file:str) -> Ad:
     """Validate a raw YAML dict into an :class:`Ad` with *ad_defaults* applied."""
-    return AdPartial.model_validate(ad_cfg_orig, context = ad_file).to_ad(ad_defaults)
+    return AdPartial.model_validate(ad_cfg_orig, context = ad_file).to_ad(ad_defaults, context = ad_file)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/kleinanzeigen_bot/ad_loading.py
+++ b/src/kleinanzeigen_bot/ad_loading.py
@@ -71,9 +71,9 @@ def discover_ad_files(
 # --------------------------------------------------------------------------- #
 
 
-def load_ad(ad_cfg_orig:dict[str, Any], ad_defaults:Any) -> Ad:
+def load_ad(ad_cfg_orig:dict[str, Any], ad_defaults:Any, ad_file:str) -> Ad:
     """Validate a raw YAML dict into an :class:`Ad` with *ad_defaults* applied."""
-    return AdPartial.model_validate(ad_cfg_orig).to_ad(ad_defaults)
+    return AdPartial.model_validate(ad_cfg_orig, context = ad_file).to_ad(ad_defaults)
 
 
 # --------------------------------------------------------------------------- #
@@ -377,7 +377,7 @@ def load_ad_configs(
     result:list[tuple[str, str, Ad, dict[str, Any]]] = []
     for ad_file, ad_file_relative in sorted(ad_files.items()):
         ad_cfg_orig = _dicts.load_dict(ad_file, "ad")
-        ad_cfg = load_ad(ad_cfg_orig, ad_defaults)
+        ad_cfg = load_ad(ad_cfg_orig, ad_defaults, ad_file)
         result.append((ad_file, ad_file_relative, ad_cfg, ad_cfg_orig))
     return result
 

--- a/src/kleinanzeigen_bot/model/ad_model.py
+++ b/src/kleinanzeigen_bot/model/ad_model.py
@@ -301,7 +301,7 @@ class AdPartial(ContextualModel):
         self.content_hash = hashlib.sha256(json_string.encode()).hexdigest()
         return self
 
-    def to_ad(self, ad_defaults:AdDefaults) -> Ad:
+    def to_ad(self, ad_defaults:AdDefaults, *, context:Any | None = None) -> Ad:
         """
         Returns a complete, validated Ad by merging this partial with values from ad_defaults.
 
@@ -323,7 +323,7 @@ class AdPartial(ContextualModel):
             ad_cfg["price_reduction_count"] = 0
         if not isinstance(ad_cfg.get("repost_count"), int):
             ad_cfg["repost_count"] = 0
-        return Ad.model_validate(ad_cfg)
+        return Ad.model_validate(ad_cfg, context = context)
 
 
 def _calculate_auto_price_internal(

--- a/tests/unit/test_ad_loading.py
+++ b/tests/unit/test_ad_loading.py
@@ -402,6 +402,38 @@ def test_load_ads_validation_errors_include_ad_file_path(
     assert expected_error in formatted_error
 
 
+def test_load_ads_final_validation_errors_include_ad_file_path(
+    tmp_path:Path,
+    base_ad_config:dict[str, Any],
+    test_bot_config:Config,
+) -> None:
+    """Final Ad validation errors retain the source ad file path."""
+    ad_dir = tmp_path / "ads"
+    ad_dir.mkdir()
+    ad_file = ad_dir / "invalid_ad.yaml"
+    ad_cfg = base_ad_config.copy()
+    ad_cfg.pop("sell_directly")
+    dicts.save_dict(ad_file, ad_cfg)
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("")
+    ad_defaults = test_bot_config.ad_defaults.model_copy(update = {"sell_directly": True})
+
+    with pytest.raises(ValidationError) as exc_info:
+        load_ads(
+            config_file_path = str(config_file),
+            ad_file_patterns = ["ads/*.yaml"],
+            ad_defaults = ad_defaults,
+            categories = {},
+            ads_selector = "due",
+            command = "publish",
+        )
+
+    formatted_error = format_validation_error(exc_info.value)
+    assert str(ad_file) in formatted_error
+    assert "shipping_options" in formatted_error
+
+
 # --------------------------------------------------------------------------- #
 # load_ads — selector behavior tests
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_ad_loading.py
+++ b/tests/unit/test_ad_loading.py
@@ -26,6 +26,7 @@ from kleinanzeigen_bot.model.config_model import (
     Config,
 )
 from kleinanzeigen_bot.utils import dicts, misc
+from kleinanzeigen_bot.utils.pydantics import format_validation_error
 
 # --------------------------------------------------------------------------- #
 # Local fixtures (base_ad_config is in tests/conftest.py)
@@ -326,6 +327,20 @@ _VALIDATION_ERROR_CASES = [
 ]
 
 
+_FILE_CONTEXT_VALIDATION_ERROR_CASES = [
+    pytest.param(
+        {"title": "x" * 66},
+        "title length exceeds 65 characters",
+        id = "title_too_long",
+    ),
+    pytest.param(
+        {"description": "x" * 4_001},
+        "description length exceeds 4000 characters",
+        id = "description_too_long",
+    ),
+]
+
+
 @pytest.mark.parametrize(("ad_overrides", "expected_error"), _VALIDATION_ERROR_CASES)
 def test_load_ads_validation_errors(
     tmp_path:Path,
@@ -353,6 +368,38 @@ def test_load_ads_validation_errors(
             command = "publish",
         )
     assert expected_error in str(exc_info.value)
+
+
+@pytest.mark.parametrize(("ad_overrides", "expected_error"), _FILE_CONTEXT_VALIDATION_ERROR_CASES)
+def test_load_ads_validation_errors_include_ad_file_path(
+    tmp_path:Path,
+    base_ad_config:dict[str, Any],
+    test_bot_config:Config,
+    ad_overrides:dict[str, Any],
+    expected_error:str,
+) -> None:
+    """Invalid ad files include their paths in the user-facing validation error."""
+    ad_dir = tmp_path / "ads"
+    ad_dir.mkdir()
+    ad_file = ad_dir / "invalid_ad.yaml"
+    dicts.save_dict(ad_file, base_ad_config | ad_overrides)
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("")
+
+    with pytest.raises(ValidationError) as exc_info:
+        load_ads(
+            config_file_path = str(config_file),
+            ad_file_patterns = ["ads/*.yaml"],
+            ad_defaults = test_bot_config.ad_defaults,
+            categories = {},
+            ads_selector = "due",
+            command = "publish",
+        )
+
+    formatted_error = format_validation_error(exc_info.value)
+    assert str(ad_file) in formatted_error
+    assert expected_error in formatted_error
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Fixes #1252
- Ad-validation errors now identify the source YAML/JSON file, so users can locate invalid titles or descriptions immediately.

## 📋 Changes Summary

- Pass each discovered ad file path through both validation stages.
- Add regression tests for overlong titles, descriptions, and final-model validation errors.
- No dependencies, configuration, or generated artifacts changed.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.