### PR TITLE
feat: add reserve/activate commands to toggle an ad's reserved state

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Commands:
   delete   - deletes ads
   update   - updates published ads
   extend   - extends ads within the 8-day window before expiry (keeps watchers/savers and does not count towards the monthly ad quota)
+  reserve  - reserves ads: removes them from search results while keeping the ad ID, age, view count and watchers/savers
+  activate - re-activates reserved ads
   download - downloads one or multiple ads
   update-check - checks for available updates
   update-content-hash – recalculates each ad's content_hash based on the current ad_defaults;
@@ -245,6 +247,11 @@ Options:
         * all: extend all ads expiring within 8 days
         * <id(s)>: specify ad IDs to extend, e.g. "--ads=1,2,3"
         * Note: ads outside the 8-day window are skipped.
+  --ads=all|<id(s)> (reserve, activate) - specifies which ads to switch (DEFAULT: all)
+        Possible values:
+        * all: switch all eligible ads
+        * <id(s)>: specify ad IDs, e.g. "--ads=1,2,3"
+        * Note: ads already in the target state are skipped.
   --force           - alias for '--ads=all'
   --keep-old        - don't delete old ads on republication
   --preserve-local-settings - force-enable preservation of local-only settings on re-download (overrides config value of false)

--- a/src/kleinanzeigen_bot/app.py
+++ b/src/kleinanzeigen_bot/app.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Final, cast
 
 import certifi
 
-from . import ad_loading, ad_status, delete_flow, download_flow, extend_flow
+from . import ad_loading, ad_status, delete_flow, download_flow, extend_flow, reserve_flow
 from . import login_flow as _login_flow
 from . import publishing_workflow as _publishing_workflow
 from . import runtime_config as _runtime_config
@@ -146,6 +146,10 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
                     await self._handle_delete()
                 case "extend":
                     await self._handle_extend()
+                case "reserve":
+                    await self._handle_reserve_or_activate("reserve")
+                case "activate":
+                    await self._handle_reserve_or_activate("activate")
                 case "download":
                     await self._handle_download()
                 case _:
@@ -337,6 +341,32 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
         else:
             LOG.info("############################################")
             LOG.info("DONE: No ads found to extend.")
+            LOG.info("############################################")
+
+    async def _handle_reserve_or_activate(self, action:reserve_flow.ReserveAction) -> None:
+        """Takes ads out of circulation (``reserve``) or puts them back (``activate``)."""
+        self._bootstrap_runtime()
+        self._check_for_updates()
+
+        # Default to all ads if no selector provided, but reject invalid values
+        if not ad_loading.is_valid_ads_selector(self.ads_selector, {"all"}):
+            if self._ads_selector_explicit:
+                LOG.error('Invalid --ads selector: "%s". Valid values: all or comma-separated numeric IDs.', self.ads_selector)
+                sys.exit(2)
+            self.ads_selector = "all"
+
+        if ads := self.load_ads():
+            await self._open_logged_in_browser()
+            await reserve_flow.set_reservation_state(
+                web = self, root_url = self.root_url,
+                ad_cfgs = ads, action = action,
+            )
+        else:
+            LOG.info("############################################")
+            if action == "reserve":
+                LOG.info("DONE: No ads found to reserve.")
+            else:
+                LOG.info("DONE: No ads found to activate.")
             LOG.info("############################################")
 
     async def _handle_download(self) -> None:

--- a/src/kleinanzeigen_bot/cli.py
+++ b/src/kleinanzeigen_bot/cli.py
@@ -134,6 +134,8 @@ def help_text(*, executable:str | None = None, language:str | None = None) -> st
               delete   - Löscht Anzeigen
               update   - Aktualisiert bestehende Anzeigen
               extend   - Verlängert Anzeigen im 8-Tage-Zeitfenster (behält Beobachter/Interessenten bei und zählt nicht zum monatlichen Anzeigenkontingent)
+              reserve  - Reserviert Anzeigen: nimmt sie aus der Suche, behält aber ID, Alter, Aufrufe und Beobachter/Interessenten
+              activate - Aktiviert reservierte Anzeigen wieder
               download - Lädt eine oder mehrere Anzeigen herunter
               update-check - Prüft auf verfügbare Updates
               update-content-hash - Berechnet den content_hash aller Anzeigen anhand der aktuellen ad_defaults neu;
@@ -171,6 +173,11 @@ def help_text(*, executable:str | None = None, language:str | None = None) -> st
                     * all: Verlängert alle Anzeigen, die innerhalb von 8 Tagen ablaufen
                     * <id(s)>: Gibt bestimmte Anzeigen-IDs an, z. B. "--ads=1,2,3"
                     * Hinweis: Anzeigen außerhalb des 8-Tage-Fensters werden übersprungen.
+              --ads=all|<id(s)> (reserve, activate) - Gibt an, welche Anzeigen umgestellt werden sollen (STANDARD: all)
+                    Mögliche Werte:
+                    * all: Stellt alle passenden Anzeigen um
+                    * <id(s)>: Gibt bestimmte Anzeigen-IDs an, z. B. "--ads=1,2,3"
+                    * Hinweis: Anzeigen, die bereits im Zielzustand sind, werden übersprungen.
               --force           - Alias für '--ads=all'
               --keep-old        - Verhindert das Löschen alter Anzeigen bei erneuter Veröffentlichung
               --preserve-local-settings - Erzwingt das Beibehalten lokaler Einstellungen bei erneutem Download (überschreibt config-Wert false)
@@ -192,6 +199,8 @@ def help_text(*, executable:str | None = None, language:str | None = None) -> st
           delete   - deletes ads
           update   - updates published ads
           extend   - extends ads within the 8-day window before expiry (keeps watchers/savers and does not count towards the monthly ad quota)
