### PR TITLE
fix: preserve decoded Astro island props

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -744,16 +744,28 @@ class AdExtractor(WebScrapingMixin):
             })()""")
             if not raw or not isinstance(raw, str):
                 return {}
-            # The props attribute uses &quot; encoded quotes
-            decoded = html.unescape(raw)
-            props = json.loads(decoded)
+            # getAttribute() returns an HTML-decoded value. Parse it directly
+            # first so entity-like content inside JSON strings is preserved.
+            # Retain unescaping as a compatibility fallback for unexpected
+            # browser responses that still contain HTML entities.
+            props:dict[str, Any] | None = None
+            for candidate in (raw, html.unescape(raw)):
+                try:
+                    parsed = json.loads(candidate)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict):
+                    props = parsed
+                    break
+            if props is None:
+                return {}
             # The ad data is nested under 'data' -> [0, {...}]
             data_val = props.get("data", {})
             if isinstance(data_val, list) and len(data_val) == _ISLAND_ENVELOPE_LENGTH:
                 data_val = data_val[1]
             if isinstance(data_val, dict):
                 return cast(dict[str, Any], data_val)
-            return cast(dict[str, Any], props) if isinstance(props, dict) else {}
+            return props
         except Exception:
             return {}
 

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -91,6 +91,17 @@ class TestAdExtractorBasics:
         assert extractor.download_dir == Path("downloaded-ads")
 
     @pytest.mark.asyncio
+    async def test_extract_island_props_preserves_decoded_entity_like_description(self, test_extractor:extract_module.AdExtractor) -> None:
+        """Parse the browser-returned attribute before attempting HTML unescaping."""
+        description = "Verkaufe LEGO-Set mit &quot;The Great Wall of China&quot;."
+        astro_props = json.dumps({"data": [0, {"description": [0, description]}]})
+
+        with patch.object(test_extractor, "web_execute", new_callable = AsyncMock, return_value = astro_props):
+            island_props = await test_extractor._extract_island_props()
+
+        assert island_props["description"] == [0, description]
+
+    @pytest.mark.asyncio
     async def test_extract_island_props_unescapes_and_unwraps_ad_data(self, test_extractor:extract_module.AdExtractor) -> None:
         """Extract usable ad data from an HTML-escaped Astro props attribute."""
         astro_props = (


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Fixes #1255
- `astro-island` props returned by browser `getAttribute("props")` are already HTML-decoded. Applying `html.unescape()` first can corrupt entity-like content inside otherwise valid JSON strings and prevent the Astro fallbacks from receiving ad data.

## 📋 Changes Summary

- Parse the browser-returned props value with `json.loads()` before attempting HTML unescaping.
- Retain `html.unescape()` as a compatibility fallback for responses that still contain HTML entities.
- Add a regression test covering an entity-like quoted phrase in a decoded description.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of listing details containing entity-like text, such as `&quot;`, preserving the original content.
  * Added safer handling for invalid or unexpected island properties, returning an empty result when necessary.

* **Tests**
  * Added coverage to verify descriptions with entity-like content are parsed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->