### PR TITLE
enh: continue downloading after individual ad failures

### DIFF
--- a/src/kleinanzeigen_bot/download_flow.py
+++ b/src/kleinanzeigen_bot/download_flow.py
@@ -81,6 +81,47 @@ async def _download_ad_with_resolved_state(
     await ad_extractor.download_ad(ad_id, active = resolved.active, owned_overview = True)
 
 
+async def _try_download_ad(
+    ad_extractor:extract.AdExtractor,
+    ad_id:int,
+    published_ads_by_id:dict[int, PublishedAd],
+    *,
+    ad_reference:str | int,
+    owned_overview:bool,
+) -> bool:
+    """Download one ad without aborting the surrounding batch on failure."""
+    try:
+        if not await ad_extractor.navigate_to_ad_page(ad_reference):
+            LOG.error("Could not navigate to ad with id %d. Skipping ad.", ad_id)
+            return False
+
+        if owned_overview:
+            await _download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
+        else:
+            resolved = _download_selection.resolve_download_ad_activity(ad_id, published_ads_by_id)
+            if not resolved.owned:
+                # Foreign ad - expected for numeric IDs (can download any public ad)
+                LOG.warning("Ad id %d is not in your published profile ads. Saving downloaded ad as inactive.", ad_id)
+
+            await ad_extractor.download_ad(ad_id, active = resolved.active)
+            LOG.info("Downloaded ad with id %d", ad_id)
+    except Exception:  # noqa: BLE001 - one bad ad must not abort the batch
+        # asyncio.CancelledError inherits BaseException and therefore still propagates.
+        LOG.exception("Failed to download ad with id %d. Skipping ad.", ad_id)
+        return False
+    return True
+
+
+def _log_download_summary(success_count:int, total_count:int) -> None:
+    """Log the common batch result for all download selectors."""
+    LOG.info(
+        "DONE: downloaded %s of %s (%s failed)",
+        pluralize("ad", success_count),
+        pluralize("ad", total_count),
+        total_count - success_count,
+    )
+
+
 async def _fetch_published_ads_by_id(
     web:WebScrapingMixin,
     root_url:str,
@@ -122,10 +163,15 @@ async def _download_all_ads(
     for idx, (ad_url, ad_id) in enumerate(valid_ad_refs, start = 1):
         LOG.info("Downloading %d/%d ads...", idx, len(valid_ad_refs))
 
-        if await ad_extractor.navigate_to_ad_page(ad_url):
-            await _download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
+        if await _try_download_ad(
+            ad_extractor,
+            ad_id,
+            published_ads_by_id,
+            ad_reference = ad_url,
+            owned_overview = True,
+        ):
             success_count += 1
-    LOG.info("%d of %d ads were downloaded from your profile.", success_count, len(valid_ad_refs))
+    _log_download_summary(success_count, len(valid_ad_refs))
 
 
 async def _download_new_ads(
@@ -165,10 +211,15 @@ async def _download_new_ads(
     for idx, (ad_url, ad_id) in enumerate(ads_to_download, start = 1):
         LOG.info("Downloading %d/%d ads...", idx, len(ads_to_download))
 
-        if await ad_extractor.navigate_to_ad_page(ad_url):
-            await _download_ad_with_resolved_state(ad_extractor, ad_id, published_ads_by_id)
+        if await _try_download_ad(
+            ad_extractor,
+            ad_id,
+            published_ads_by_id,
+            ad_reference = ad_url,
+            owned_overview = True,
+        ):
             new_count += 1
-    LOG.info("%s were downloaded from your profile.", pluralize("new ad", new_count))
+    _log_download_summary(new_count, len(ads_to_download))
 
 
 async def _download_ads_by_ids(
@@ -180,19 +231,18 @@ async def _download_ads_by_ids(
     LOG.info("Starting download of ad(s) with the id(s):")
     LOG.info(" | ".join([str(ad_id) for ad_id in ids]))
 
+    success_count = 0
     for idx, ad_id in enumerate(ids, start = 1):
         LOG.info("Downloading %d/%d ads...", idx, len(ids))
-        exists = await ad_extractor.navigate_to_ad_page(ad_id)
-        if exists:
-            resolved = _download_selection.resolve_download_ad_activity(ad_id, published_ads_by_id)
-            if not resolved.owned:
-                # Foreign ad - expected for numeric IDs (can download any public ad)
-                LOG.warning("Ad id %d is not in your published profile ads. Saving downloaded ad as inactive.", ad_id)
-
-            await ad_extractor.download_ad(ad_id, active = resolved.active)
-            LOG.info("Downloaded ad with id %d", ad_id)
-        else:
-            LOG.error("The page with the id %d does not exist!", ad_id)
+        if await _try_download_ad(
+            ad_extractor,
+            ad_id,
+            published_ads_by_id,
+            ad_reference = ad_id,
+            owned_overview = False,
+        ):
+            success_count += 1
+    _log_download_summary(success_count, len(ids))
 
 
 async def download_ads(

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -462,25 +462,29 @@ kleinanzeigen_bot/download_flow.py:
   _download_all_ads:
     "Starting download of all ads...": "Starte den Download aller Anzeigen..."
     "Downloading %d/%d ads...": "Lade Anzeige %d/%d herunter..."
-    "%d of %d ads were downloaded from your profile.": "%d von %d Anzeigen wurden aus Ihrem Profil heruntergeladen."
 
   _download_new_ads:
     "Starting download of not yet downloaded ads...": "Starte den Download noch nicht heruntergeladener Anzeigen..."
     "Downloading %d/%d ads...": "Lade Anzeige %d/%d herunter..."
     "Skipping saved ad without id (likely unpublished or manually created): %s": "Überspringe gespeicherte Anzeige ohne ID (vermutlich nicht veröffentlicht oder manuell erstellt): %s"
     "The ad with id %d has already been saved.": "Die Anzeige mit der ID %d wurde bereits gespeichert."
-    "%s were downloaded from your profile.": "%s wurden aus Ihrem Profil heruntergeladen."
-    "new ad": "neue Anzeige"
 
   _download_ads_by_ids:
     "Starting download of ad(s) with the id(s):": "Starte Download der Anzeige(n) mit den ID(s):"
     "Downloading %d/%d ads...": "Lade Anzeige %d/%d herunter..."
-    "Ad id %d is not in your published profile ads. Saving downloaded ad as inactive.": "Anzeigen-ID %d ist nicht in Ihren veröffentlichten Profilanzeigen. Speichere die heruntergeladene Anzeige als inaktiv."
-    "Downloaded ad with id %d": "Anzeige mit der ID %d heruntergeladen"
-    "The page with the id %d does not exist!": "Die Seite mit der ID %d existiert nicht!"
 
   _download_ad_with_resolved_state:
     "Ad %d found in overview but not in published profile. Saving as inactive.": "Anzeige %d wurde in der Übersicht gefunden, aber nicht im veröffentlichten Profil. Speichere als inaktiv."
+
+  _try_download_ad:
+    "Ad id %d is not in your published profile ads. Saving downloaded ad as inactive.": "Anzeigen-ID %d ist nicht in Ihren veröffentlichten Profilanzeigen. Speichere die heruntergeladene Anzeige als inaktiv."
+    "Could not navigate to ad with id %d. Skipping ad.": "Navigation zu Anzeige mit ID %d nicht möglich. Überspringe Anzeige."
+    "Downloaded ad with id %d": "Anzeige mit der ID %d heruntergeladen"
+    "Failed to download ad with id %d. Skipping ad.": "Download der Anzeige mit ID %d fehlgeschlagen. Überspringe Anzeige."
+
+  _log_download_summary:
+    "DONE: downloaded %s of %s (%s failed)": "FERTIG: %s von %s heruntergeladen (%s fehlgeschlagen)"
+    "ad": "Anzeige"
 
 #################################################
 kleinanzeigen_bot/ad_status.py:

--- a/tests/unit/test_download_flow.py
+++ b/tests/unit/test_download_flow.py
@@ -3,10 +3,11 @@
 # SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
 """Tests for download flow functionality."""
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -558,6 +559,93 @@ class TestDownloadFlow:
 
         # Verify download_ad was NOT called when navigation fails
         extractor_mock.download_ad.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("selector", ["all", "new", "123,456"])
+    @pytest.mark.parametrize("failure_stage", ["navigation", "download"])
+    async def test_download_ads_continues_after_individual_ad_failure(
+        self,
+        test_bot:KleinanzeigenBot,
+        tmp_path:Path,
+        selector:str,
+        failure_stage:str,
+    ) -> None:
+        """Continue the batch and report failures when one ad cannot be downloaded."""
+        test_bot.workspace = xdg_paths.Workspace.for_config(tmp_path / "config.yaml", "kleinanzeigen-bot")
+        test_bot.ads_selector = selector
+        test_bot.browser = MagicMock()
+
+        extractor_mock = MagicMock()
+        extractor_mock.extract_own_ads_urls = AsyncMock(return_value = [
+            "https://www.kleinanzeigen.de/s-anzeige/test/123",
+            "https://www.kleinanzeigen.de/s-anzeige/test/456",
+        ])
+        extractor_mock.extract_ad_id_from_ad_url = MagicMock(side_effect = [123, 456])
+        if failure_stage == "navigation":
+            extractor_mock.navigate_to_ad_page = AsyncMock(side_effect = [RuntimeError("navigation failed"), True])
+            extractor_mock.download_ad = AsyncMock()
+        else:
+            extractor_mock.navigate_to_ad_page = AsyncMock(return_value = True)
+            extractor_mock.download_ad = AsyncMock(side_effect = [RuntimeError("download failed"), None])
+
+        def load_ads_func(
+            *,
+            ignore_inactive:bool = True,
+            exclude_ads_with_id:bool = True,
+        ) -> list[tuple[str, Ad, dict[str, Any]]]:
+            return []
+
+        with (
+            patch(
+                "kleinanzeigen_bot.published_ads.fetch_published_ads",
+                new_callable = AsyncMock,
+                return_value = [{"id": 123, "state": "active"}, {"id": 456, "state": "active"}],
+            ),
+            patch("kleinanzeigen_bot.extract.AdExtractor", return_value = extractor_mock),
+        ):
+            await download_flow.download_ads(
+                web = test_bot,
+                config = test_bot.config,
+                config_file_path = test_bot.config_file_path,
+                workspace = test_bot.workspace,
+                ads_selector = selector,
+                load_ads_func = load_ads_func,
+                root_url = test_bot.root_url,
+            )
+
+        ad_references = [123, 456] if selector == "123,456" else [
+            "https://www.kleinanzeigen.de/s-anzeige/test/123",
+            "https://www.kleinanzeigen.de/s-anzeige/test/456",
+        ]
+        assert extractor_mock.navigate_to_ad_page.await_args_list == [call(reference) for reference in ad_references]
+
+        download_kwargs = {"active": True}
+        if selector != "123,456":
+            download_kwargs["owned_overview"] = True
+
+        if failure_stage == "navigation":
+            extractor_mock.download_ad.assert_awaited_once_with(456, **download_kwargs)
+        else:
+            assert extractor_mock.download_ad.await_args_list == [
+                call(123, **download_kwargs),
+                call(456, **download_kwargs),
+            ]
+
+    @pytest.mark.asyncio
+    async def test_download_ads_propagates_cancellation(self, test_bot:KleinanzeigenBot, tmp_path:Path) -> None:
+        """Do not turn task cancellation into a per-ad download failure."""
+        test_bot.workspace = xdg_paths.Workspace.for_config(tmp_path / "config.yaml", "kleinanzeigen-bot")
+        test_bot.browser = MagicMock()
+
+        extractor_mock = MagicMock()
+        extractor_mock.navigate_to_ad_page = AsyncMock(side_effect = asyncio.CancelledError())
+
+        with (
+            patch("kleinanzeigen_bot.published_ads.fetch_published_ads", new_callable = AsyncMock, return_value = [{"id": 123, "state": "active"}]),
+            patch("kleinanzeigen_bot.extract.AdExtractor", return_value = extractor_mock),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await download_flow._download_ads_by_ids(extractor_mock, [123], {123: {"id": 123, "state": "active"}})
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("state_value", ["", "deleted", "expired", "pending", "draft", None])


### PR DESCRIPTION
## ℹ️ Description

- Link to the related issue(s): Issue #1259
- Continue a download batch when navigation or extraction fails for one ad, so remaining ads are still attempted.

## 📋 Changes Summary

- Isolate navigation and download failures per ad for all, new, and numeric-ID selectors.
- Log failed ads with tracebacks and emit a unified success/failure summary.
- Preserve task cancellation and add behavior-focused coverage for continuation after failures.
- No dependencies, configuration changes, or additional requirements were introduced.

### ⚙️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (pdm run test).
- [x] I have formatted the code (pdm run format).
- [x] I have verified that linting passes (pdm run lint).
- [x] I have updated documentation where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloads now continue for remaining ads when an individual ad encounters a navigation or download failure.
  * Cancellation requests are preserved instead of being treated as ordinary download failures.
  * Download results now provide a consistent summary, including successful and failed items.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->