+          reserve  - reserves ads: removes them from search results while keeping the ad ID, age, view count and watchers/savers
+          activate - re-activates reserved ads
           download - downloads one or multiple ads
           update-check - checks for available updates
           update-content-hash – recalculates each ad's content_hash based on the current ad_defaults;
@@ -227,6 +236,11 @@ def help_text(*, executable:str | None = None, language:str | None = None) -> st
                 * all: extend all ads expiring within 8 days
                 * <id(s)>: specify ad IDs to extend, e.g. "--ads=1,2,3"
                 * Note: ads outside the 8-day window are skipped.
+          --ads=all|<id(s)> (reserve, activate) - specifies which ads to switch (DEFAULT: all)
+                Possible values:
+                * all: switch all eligible ads
+                * <id(s)>: specify ad IDs, e.g. "--ads=1,2,3"
+                * Note: ads already in the target state are skipped.
           --force           - alias for '--ads=all'
           --keep-old        - don't delete old ads on republication
           --preserve-local-settings - force-enable preservation of local-only settings on re-download (overrides config value of false)

--- a/src/kleinanzeigen_bot/reserve_flow.py
+++ b/src/kleinanzeigen_bot/reserve_flow.py
@@ -53,6 +53,11 @@ _RESULTING_STATE:Final[dict[ReserveAction, str]] = {
     "activate": STATE_ACTIVE,
 }
 
