### PR TITLE
fix: remove unused shipping selectors

### DIFF
--- a/src/kleinanzeigen_bot/publishing_form.py
+++ b/src/kleinanzeigen_bot/publishing_form.py
@@ -35,18 +35,6 @@ from .utils.misc import ensure
 from .utils.web_scraping_mixin import By, Element, Is, WebScrapingMixin
 
 LOG:Final[_loggers.Logger] = _loggers.get_logger(__name__)
-_OPEN_SHIPPING_DIALOG_XPATH:Final[str] = '//*[self::dialog[@open] or (@role="dialog" and not(@aria-hidden="true"))]'
-_OTHER_SHIPPING_METHODS_XPATH:Final[str] = (
-    _OPEN_SHIPPING_DIALOG_XPATH
-    + '//*[contains(normalize-space(.), "Andere Versandmethoden")'
-    ' and not(.//*[contains(normalize-space(.), "Andere Versandmethoden")])]'
-)
-_SHIPPING_SIZE_RADIO_XPATH:Final[str] = (
-    f'{_OPEN_SHIPPING_DIALOG_XPATH}//input[@type="radio" and '
-    '(@value="SMALL" or @value="MEDIUM" or @value="LARGE")]'
-)
-_SHIPPING_BACK_XPATH:Final[str] = f'{_OPEN_SHIPPING_DIALOG_XPATH}//button[contains(., "Zurück")]'
-
 # CSS-selector counterparts for the redesigned publishing form where nodriver
 # XPath evaluation (via CDP dom.perform_search) is unreliable.
 # Kleinanzeigen renders overlays as either native <dialog open> or ARIA

--- a/tests/unit/test_publishing_form.py
+++ b/tests/unit/test_publishing_form.py
@@ -19,8 +19,6 @@ from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad, AdUpdateStrategy
 from kleinanzeigen_bot.model.config_model import PublishingConfig
 from kleinanzeigen_bot.publishing_form import (
-    _OTHER_SHIPPING_METHODS_XPATH,  # noqa: PLC2701
-    _SHIPPING_BACK_XPATH,  # noqa: PLC2701
     _select_button_combobox,  # noqa: PLC2701 - needed for coverage of React fiber selection
     _set_condition,  # noqa: PLC2701
     _set_configured_shipping_options,  # noqa: PLC2701
@@ -1808,7 +1806,7 @@ class TestShippingOptionsDialog:
                 new_callable = AsyncMock,
                 side_effect = probe_side_effect,
             ) as mock_probe,
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.publishing_form.set_shipping_options", new_callable = AsyncMock),
         ):
@@ -1821,15 +1819,6 @@ class TestShippingOptionsDialog:
 
         # Back navigation happened via element.click(), not web_click.
         back_elem.click.assert_awaited_once()
-        # No web_click for XPath-based back or other-methods selectors.
-        assert not any(
-            call.args[:2] == (By.XPATH, _SHIPPING_BACK_XPATH)
-            for call in mock_click.await_args_list
-        )
-        assert not any(
-            call.args[:2] == (By.XPATH, _OTHER_SHIPPING_METHODS_XPATH)
-            for call in mock_click.await_args_list
-        )
         # "Zurück" was probed via By.TEXT.
         assert any(
             call.args[:2] == (By.TEXT, "Zurück")
@@ -1906,7 +1895,7 @@ class TestShippingOptionsDialog:
                 new_callable = AsyncMock,
                 side_effect = probe_side_effect,
             ),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock) as click_mock,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.publishing_form.set_shipping_options", new_callable = AsyncMock) as options_mock,
             pytest.raises(TimeoutError, match = "Failed to configure shipping options"),
@@ -1918,13 +1907,8 @@ class TestShippingOptionsDialog:
                 test_bot.timeout("quick_dom"),
             )
 
-        # Back navigation happened via element.click(), not web_click with XPath.
+        # Back navigation happened via element.click().
         assert all(elem.click.await_count == 1 for elem in back_elems)
-        back_xpath_clicks = [
-            call for call in click_mock.await_args_list
-            if call.args == (By.XPATH, _SHIPPING_BACK_XPATH)
-        ]
-        assert len(back_xpath_clicks) == 0
         options_mock.assert_not_awaited()
 
     @staticmethod


### PR DESCRIPTION
## ℹ️ Description

Removes obsolete shipping-dialog XPath selector constants that CodeQL reports as unused globals.

- Link to the related issue(s): N/A
- The CSS and text-based selector migration left these unused declarations and implementation-specific test assertions behind.

## 📋 Changes Summary

- Remove three unused XPath selector constants from the publishing form.
- Remove stale test imports and assertions for the retired XPath path.
- No dependency or configuration changes.

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (pdm run test).
- [x] I have formatted the code (pdm run format).
- [x] I have verified that linting passes (pdm run lint).
- [ ] I have updated documentation where necessary. (Not needed: no user-facing behavior changed.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.