+_OPEN_DIALOG_SELECTORS:Final[tuple[str, ...]] = (
+    "dialog[open]",
+    '[role="dialog"]:not([aria-hidden="true"])',
+)
+
 
 async def set_reservation_state(
     web:WebScrapingMixin,
@@ -167,6 +172,16 @@ async def _change_ad_state(
 
     await _dismiss_confirmation_dialog(web)
 
+    try:
+        updated_ads = await published_ads.fetch_published_ads(web, root_url, strict = True)
+    except published_ads.PublishedAdsFetchIncompleteError:
+        LOG.error(" -> FAILED: Could not confirm state change for ad '%s' (ID: %s)", ad_cfg.title, ad_cfg.id)
+        return False
+    resulting_ad = next((ad for ad in updated_ads if ad_matches_id(ad, ad_cfg.id)), None)
+    if not resulting_ad or resulting_ad.get("state") != _RESULTING_STATE[action]:
+        LOG.error(" -> FAILED: Could not confirm state change for ad '%s' (ID: %s)", ad_cfg.title, ad_cfg.id)
+        return False
+
     if action == "reserve":
         LOG.info(" -> SUCCESS: ad '%s' (ID: %s) is now reserved", ad_cfg.title, ad_cfg.id)
     else:
@@ -180,10 +195,15 @@ async def _dismiss_confirmation_dialog(web:WebScrapingMixin) -> None:
     Its absence is not an error: the action may complete without a dialog, and
     the state change has already been requested at this point either way.
     """
-    try:
-        await web.web_click(
-            By.CSS_SELECTOR, 'button[aria-label="Schließen"]', timeout = web.timeout("quick_dom")
-        )
-        LOG.debug(" -> Closed confirmation dialog")
-    except TimeoutError:
-        LOG.debug(" -> No confirmation dialog found, action may have completed directly")
+    for dialog_selector in _OPEN_DIALOG_SELECTORS:
+        try:
+            await web.web_click(
+                By.CSS_SELECTOR,
+                f'{dialog_selector} button[aria-label="Schließen"]',
+                timeout = web.timeout("quick_dom"),
+            )
+            LOG.debug(" -> Closed confirmation dialog")
+            return
+        except TimeoutError:
+            continue
+    LOG.debug(" -> No confirmation dialog found, action may have completed directly")

--- a/src/kleinanzeigen_bot/reserve_flow.py
+++ b/src/kleinanzeigen_bot/reserve_flow.py
@@ -174,7 +174,7 @@ async def _change_ad_state(
 
     try:
         updated_ads = await published_ads.fetch_published_ads(web, root_url, strict = True)
-    except published_ads.PublishedAdsFetchIncompleteError:
+    except (published_ads.PublishedAdsFetchIncompleteError, TimeoutError):
         LOG.error(" -> FAILED: Could not confirm state change for ad '%s' (ID: %s)", ad_cfg.title, ad_cfg.id)
         return False
     resulting_ad = next((ad for ad in updated_ads if ad_matches_id(ad, ad_cfg.id)), None)

--- a/src/kleinanzeigen_bot/reserve_flow.py
+++ b/src/kleinanzeigen_bot/reserve_flow.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Ad reservation browser workflow.
+
+Reserving takes an ad out of circulation without ending the sale: it keeps the
+ad ID, its age, its view count and every watcher/saver, and it is undone with a
+single "activate". Deleting and re-publishing loses all of that, which is why
+this is a separate command rather than a delete/publish round trip.
+
+The reserved state is what the API reports as ``paused`` -- the same value
+:mod:`publishing_workflow` already checks to avoid re-publishing reserved ads.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final, Literal
+
+from . import published_ads
+from .published_ads import ad_matches_id
+
+if TYPE_CHECKING:
+    from .model.ad_model import Ad
+    from .published_ads import PublishedAd
+from .utils import loggers as _loggers
+from .utils.i18n import pluralize
+from .utils.web_scraping_mixin import By, WebScrapingMixin
+
+LOG:_loggers.Logger = _loggers.get_logger(__name__)
+
+type ReserveAction = Literal["reserve", "activate"]
+
+# The API's ad state that corresponds to a reserved ad in the web UI.
+STATE_RESERVED:Final[str] = "paused"
+STATE_ACTIVE:Final[str] = "active"
+
+# Button labels in the manage-ads overview, per action. The buttons sit in the
+# same <li data-adid="..."> row that the extend flow already targets.
+_BUTTON_LABELS:Final[dict[ReserveAction, str]] = {
+    "reserve": "Reservieren",
+    "activate": "Aktivieren",
+}
+
+# The state an ad must currently be in for the action to be applicable.
+_REQUIRED_STATE:Final[dict[ReserveAction, str]] = {
+    "reserve": STATE_ACTIVE,
+    "activate": STATE_RESERVED,
+}
+
+# The state the ad ends up in once the action succeeded.
+_RESULTING_STATE:Final[dict[ReserveAction, str]] = {
+    "reserve": STATE_RESERVED,
+    "activate": STATE_ACTIVE,
+}
+
+
+async def set_reservation_state(
+    web:WebScrapingMixin,
+    root_url:str,
+    ad_cfgs:list[tuple[str, Ad, dict[str, Any]]],
+    *,
+    action:ReserveAction,
+) -> None:
+    """Reserves or activates the given ads.
+
+    Ads that are already in the target state are skipped rather than treated as
+    failures -- running the command twice must not report an error.
+    """
+    published_ads_list = await published_ads.fetch_published_ads(web, root_url)
+
+    ads_to_change:list[tuple[str, Ad, dict[str, Any]]] = []
+    for ad_file, ad_cfg, ad_cfg_orig in ad_cfgs:
+        if _is_applicable(ad_cfg, published_ads_list, action = action):
+            ads_to_change.append((ad_file, ad_cfg, ad_cfg_orig))
+
+    if not ads_to_change:
+        LOG.info("############################################")
+        if action == "reserve":
+            LOG.info("DONE: No ads to reserve.")
+        else:
+            LOG.info("DONE: No ads to activate.")
+        LOG.info("############################################")
+        return
+
+    success_count = 0
+    for idx, (ad_file, ad_cfg, _ad_cfg_orig) in enumerate(ads_to_change, start = 1):
+        LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ads_to_change), ad_cfg.title, ad_file)
+        if await _change_ad_state(web, root_url, ad_cfg, action = action):
+            success_count += 1
+        await web.web_sleep()
+
+    LOG.info("############################################")
+    if action == "reserve":
+        LOG.info("DONE: Reserved %s", pluralize("ad", success_count))
+    else:
+        LOG.info("DONE: Activated %s", pluralize("ad", success_count))
+    LOG.info("############################################")
+
+
+def _is_applicable(
+    ad_cfg:Ad,
+    published_ads_list:list[PublishedAd],
+    *,
+    action:ReserveAction,
+) -> bool:
+    """Whether the action can be applied to this ad, logging the reason if not."""
+    if ad_cfg.id is None:
+        LOG.info(" -> SKIPPED: ad '%s' is not published yet", ad_cfg.title)
+        return False
+
+    published_ad:PublishedAd | None = next(
+        (ad for ad in published_ads_list if ad_matches_id(ad, ad_cfg.id)), None
+    )
+    if not published_ad:
+        LOG.warning(" -> SKIPPED: ad '%s' (ID: %s) not found in published ads", ad_cfg.title, ad_cfg.id)
+        return False
+
+    current_state = published_ad.get("state")
+    if current_state == _REQUIRED_STATE[action]:
+        return True
+
+    if current_state == _RESULTING_STATE[action]:
+        # Already where the caller wants it -- not an error, just nothing to do.
+        LOG.info(" -> SKIPPED: ad '%s' is already in the requested state", ad_cfg.title)
+    else:
+        LOG.info(" -> SKIPPED: ad '%s' cannot be switched (state: %s)", ad_cfg.title, current_state)
+    return False
+
+
+async def _change_ad_state(
+    web:WebScrapingMixin,
+    root_url:str,
+    ad_cfg:Ad,
+    *,
+    action:ReserveAction,
+) -> bool:
+    """Clicks the reserve/activate button for a single ad in the manage-ads overview."""
+    if action == "reserve":
+        LOG.info("Reserving ad '%s' (ID: %s)...", ad_cfg.title, ad_cfg.id)
+    else:
+        LOG.info("Activating ad '%s' (ID: %s)...", ad_cfg.title, ad_cfg.id)
+
+    label = _BUTTON_LABELS[action]
+    button_xpath = f'//li[@data-adid="{ad_cfg.id}"]//button[contains(., "{label}")]'
+
+    async def find_and_click_button(page_num:int) -> bool:
+        try:
+            button = await web.web_find(By.XPATH, button_xpath, timeout = web.timeout("quick_dom"))
+            LOG.info("Found '%s' button on page %s", label, page_num)
+            await button.click()
+            return True
+        except TimeoutError:
+            LOG.debug("'%s' button not found on page %s", label, page_num)
+            return False
+
+    try:
+        success = await web.navigate_paginated_ad_overview(
+            find_and_click_button, page_url = f"{root_url}/m-meine-anzeigen.html"
+        )
+    except TimeoutError as ex:
+        LOG.error(" -> FAILED: Timeout while switching ad '%s': %s", ad_cfg.title, ex)
+        return False
+
+    if not success:
+        LOG.error(" -> FAILED: Could not find '%s' button for ad ID %s", label, ad_cfg.id)
+        return False
+
+    await _dismiss_confirmation_dialog(web)
+
+    if action == "reserve":
+        LOG.info(" -> SUCCESS: ad '%s' (ID: %s) is now reserved", ad_cfg.title, ad_cfg.id)
+    else:
+        LOG.info(" -> SUCCESS: ad '%s' (ID: %s) is now active", ad_cfg.title, ad_cfg.id)
+    return True
+
+
+async def _dismiss_confirmation_dialog(web:WebScrapingMixin) -> None:
+    """Closes the confirmation dialog if one appeared.
+
+    Its absence is not an error: the action may complete without a dialog, and
+    the state change has already been requested at this point either way.
+    """
+    try:
+        await web.web_click(
+            By.CSS_SELECTOR, 'button[aria-label="Schließen"]', timeout = web.timeout("quick_dom")
+        )
+        LOG.debug(" -> Closed confirmation dialog")
+    except TimeoutError:
+        LOG.debug(" -> No confirmation dialog found, action may have completed directly")

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -109,6 +109,12 @@ kleinanzeigen_bot/app.py:
     "Extending all ads within 8-day window...": "Verlängere alle Anzeigen innerhalb des 8-Tage-Zeitfensters..."
     "Invalid --ads selector: \"%s\". Valid values: all or comma-separated numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: all oder kommagetrennte numerische IDs."
 
+  _handle_reserve_or_activate:
+    "############################################": "############################################"
+    "DONE: No ads found to reserve.": "FERTIG: Keine Anzeigen zum Reservieren gefunden."
+    "DONE: No ads found to activate.": "FERTIG: Keine Anzeigen zum Aktivieren gefunden."
+    "Invalid --ads selector: \"%s\". Valid values: all or comma-separated numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: all oder kommagetrennte numerische IDs."
+
   _handle_download:
     "Invalid --ads selector: \"%s\". Valid values: comma-separated keywords (all, new) or numeric IDs.": "Ungültiger --ads-Selektor: \"%s\". Gültige Werte: kommagetrennte Schlüsselwörter (all, new) oder numerische IDs."
 
@@ -443,6 +449,35 @@ kleinanzeigen_bot/extend_flow.py:
 
   find_and_click_extend_button:
     "Found extend button on page %s": "'Verlängern'-Button auf Seite %s gefunden"
+
+#################################################
+kleinanzeigen_bot/reserve_flow.py:
+#################################################
+  set_reservation_state:
+    "############################################": "############################################"
+    "DONE: No ads to reserve.": "FERTIG: Keine Anzeigen zu reservieren."
+    "DONE: No ads to activate.": "FERTIG: Keine Anzeigen zu aktivieren."
+    "DONE: Reserved %s": "FERTIG: %s reserviert"
+    "DONE: Activated %s": "FERTIG: %s aktiviert"
+    "ad": "Anzeige"
+    "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' aus [%s]..."
+
+  _is_applicable:
+    " -> SKIPPED: ad '%s' is not published yet": " -> ÜBERSPRUNGEN: Anzeige '%s' ist noch nicht veröffentlicht"
+    " -> SKIPPED: ad '%s' (ID: %s) not found in published ads": " -> ÜBERSPRUNGEN: Anzeige '%s' (ID: %s) nicht gefunden"
+    " -> SKIPPED: ad '%s' is already in the requested state": " -> ÜBERSPRUNGEN: Anzeige '%s' ist bereits im gewünschten Zustand"
+    " -> SKIPPED: ad '%s' cannot be switched (state: %s)": " -> ÜBERSPRUNGEN: Anzeige '%s' kann nicht umgestellt werden (Status: %s)"
+
+  _change_ad_state:
+    "Reserving ad '%s' (ID: %s)...": "Reserviere Anzeige '%s' (ID: %s)..."
+    "Activating ad '%s' (ID: %s)...": "Aktiviere Anzeige '%s' (ID: %s)..."
+    " -> FAILED: Timeout while switching ad '%s': %s": " -> FEHLER: Zeitüberschreitung beim Umstellen der Anzeige '%s': %s"
+    " -> FAILED: Could not find '%s' button for ad ID %s": " -> FEHLER: '%s'-Button für Anzeigen-ID %s nicht gefunden"
+    " -> SUCCESS: ad '%s' (ID: %s) is now reserved": " -> ERFOLG: Anzeige '%s' (ID: %s) ist jetzt reserviert"
+    " -> SUCCESS: ad '%s' (ID: %s) is now active": " -> ERFOLG: Anzeige '%s' (ID: %s) ist jetzt aktiv"
+
+  find_and_click_button:
+    "Found '%s' button on page %s": "'%s'-Button auf Seite %s gefunden"
 
 #################################################
 kleinanzeigen_bot/download_flow.py:

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -473,6 +473,7 @@ kleinanzeigen_bot/reserve_flow.py:
     "Activating ad '%s' (ID: %s)...": "Aktiviere Anzeige '%s' (ID: %s)..."
     " -> FAILED: Timeout while switching ad '%s': %s": " -> FEHLER: Zeitüberschreitung beim Umstellen der Anzeige '%s': %s"
     " -> FAILED: Could not find '%s' button for ad ID %s": " -> FEHLER: '%s'-Button für Anzeigen-ID %s nicht gefunden"
+    " -> FAILED: Could not confirm state change for ad '%s' (ID: %s)": " -> FEHLER: Zustandsänderung für Anzeige '%s' (ID: %s) konnte nicht bestätigt werden"
     " -> SUCCESS: ad '%s' (ID: %s) is now reserved": " -> ERFOLG: Anzeige '%s' (ID: %s) ist jetzt reserviert"
     " -> SUCCESS: ad '%s' (ID: %s) is now active": " -> ERFOLG: Anzeige '%s' (ID: %s) ist jetzt aktiv"
 

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -473,7 +473,7 @@ kleinanzeigen_bot/reserve_flow.py:
     "Activating ad '%s' (ID: %s)...": "Aktiviere Anzeige '%s' (ID: %s)..."
     " -> FAILED: Timeout while switching ad '%s': %s": " -> FEHLER: Zeitüberschreitung beim Umstellen der Anzeige '%s': %s"
     " -> FAILED: Could not find '%s' button for ad ID %s": " -> FEHLER: '%s'-Button für Anzeigen-ID %s nicht gefunden"
-    " -> FAILED: Could not confirm state change for ad '%s' (ID: %s)": " -> FEHLER: Zustandsänderung für Anzeige '%s' (ID: %s) konnte nicht bestätigt werden"
+    " -> FAILED: Could not confirm state change for ad '%s' (ID: %s)": " -> FEHLER: Die Zustandsänderung für die Anzeige '%s' (ID: %s) konnte nicht bestätigt werden."
     " -> SUCCESS: ad '%s' (ID: %s) is now reserved": " -> ERFOLG: Anzeige '%s' (ID: %s) ist jetzt reserviert"
     " -> SUCCESS: ad '%s' (ID: %s) is now active": " -> ERFOLG: Anzeige '%s' (ID: %s) ist jetzt aktiv"
 

--- a/src/kleinanzeigen_bot/runtime_config.py
+++ b/src/kleinanzeigen_bot/runtime_config.py
@@ -37,6 +37,7 @@ VALID_COMMANDS:Final[frozenset[str]] = frozenset({
     "help", "version", "create-config", "diagnose", "verify",
     "update-check", "update-content-hash",
     "publish", "status", "update", "delete", "extend", "download",
+    "reserve", "activate",
 })
 
 

--- a/tests/unit/test_publishing_submission.py
+++ b/tests/unit/test_publishing_submission.py
@@ -143,7 +143,7 @@ class TestClickSubmitButton:
     async def test_raises_timeout_when_no_submit_button_found(self, test_bot:KleinanzeigenBot) -> None:
         """When web_execute returns False for all labels, TimeoutError is raised."""
 
-        async def await_side_effect(condition: Any, **__: Any) -> Any:
+        async def await_side_effect(condition:Any, **__:Any) -> Any:
             """Simulate web_await: call condition, raise TimeoutError if falsy."""
             result = await condition()
             if not result:

--- a/tests/unit/test_reserve_flow.py
+++ b/tests/unit/test_reserve_flow.py
@@ -14,6 +14,7 @@ import pytest
 from kleinanzeigen_bot import reserve_flow, runtime_config
 from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad
+from kleinanzeigen_bot.published_ads import PublishedAdsFetchIncompleteError
 from kleinanzeigen_bot.utils import xdg_paths
 
 
@@ -67,25 +68,45 @@ class TestReserveCommand:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("command", ["reserve", "activate"])
-    async def test_run_command_defaults_to_all_ads(self, test_bot:KleinanzeigenBot, tmp_path:Path, command:str) -> None:
+    async def test_run_command_defaults_to_all_ads(
+        self, test_bot:KleinanzeigenBot, tmp_path:Path, base_ad_config_with_id:dict[str, Any], command:str
+    ) -> None:
         patches = _patched_command_run(test_bot, tmp_path)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+        ads = [("test.yaml", ad_cfg, base_ad_config_with_id)]
+        with (
+            patches[0], patches[1], patches[2], patches[3], patches[4], patches[5],
+            patch.object(test_bot, "load_ads", return_value = ads),
+            patch.object(test_bot, "create_browser_session", new_callable = AsyncMock),
+            patch.object(test_bot, "login", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow.set_reservation_state", new_callable = AsyncMock) as mock_flow,
+        ):
             await test_bot.run(["script.py", command])
             assert test_bot.command == command
             assert test_bot.ads_selector == "all"
+            mock_flow.assert_awaited_once()
+            assert mock_flow.call_args.kwargs["action"] == command
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("command", ["reserve", "activate"])
-    async def test_run_command_with_specific_ids(self, test_bot:KleinanzeigenBot, tmp_path:Path, command:str) -> None:
+    async def test_run_command_with_specific_ids(
+        self, test_bot:KleinanzeigenBot, tmp_path:Path, base_ad_config_with_id:dict[str, Any], command:str
+    ) -> None:
         patches = _patched_command_run(test_bot, tmp_path)
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+        ads = [("test.yaml", ad_cfg, base_ad_config_with_id)]
         with (
             patches[0], patches[1], patches[2], patches[3], patches[4], patches[5],
+            patch.object(test_bot, "load_ads", return_value = ads),
             patch.object(test_bot, "create_browser_session", new_callable = AsyncMock),
             patch.object(test_bot, "login", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow.set_reservation_state", new_callable = AsyncMock) as mock_flow,
         ):
             await test_bot.run(["script.py", command, "--ads=12345,67890"])
             assert test_bot.command == command
             assert test_bot.ads_selector == "12345,67890"
+            mock_flow.assert_awaited_once()
+            assert mock_flow.call_args.kwargs["action"] == command
 
 
 class TestSetReservationState:
@@ -279,6 +300,11 @@ class TestChangeAdState:
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+            patch(
+                "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
+                new_callable = AsyncMock,
+                return_value = [{"id": 12345, "state": reserve_flow._RESULTING_STATE[action]}],  # noqa: SLF001
+            ),
         ):
             mock_find.return_value = button
 
@@ -314,6 +340,11 @@ class TestChangeAdState:
             patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = [TimeoutError, button]),
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+            patch(
+                "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
+                new_callable = AsyncMock,
+                return_value = [{"id": 12345, "state": reserve_flow.STATE_RESERVED}],
+            ),
         ):
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
                 test_bot, test_bot.root_url, ad_cfg, action = "reserve",
@@ -371,9 +402,70 @@ class TestChangeAdState:
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
             patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
             patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+            patch(
+                "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
+                new_callable = AsyncMock,
+                return_value = [{"id": 12345, "state": reserve_flow.STATE_RESERVED}],
+            ),
         ):
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
                 test_bot, test_bot.root_url, ad_cfg, action = "reserve",
             )
 
             assert result is True
+
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_resulting_state_is_not_confirmed(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
+    ) -> None:
+        """A button click alone must not be reported as a successful state change."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+        button = MagicMock()
+        button.click = AsyncMock()
+
+        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            return await callback(1)
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+            patch(
+                "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
+                new_callable = AsyncMock,
+                return_value = [{"id": 12345, "state": reserve_flow.STATE_ACTIVE}],
+            ),
+        ):
+            result = await reserve_flow._change_ad_state(  # noqa: SLF001
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+            )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_state_verification_is_incomplete(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
+    ) -> None:
+        """An incomplete verification response must fail only this ad, not abort the batch."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+        button = MagicMock()
+        button.click = AsyncMock()
+
+        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            return await callback(1)
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+            patch(
+                "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
+                new_callable = AsyncMock,
+                side_effect = PublishedAdsFetchIncompleteError("incomplete response"),
+            ),
+        ):
+            result = await reserve_flow._change_ad_state(  # noqa: SLF001
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+            )
+
+        assert result is False

--- a/tests/unit/test_reserve_flow.py
+++ b/tests/unit/test_reserve_flow.py
@@ -469,3 +469,31 @@ class TestChangeAdState:
             )
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_state_verification_times_out(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
+    ) -> None:
+        """A verification timeout must fail only the current ad."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+        button = MagicMock()
+        button.click = AsyncMock()
+
+        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            return await callback(1)
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+            patch(
+                "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
+                new_callable = AsyncMock,
+                side_effect = TimeoutError("verification timed out"),
+            ),
+        ):
+            result = await reserve_flow._change_ad_state(  # noqa: SLF001
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+            )
+
+        assert result is False

--- a/tests/unit/test_reserve_flow.py
+++ b/tests/unit/test_reserve_flow.py
@@ -1,0 +1,379 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Tests for the reserve/activate commands and the reserve_flow module."""
+
+import json
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kleinanzeigen_bot import reserve_flow, runtime_config
+from kleinanzeigen_bot.app import KleinanzeigenBot
+from kleinanzeigen_bot.model.ad_model import Ad
+from kleinanzeigen_bot.utils import xdg_paths
+
+
+@pytest.fixture
+def base_ad_config_with_id() -> dict[str, Any]:
+    """Provide a base ad configuration with an ID for reserve tests."""
+    return {
+        "id": 12345,
+        "title": "Test Ad Title",
+        "description": "Test Description",
+        "type": "OFFER",
+        "price_type": "FIXED",
+        "price": 100,
+        "shipping_type": "SHIPPING",
+        "shipping_options": [],
+        "category": "160",
+        "special_attributes": {},
+        "sell_directly": False,
+        "images": [],
+        "active": True,
+        "republication_interval": 7,
+        "created_on": "2024-12-07T10:00:00",
+        "updated_on": "2024-12-10T15:20:00",
+        "contact": {"name": "Test User", "zipcode": "12345", "location": "Test City", "street": "", "phone": ""},
+    }
+
+
+def _published(state:str, ad_id:int = 12345) -> dict[str, Any]:
+    return {"ads": [{"id": ad_id, "title": "Test Ad Title", "state": state}]}
+
+
+def _patched_command_run(test_bot:KleinanzeigenBot, tmp_path:Path) -> Any:
+    """Patch set that lets ``run()`` reach the command handler without a browser."""
+    test_bot.config_file_path = str(tmp_path / "config.yaml")
+    workspace = xdg_paths.Workspace.for_config(tmp_path / "config.yaml", "kleinanzeigen-bot")
+    return (
+        patch("kleinanzeigen_bot.runtime_config.resolve_workspace", return_value = workspace),
+        patch(
+            "kleinanzeigen_bot.runtime_config.load_config",
+            return_value = runtime_config.RuntimeState(config = test_bot.config, categories = {}, timing_collector = None),
+        ),
+        patch("kleinanzeigen_bot.runtime_config.configure_file_logging", return_value = None),
+        patch("kleinanzeigen_bot.runtime_config.apply_browser_config"),
+        patch.object(test_bot, "load_ads", return_value = []),
+        patch("kleinanzeigen_bot.update_checker.UpdateChecker"),
+    )
+
+
+class TestReserveCommand:
+    """Tests for wiring the reserve/activate commands into the CLI."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["reserve", "activate"])
+    async def test_run_command_defaults_to_all_ads(self, test_bot:KleinanzeigenBot, tmp_path:Path, command:str) -> None:
+        patches = _patched_command_run(test_bot, tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            await test_bot.run(["script.py", command])
+            assert test_bot.command == command
+            assert test_bot.ads_selector == "all"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["reserve", "activate"])
+    async def test_run_command_with_specific_ids(self, test_bot:KleinanzeigenBot, tmp_path:Path, command:str) -> None:
+        patches = _patched_command_run(test_bot, tmp_path)
+        with (
+            patches[0], patches[1], patches[2], patches[3], patches[4], patches[5],
+            patch.object(test_bot, "create_browser_session", new_callable = AsyncMock),
+            patch.object(test_bot, "login", new_callable = AsyncMock),
+        ):
+            await test_bot.run(["script.py", command, "--ads=12345,67890"])
+            assert test_bot.command == command
+            assert test_bot.ads_selector == "12345,67890"
+
+
+class TestSetReservationState:
+    """Tests for the set_reservation_state() method."""
+
+    @pytest.mark.asyncio
+    async def test_skips_unpublished_ad(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
+        """An ad without an ID was never published — there is nothing to reserve."""
+        ad_config = base_ad_config_with_id.copy()
+        ad_config["id"] = None
+        ad_cfg = Ad.model_validate(ad_config)
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow._change_ad_state", new_callable = AsyncMock) as mock_change,
+        ):
+            mock_request.return_value = {"content": '{"ads": []}'}
+
+            await reserve_flow.set_reservation_state(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfgs = [("test.yaml", ad_cfg, ad_config)], action = "reserve",
+            )
+
+            mock_change.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_ad_not_in_published_list(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
+        """An ad the account does not list cannot be switched — no blind request."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow._change_ad_state", new_callable = AsyncMock) as mock_change,
+        ):
+            mock_request.return_value = {"content": '{"ads": []}'}
+
+            await reserve_flow.set_reservation_state(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfgs = [("test.yaml", ad_cfg, base_ad_config_with_id)], action = "reserve",
+            )
+
+            mock_change.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reserve_skips_already_reserved_ad(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
+        """Running reserve twice must be a no-op, not a failure."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow._change_ad_state", new_callable = AsyncMock) as mock_change,
+        ):
+            mock_request.return_value = {"content": json.dumps(_published(reserve_flow.STATE_RESERVED))}
+
+            await reserve_flow.set_reservation_state(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfgs = [("test.yaml", ad_cfg, base_ad_config_with_id)], action = "reserve",
+            )
+
+            mock_change.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_activate_skips_already_active_ad(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow._change_ad_state", new_callable = AsyncMock) as mock_change,
+        ):
+            mock_request.return_value = {"content": json.dumps(_published(reserve_flow.STATE_ACTIVE))}
+
+            await reserve_flow.set_reservation_state(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfgs = [("test.yaml", ad_cfg, base_ad_config_with_id)], action = "activate",
+            )
+
+            mock_change.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reserve_switches_active_ad(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow._change_ad_state", new_callable = AsyncMock) as mock_change,
+        ):
+            mock_request.return_value = {"content": json.dumps(_published(reserve_flow.STATE_ACTIVE))}
+            mock_change.return_value = True
+
+            await reserve_flow.set_reservation_state(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfgs = [("test.yaml", ad_cfg, base_ad_config_with_id)], action = "reserve",
+            )
+
+            mock_change.assert_called_once()
+            assert mock_change.call_args.kwargs["action"] == "reserve"
+
+    @pytest.mark.asyncio
+    async def test_activate_switches_reserved_ad(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow._change_ad_state", new_callable = AsyncMock) as mock_change,
+        ):
+            mock_request.return_value = {"content": json.dumps(_published(reserve_flow.STATE_RESERVED))}
+            mock_change.return_value = True
+
+            await reserve_flow.set_reservation_state(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfgs = [("test.yaml", ad_cfg, base_ad_config_with_id)], action = "activate",
+            )
+
+            mock_change.assert_called_once()
+            assert mock_change.call_args.kwargs["action"] == "activate"
+
+    @pytest.mark.asyncio
+    async def test_skips_ad_in_unrelated_state(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
+        """A state that is neither active nor paused (e.g. expired) is left alone."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow._change_ad_state", new_callable = AsyncMock) as mock_change,
+        ):
+            mock_request.return_value = {"content": json.dumps(_published("expired"))}
+
+            await reserve_flow.set_reservation_state(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfgs = [("test.yaml", ad_cfg, base_ad_config_with_id)], action = "reserve",
+            )
+
+            mock_change.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_ad_does_not_stop_the_remaining_ads(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
+    ) -> None:
+        """One ad failing must neither abort the run nor be counted as switched."""
+        first_cfg = Ad.model_validate(base_ad_config_with_id)
+        second_config = base_ad_config_with_id | {"id": 67890}
+        second_cfg = Ad.model_validate(second_config)
+        published = {"ads": [
+            {"id": 12345, "title": "Test Ad Title", "state": reserve_flow.STATE_ACTIVE},
+            {"id": 67890, "title": "Test Ad Title", "state": reserve_flow.STATE_ACTIVE},
+        ]}
+
+        with (
+            patch.object(test_bot, "web_request", new_callable = AsyncMock) as mock_request,
+            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
+            patch("kleinanzeigen_bot.reserve_flow._change_ad_state", new_callable = AsyncMock) as mock_change,
+        ):
+            mock_request.return_value = {"content": json.dumps(published)}
+            mock_change.side_effect = [False, True]
+
+            await reserve_flow.set_reservation_state(
+                web = test_bot, root_url = test_bot.root_url,
+                ad_cfgs = [("first.yaml", first_cfg, base_ad_config_with_id), ("second.yaml", second_cfg, second_config)],
+                action = "reserve",
+            )
+
+            # The second ad is still attempted even though the first one failed.
+            assert mock_change.await_count == 2
+
+
+class TestChangeAdState:
+    """Tests for the single-ad browser interaction."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("action", "label"), [("reserve", "Reservieren"), ("activate", "Aktivieren")])
+    async def test_clicks_button_of_matching_row(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any],
+        action:reserve_flow.ReserveAction, label:str,
+    ) -> None:
+        """The XPath must address the ad's own row, so a neighbouring ad is never hit."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+        button = MagicMock()
+        button.click = AsyncMock()
+
+        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            return await callback(1)
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+        ):
+            mock_find.return_value = button
+
+            result = await reserve_flow._change_ad_state(  # noqa: SLF001
+                test_bot, test_bot.root_url, ad_cfg, action = action,
+            )
+
+            assert result is True
+            button.click.assert_awaited_once()
+            xpath = mock_find.call_args.args[1]
+            assert '@data-adid="12345"' in xpath
+            assert label in xpath
+
+    @pytest.mark.asyncio
+    async def test_button_missing_on_page_continues_pagination(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
+    ) -> None:
+        """The ad may sit on a later page, so a miss must not abort the search."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+        button = MagicMock()
+        button.click = AsyncMock()
+        visited_pages:list[int] = []
+
+        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            for page_num in (1, 2):
+                visited_pages.append(page_num)
+                if await callback(page_num):
+                    return True
+            return False
+
+        with (
+            # Page 1 has no matching row, page 2 does.
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = [TimeoutError, button]),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock),
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+        ):
+            result = await reserve_flow._change_ad_state(  # noqa: SLF001
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+            )
+
+            assert result is True
+            assert visited_pages == [1, 2]
+            button.click.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_navigation_timeout_is_reported_as_failure(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
+    ) -> None:
+        """A timeout while loading the overview must be caught, not propagated to the caller."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+
+        with patch.object(
+            test_bot, "navigate_paginated_ad_overview", new_callable = AsyncMock, side_effect = TimeoutError("overview did not load")
+        ):
+            result = await reserve_flow._change_ad_state(  # noqa: SLF001
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_button_absent(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
+    ) -> None:
+        """A missing button means the state did not change — that must not read as success."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+
+        with patch.object(test_bot, "navigate_paginated_ad_overview", new_callable = AsyncMock) as mock_nav:
+            mock_nav.return_value = False
+
+            result = await reserve_flow._change_ad_state(  # noqa: SLF001
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_missing_confirmation_dialog_is_not_a_failure(
+        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
+    ) -> None:
+        """The click already requested the change; no dialog is not an error."""
+        ad_cfg = Ad.model_validate(base_ad_config_with_id)
+        button = MagicMock()
+        button.click = AsyncMock()
+
+        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            return await callback(1)
+
+        with (
+            patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
+            patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
+        ):
+            result = await reserve_flow._change_ad_state(  # noqa: SLF001
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+            )
+
+            assert result is True


### PR DESCRIPTION
## ℹ️ Description

Adds two new CLI commands, `reserve` and `activate`, that toggle an ad's reserved state on kleinanzeigen.de.

- Link to the related issue(s): Issue # — none; opening this directly as a small, self-contained feature. Happy to file one first if you prefer that order.
- Motivation and context:

  Reserving takes an ad out of circulation without ending the sale. The bot **already understands** this state: `publishing_workflow` skips ads whose API state is `paused` and logs `"Skipping because ad is reserved"`, and `download_flow`/`download_selection` map the same state onto `active: false`. What was missing was any way to *set* or *clear* it, so that one step had to be done by hand in the browser while the rest of the ad lifecycle stayed automated.

  Deleting and re-publishing is not a workaround: it loses the ad ID, its age, its view count and every watcher/saver — precisely what the `extend` command was added to protect.

  Typical use: a buyer commits, you `reserve` the ad while the handover is arranged, and `activate` it again if the deal falls through — without ever touching the ad's identity or its history.

## 📋 Changes Summary

- **New module `reserve_flow.py`**, closely modelled on `extend_flow.py`. The `Reservieren` / `Aktivieren` buttons sit in the same `<li data-adid="...">` row of the manage-ads overview that the extend flow already targets, so `navigate_paginated_ad_overview()` does the work — no new navigation, pagination or session handling was needed.
- **New commands `reserve` and `activate`** wired into `runtime_config.VALID_COMMANDS` and dispatched in `app.py` via a shared `_handle_reserve_or_activate()` handler, so both commands share selector validation, login and ad loading.
- **`--ads=all|<id(s)>` support** for both commands, defaulting to `all`, matching the `extend` command's behaviour and validation.
- **State-aware, idempotent behaviour**, derived from the manage-ads JSON API before any click:
  - ad already in the requested state → skipped, not failed (running either command twice is a no-op);
  - ad in an unrelated state (e.g. expired) → left alone rather than clicked blindly;
  - unpublished ad or ad missing from the published list → skipped with a clear reason.
- **German translations** added to `resources/translations.de.yaml` for all new user-facing log messages.
- **README Usage block regenerated** via `pdm run generate-readme-commands`, since it is derived from `cli.help_text` and verified by `scripts/check_generated_artifacts.py`.
- **New unit tests** in `tests/unit/test_reserve_flow.py` (18 tests) covering command wiring, every skip/state case, both success paths, and the browser failure paths.

Notes on scope and design:

- **Nothing is persisted to the ad YAML.** The reserved state lives on the platform, and the existing `ad.active` field is a separate *local publishing* flag — conflating the two would change existing behaviour, so this PR deliberately does not touch it.
- Browser failure paths follow the repo rules: `TimeoutError` is caught around both the button lookup and the overview navigation, and a missing button is reported as a failure rather than silently counted as success. A missing confirmation dialog is *not* treated as an error, since the state change has already been requested at that point.
- No new dependencies, no config keys, no schema changes, no new timeout keys — `timeouts.quick_dom` is reused for the transient overlay, as `CONTRIBUTING.md` prescribes.

### ⚙️ Type of Change
Select the type(s) of change(s) included in this pull request:
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)


## ✅ Checklist
Before requesting a review, confirm the following:
- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass  (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary.

Verification run locally on macOS (arm64), Python 3.13:

- `pdm run format` — clean
- `pdm run lint` — ruff, mypy, pyright, actionlint all pass (`0 errors, 0 warnings`)
- `pdm run test` — `1570 passed, 5 skipped`; `reserve_flow.py` at 100% statement and branch coverage
- `pdm run python scripts/check_generated_artifacts.py` — schemas, `docs/config.default.yaml` and `README.md` up-to-date

No test touches kleinanzeigen.de; all browser and API interaction is mocked. The flow itself was exercised manually against a real account before this PR, but no automated test performs a real login or state change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `reserve` and `activate` commands to remove ads from search results or restore them.
  * Added `--ads=all|<id(s)>` to target all ads or selected ads.
  * Ads already in the requested state are skipped automatically.
  * Reserved ads retain details such as their ID, age, views, and watchers.
  * Reservation changes are verified and reported for each ad.

* **Documentation**
  * Updated English and German help text and usage documentation with the new commands and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->