### PR TITLE
fix: fall back to shippingHeader island prop when legacy shipping element is absent (#1256)

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -1135,7 +1135,7 @@ class AdExtractor(WebScrapingMixin):
             return header.strip()
         return None
 
-    async def _extract_shipping_info_from_ad_page(self, *, island_props: dict[str, Any] | None = None) -> tuple[str, float | None, list[str] | None]:
+    async def _extract_shipping_info_from_ad_page(self, *, island_props:dict[str, Any] | None = None) -> tuple[str, float | None, list[str] | None]:
         """
         Extracts shipping information from an ad page.
 
@@ -1151,8 +1151,8 @@ class AdExtractor(WebScrapingMixin):
         ship_type, ship_costs, shipping_options = "NOT_APPLICABLE", None, None
         try:
             shipping_text = await self._extract_shipping_text_from_dom()
-            if shipping_text is None:
-                # Redesigned layout: legacy shipping element is absent.
+            if not shipping_text:
+                # Redesigned layout: legacy shipping element is absent or empty.
                 # Fall back to the shippingHeader Astro island prop, which
                 # carries the same wording as the legacy element.
                 shipping_text = self._shipping_text_from_island_props(island_props)

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -869,7 +869,7 @@ class AdExtractor(WebScrapingMixin):
             # change f to  'nein' and 't' to 'ja'
             info["special_attributes"]["schaden_s"] = info["special_attributes"]["schaden_s"].translate(str.maketrans({"t": "ja", "f": "nein"}))
         info["price"], info["price_type"] = await self._extract_pricing_info_from_ad_page()
-        info["shipping_type"], info["shipping_costs"], info["shipping_options"] = await self._extract_shipping_info_from_ad_page()
+        info["shipping_type"], info["shipping_costs"], info["shipping_options"] = await self._extract_shipping_info_from_ad_page(island_props = island_props)
         info["sell_directly"] = await self._extract_sell_directly_from_ad_page()
         info["images"] = await self._download_images_from_ad_page(directory, ad_file_stem, island_props = island_props)
         info["contact"] = await self._extract_contact_from_ad_page(island_props = island_props)
@@ -1119,15 +1119,46 @@ class AdExtractor(WebScrapingMixin):
         except TimeoutError:  # no 'commercial' ad, has no pricing box etc.
             return None, "NOT_APPLICABLE"
 
-    async def _extract_shipping_info_from_ad_page(self) -> tuple[str, float | None, list[str] | None]:
+    async def _extract_shipping_text_from_dom(self) -> str | None:
+        """Return the legacy shipping wording element, or ``None`` if it is absent."""
+        try:
+            return await self.web_text(By.CLASS_NAME, "boxedarticle--details--shipping")
+        except TimeoutError:
+            return None
+
+    def _shipping_text_from_island_props(self, island_props:dict[str, Any] | None) -> str | None:
+        """Return the shipping wording from the ``shippingHeader`` island prop, if present."""
+        if not island_props:
+            return None
+        header = self._unwrap_island_value(island_props.get("shippingHeader"))
+        if isinstance(header, str) and header.strip():
+            return header.strip()
+        return None
+
+    async def _extract_shipping_info_from_ad_page(self, *, island_props: dict[str, Any] | None = None) -> tuple[str, float | None, list[str] | None]:
         """
         Extracts shipping information from an ad page.
 
-        :return: the shipping type, and the shipping price (optional)
+        On the redesigned (Astro) layout the legacy shipping element
+        (``boxedarticle--details--shipping``) is absent on owned ads. In that
+        case the ``shippingHeader`` island prop is used as a fallback — it
+        carries the same display text (e.g. ``+ Versand ab 5,49 €`` or
+        ``Nur Abholung``).
+
+        :param island_props: optional Astro island props from the redesigned layout
+        :return: the shipping type, the shipping price (optional), and the matching shipping options (optional)
         """
         ship_type, ship_costs, shipping_options = "NOT_APPLICABLE", None, None
         try:
-            shipping_text = await self.web_text(By.CLASS_NAME, "boxedarticle--details--shipping")
+            shipping_text = await self._extract_shipping_text_from_dom()
+            if shipping_text is None:
+                # Redesigned layout: legacy shipping element is absent.
+                # Fall back to the shippingHeader Astro island prop, which
+                # carries the same wording as the legacy element.
+                shipping_text = self._shipping_text_from_island_props(island_props)
+                if shipping_text is None:  # no shipping info anywhere
+                    raise TimeoutError
+                LOG.debug("Falling back to shippingHeader island prop: %s", shipping_text)
             # e.g. '+ Versand ab 5,49 €' OR 'Nur Abholung'
             if shipping_text == "Nur Abholung":
                 ship_type = "PICKUP"

--- a/tests/fixtures/astro_ad_props_pickup.json
+++ b/tests/fixtures/astro_ad_props_pickup.json
@@ -1,0 +1,347 @@
+{
+  "shippingHeader": [
+    0,
+    "Nur Abholung"
+  ],
+  "title": [
+    0,
+    "Sample ad with pickup only"
+  ],
+  "ogTitle": [
+    0,
+    "Sample ad with pickup only"
+  ],
+  "price": [
+    0,
+    {
+      "amount": [
+        0,
+        120
+      ],
+      "type": [
+        0,
+        "NEGOTIABLE"
+      ]
+    }
+  ],
+  "basePrice": [
+    0,
+    null
+  ],
+  "priceEnabled": [
+    0,
+    true
+  ],
+  "startingPrice": [
+    0,
+    null
+  ],
+  "adStatus": [
+    0,
+    {
+      "mobileAd": [
+        0,
+        false
+      ],
+      "mobileDeAd": [
+        0,
+        false
+      ],
+      "realEstateAd": [
+        0,
+        false
+      ],
+      "jobOffer": [
+        0,
+        false
+      ],
+      "newConstructionsAd": [
+        0,
+        false
+      ],
+      "newConstructionsProjectAd": [
+        0,
+        false
+      ],
+      "newConstructionsUnitAd": [
+        0,
+        false
+      ],
+      "viewable": [
+        0,
+        true
+      ],
+      "paused": [
+        0,
+        false
+      ],
+      "pendingAd": [
+        0,
+        false
+      ],
+      "expiredAd": [
+        0,
+        false
+      ],
+      "deletedOrExpiredAd": [
+        0,
+        false
+      ],
+      "preview": [
+        0,
+        false
+      ],
+      "onWatchlist": [
+        0,
+        false
+      ],
+      "featured": [
+        0,
+        false
+      ],
+      "featureTopAd": [
+        0,
+        false
+      ],
+      "featureHpGallery": [
+        0,
+        false
+      ],
+      "featureHighlight": [
+        0,
+        false
+      ],
+      "featureMultiBumpUp": [
+        0,
+        false
+      ],
+      "featureArtificialPhoneNumber": [
+        0,
+        false
+      ]
+    }
+  ],
+  "adType": [
+    0,
+    "OFFER"
+  ],
+  "formattedCreationDate": [
+    0,
+    "25.08.2026"
+  ],
+  "sortingDate": [
+    0,
+    1787640276000
+  ],
+  "adLifeTimeInSeconds": [
+    0,
+    1059890
+  ],
+  "breadcrumbPosition": [
+    0,
+    "ABOVE_IMAGE_GALLERY"
+  ],
+  "id": [
+    0,
+    "9999999902"
+  ],
+  "mobileDeAdId": [
+    0,
+    ""
+  ],
+  "buyNowPossible": [
+    0,
+    false
+  ],
+  "offerPossible": [
+    0,
+    false
+  ],
+  "priceLabelMessageKey": [
+    0,
+    "price.defaultLabel"
+  ],
+  "securePayment": [
+    0,
+    true
+  ],
+  "visibleComponents": [
+    0,
+    {
+      "displayMap": [
+        0,
+        false
+      ],
+      "showUserInventoryLink": [
+        0,
+        true
+      ],
+      "showPostersOtherAds": [
+        0,
+        true
+      ],
+      "separatedBeforePostersOtherAds": [
+        0,
+        true
+      ],
+      "showSecureOverlay": [
+        0,
+        false
+      ],
+      "showDogsWarningOverlay": [
+        0,
+        false
+      ],
+      "showCatsWarningOverlay": [
+        0,
+        false
+      ],
+      "showPublicTransportationWarningOverlay": [
+        0,
+        false
+      ],
+      "openFlagWindow": [
+        0,
+        false
+      ],
+      "showLoadingBar": [
+        0,
+        false
+      ],
+      "showPetContract": [
+        0,
+        false
+      ],
+      "useEnhancedAdDescription": [
+        0,
+        false
+      ],
+      "displayAdBackwardsCompatible": [
+        0,
+        false
+      ],
+      "descriptionClamped": [
+        0,
+        false
+      ],
+      "sidebarSticky": [
+        0,
+        false
+      ],
+      "offerBookProBanner": [
+        0,
+        false
+      ]
+    }
+  ],
+  "sectionHeaders": [
+    0,
+    {
+      "CONTACT_POSTER": [
+        0,
+        "Nachricht schreiben"
+      ],
+      "CUSTOMER_INFORMATION": [
+        0,
+        "Verbraucherinformationen"
+      ],
+      "DESCRIPTION": [
+        0,
+        "Beschreibung"
+      ],
+      "DOCUMENTS": [
+        0,
+        "Weitere Informationen"
+      ],
+      "IMPRINT": [
+        0,
+        "Rechtliche Angaben"
+      ],
+      "MAP": [
+        0,
+        "Standort"
+      ],
+      "PRODUCT_SAFETY": [
+        0,
+        "Produktsicherheit"
+      ],
+      "RADIUS_MAP": [
+        0,
+        "Anzeige mit erweitertem Umkreis"
+      ]
+    }
+  ],
+  "sectionOrder": [
+    1,
+    [
+      [
+        0,
+        "MAIN_INFO"
+      ],
+      [
+        0,
+        "ADVERTISING_SLOT_BELLY"
+      ],
+      [
+        0,
+        "PET_CONTRACT"
+      ],
+      [
+        0,
+        "ATTRIBUTES"
+      ],
+      [
+        0,
+        "TAGS"
+      ],
+      [
+        0,
+        "DOCUMENTS"
+      ],
+      [
+        0,
+        "MAP"
+      ],
+      [
+        0,
+        "DESCRIPTION"
+      ],
+      [
+        0,
+        "MORTGAGE_SIMULATOR"
+      ],
+      [
+        0,
+        "RADIUS_MAP"
+      ],
+      [
+        0,
+        "IMPRINT"
+      ],
+      [
+        0,
+        "PRODUCT_SAFETY"
+      ],
+      [
+        0,
+        "CAR_FINANCING"
+      ],
+      [
+        0,
+        "CUSTOMER_INFORMATION"
+      ],
+      [
+        0,
+        "CONTACT_POSTER"
+      ]
+    ]
+  ],
+  "tags": [
+    1,
+    []
+  ],
+  "dmhSource": [
+    0,
+    null
+  ]
+}

--- a/tests/fixtures/astro_ad_props_shipping.json
+++ b/tests/fixtures/astro_ad_props_shipping.json
@@ -1,0 +1,347 @@
+{
+  "shippingHeader": [
+    0,
+    "+ Versand ab 0,99 €"
+  ],
+  "title": [
+    0,
+    "Sample ad with shipping"
+  ],
+  "ogTitle": [
+    0,
+    "Sample ad with shipping"
+  ],
+  "price": [
+    0,
+    {
+      "amount": [
+        0,
+        120
+      ],
+      "type": [
+        0,
+        "NEGOTIABLE"
+      ]
+    }
+  ],
+  "basePrice": [
+    0,
+    null
+  ],
+  "priceEnabled": [
+    0,
+    true
+  ],
+  "startingPrice": [
+    0,
+    null
+  ],
+  "adStatus": [
+    0,
+    {
+      "mobileAd": [
+        0,
+        false
+      ],
+      "mobileDeAd": [
+        0,
+        false
+      ],
+      "realEstateAd": [
+        0,
+        false
+      ],
+      "jobOffer": [
+        0,
+        false
+      ],
+      "newConstructionsAd": [
+        0,
+        false
+      ],
+      "newConstructionsProjectAd": [
+        0,
+        false
+      ],
+      "newConstructionsUnitAd": [
+        0,
+        false
+      ],
+      "viewable": [
+        0,
+        true
+      ],
+      "paused": [
+        0,
+        false
+      ],
+      "pendingAd": [
+        0,
+        false
+      ],
+      "expiredAd": [
+        0,
+        false
+      ],
+      "deletedOrExpiredAd": [
+        0,
+        false
+      ],
+      "preview": [
+        0,
+        false
+      ],
+      "onWatchlist": [
+        0,
+        false
+      ],
+      "featured": [
+        0,
+        false
+      ],
+      "featureTopAd": [
+        0,
+        false
+      ],
+      "featureHpGallery": [
+        0,
+        false
+      ],
+      "featureHighlight": [
+        0,
+        false
+      ],
+      "featureMultiBumpUp": [
+        0,
+        false
+      ],
+      "featureArtificialPhoneNumber": [
+        0,
+        false
+      ]
+    }
+  ],
+  "adType": [
+    0,
+    "OFFER"
+  ],
+  "formattedCreationDate": [
+    0,
+    "25.08.2026"
+  ],
+  "sortingDate": [
+    0,
+    1787689416000
+  ],
+  "adLifeTimeInSeconds": [
+    0,
+    1010807
+  ],
+  "breadcrumbPosition": [
+    0,
+    "ABOVE_IMAGE_GALLERY"
+  ],
+  "id": [
+    0,
+    "9999999901"
+  ],
+  "mobileDeAdId": [
+    0,
+    ""
+  ],
+  "buyNowPossible": [
+    0,
+    true
+  ],
+  "offerPossible": [
+    0,
+    true
+  ],
+  "priceLabelMessageKey": [
+    0,
+    "price.defaultLabel"
+  ],
+  "securePayment": [
+    0,
+    true
+  ],
+  "visibleComponents": [
+    0,
+    {
+      "displayMap": [
+        0,
+        false
+      ],
+      "showUserInventoryLink": [
+        0,
+        true
+      ],
+      "showPostersOtherAds": [
+        0,
+        true
+      ],
+      "separatedBeforePostersOtherAds": [
+        0,
+        true
+      ],
+      "showSecureOverlay": [
+        0,
+        false
+      ],
+      "showDogsWarningOverlay": [
+        0,
+        false
+      ],
+      "showCatsWarningOverlay": [
+        0,
+        false
+      ],
+      "showPublicTransportationWarningOverlay": [
+        0,
+        false
+      ],
+      "openFlagWindow": [
+        0,
+        false
+      ],
+      "showLoadingBar": [
+        0,
+        false
+      ],
+      "showPetContract": [
+        0,
+        false
+      ],
+      "useEnhancedAdDescription": [
+        0,
+        false
+      ],
+      "displayAdBackwardsCompatible": [
+        0,
+        false
+      ],
+      "descriptionClamped": [
+        0,
+        false
+      ],
+      "sidebarSticky": [
+        0,
+        false
+      ],
+      "offerBookProBanner": [
+        0,
+        false
+      ]
+    }
+  ],
+  "sectionHeaders": [
+    0,
+    {
+      "CONTACT_POSTER": [
+        0,
+        "Nachricht schreiben"
+      ],
+      "CUSTOMER_INFORMATION": [
+        0,
+        "Verbraucherinformationen"
+      ],
+      "DESCRIPTION": [
+        0,
+        "Beschreibung"
+      ],
+      "DOCUMENTS": [
+        0,
+        "Weitere Informationen"
+      ],
+      "IMPRINT": [
+        0,
+        "Rechtliche Angaben"
+      ],
+      "MAP": [
+        0,
+        "Standort"
+      ],
+      "PRODUCT_SAFETY": [
+        0,
+        "Produktsicherheit"
+      ],
+      "RADIUS_MAP": [
+        0,
+        "Anzeige mit erweitertem Umkreis"
+      ]
+    }
+  ],
+  "sectionOrder": [
+    1,
+    [
+      [
+        0,
+        "MAIN_INFO"
+      ],
+      [
+        0,
+        "ADVERTISING_SLOT_BELLY"
+      ],
+      [
+        0,
+        "PET_CONTRACT"
+      ],
+      [
+        0,
+        "ATTRIBUTES"
+      ],
+      [
+        0,
+        "TAGS"
+      ],
+      [
+        0,
+        "DOCUMENTS"
+      ],
+      [
+        0,
+        "MAP"
+      ],
+      [
+        0,
+        "DESCRIPTION"
+      ],
+      [
+        0,
+        "MORTGAGE_SIMULATOR"
+      ],
+      [
+        0,
+        "RADIUS_MAP"
+      ],
+      [
+        0,
+        "IMPRINT"
+      ],
+      [
+        0,
+        "PRODUCT_SAFETY"
+      ],
+      [
+        0,
+        "CAR_FINANCING"
+      ],
+      [
+        0,
+        "CUSTOMER_INFORMATION"
+      ],
+      [
+        0,
+        "CONTACT_POSTER"
+      ]
+    ]
+  ],
+  "tags": [
+    1,
+    []
+  ],
+  "dmhSource": [
+    0,
+    null
+  ]
+}

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -28,6 +28,12 @@ def _read_text_file(path:Path) -> str:
     return path.read_text(encoding = "utf-8")
 
 
+def _load_astro_props_fixture(name:str) -> dict[str, Any]:
+    """Load a saved Astro island props fixture from ``tests/fixtures``."""
+    fixture_path = Path(__file__).resolve().parents[1] / "fixtures" / name
+    return json.loads(fixture_path.read_text(encoding = "utf-8"))
+
+
 def _create_test_ad_partial(**overrides:Any) -> AdPartial:
     """Create a valid AdPartial payload for extract staging/rollback tests."""
     payload:dict[str, Any] = {
@@ -286,6 +292,125 @@ class TestAdExtractorShipping:
                 assert options == [OPTION_NAME_BY_CARRIER_CODE["DHL_001"]]
             else:
                 assert options is None
+
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    async def test_extract_shipping_info_from_island_props_fallback(self, test_extractor:extract_module.AdExtractor) -> None:
+        """Shipping is extracted from the shippingHeader island prop when the legacy DOM element is absent."""
+        island_props:dict[str, Any] = {"shippingHeader": [0, "+ Versand ab 2,99 €"]}
+        shipping_response:dict[str, Any] = {
+            "content": json.dumps(
+                {
+                    "data": {
+                        "shippingOptionsResponse": {
+                            "options": [{"id": "DHL_001", "priceInEuroCent": 299, "packageSize": "SMALL"}]
+                        }
+                    }
+                }
+            )
+        }
+        with (
+            patch.object(test_extractor, "page", MagicMock()),
+            patch.object(test_extractor, "web_text", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_extractor, "web_request", new_callable = AsyncMock, return_value = shipping_response),
+        ):
+            shipping_type, costs, options = await test_extractor._extract_shipping_info_from_ad_page(island_props = island_props)
+
+            assert shipping_type == "SHIPPING"
+            assert costs == 2.99
+            assert options == [OPTION_NAME_BY_CARRIER_CODE["DHL_001"]]
+
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    @pytest.mark.parametrize(
+        ("header_text", "expected_type"),
+        [
+            ("Nur Abholung", "PICKUP"),
+            ("Versand möglich", "SHIPPING"),
+        ],
+    )
+    async def test_extract_shipping_type_from_island_props_fallback_without_costs(
+        self, test_extractor:extract_module.AdExtractor, header_text:str, expected_type:str
+    ) -> None:
+        """Island-prop fallback also covers PICKUP / shipping-without-costs wording."""
+        island_props:dict[str, Any] = {"shippingHeader": [0, header_text]}
+        with (
+            patch.object(test_extractor, "page", MagicMock()),
+            patch.object(test_extractor, "web_text", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_extractor, "web_request", new_callable = AsyncMock) as mock_web_request,
+        ):
+            shipping_type, costs, options = await test_extractor._extract_shipping_info_from_ad_page(island_props = island_props)
+
+            assert shipping_type == expected_type
+            assert costs is None
+            assert options is None
+            mock_web_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    async def test_extract_shipping_info_island_props_without_shipping_header(
+        self, test_extractor:extract_module.AdExtractor
+    ) -> None:
+        """Missing shippingHeader island prop keeps the legacy NOT_APPLICABLE behaviour."""
+        with (
+            patch.object(test_extractor, "page", MagicMock()),
+            patch.object(test_extractor, "web_text", new_callable = AsyncMock, side_effect = TimeoutError),
+        ):
+            shipping_type, costs, options = await test_extractor._extract_shipping_info_from_ad_page(
+                island_props = {"formattedCreationDate": [0, "Heute"]}
+            )
+
+            assert shipping_type == "NOT_APPLICABLE"
+            assert costs is None
+            assert options is None
+
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    async def test_extract_shipping_from_real_island_props_fixture_shipping(self, test_extractor:extract_module.AdExtractor) -> None:
+        """Real saved redesigned-page props (shipping ad) restore SHIPPING via the island fallback."""
+        island_props = _load_astro_props_fixture("astro_ad_props_shipping.json")
+        assert island_props["shippingHeader"] == [0, "+ Versand ab 0,99 €"]
+
+        shipping_response:dict[str, Any] = {
+            "content": json.dumps(
+                {
+                    "data": {
+                        "shippingOptionsResponse": {
+                            "options": [{"id": "DHL_001", "priceInEuroCent": 99, "packageSize": "SMALL"}]
+                        }
+                    }
+                }
+            )
+        }
+        with (
+            patch.object(test_extractor, "page", MagicMock()),
+            patch.object(test_extractor, "web_text", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_extractor, "web_request", new_callable = AsyncMock, return_value = shipping_response),
+        ):
+            shipping_type, costs, options = await test_extractor._extract_shipping_info_from_ad_page(island_props = island_props)
+
+        assert shipping_type == "SHIPPING"
+        assert costs == 0.99
+        assert options == [OPTION_NAME_BY_CARRIER_CODE["DHL_001"]]
+
+    @pytest.mark.asyncio
+    # pylint: disable=protected-access
+    async def test_extract_shipping_from_real_island_props_fixture_pickup(self, test_extractor:extract_module.AdExtractor) -> None:
+        """Real saved redesigned-page props (pickup ad) restore PICKUP via the island fallback."""
+        island_props = _load_astro_props_fixture("astro_ad_props_pickup.json")
+        assert island_props["shippingHeader"] == [0, "Nur Abholung"]
+
+        with (
+            patch.object(test_extractor, "page", MagicMock()),
+            patch.object(test_extractor, "web_text", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(test_extractor, "web_request", new_callable = AsyncMock) as mock_web_request,
+        ):
+            shipping_type, costs, options = await test_extractor._extract_shipping_info_from_ad_page(island_props = island_props)
+
+        assert shipping_type == "PICKUP"
+        assert costs is None
+        assert options is None
+        mock_web_request.assert_not_awaited()
 
     @pytest.mark.asyncio
     # pylint: disable=protected-access

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -7,7 +7,7 @@ import errno
 import shutil
 import stat
 from pathlib import Path
-from typing import Any, Final, TypedDict
+from typing import Any, Final, TypedDict, cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 from urllib.error import URLError
 
@@ -31,7 +31,7 @@ def _read_text_file(path:Path) -> str:
 def _load_astro_props_fixture(name:str) -> dict[str, Any]:
     """Load a saved Astro island props fixture from ``tests/fixtures``."""
     fixture_path = Path(__file__).resolve().parents[1] / "fixtures" / name
-    return json.loads(fixture_path.read_text(encoding = "utf-8"))
+    return cast(dict[str, Any], json.loads(fixture_path.read_text(encoding = "utf-8")))
 
 
 def _create_test_ad_partial(**overrides:Any) -> AdPartial:
@@ -259,6 +259,7 @@ class TestAdExtractorPricing:
 class TestAdExtractorShipping:
     """Tests for shipping related functionality."""
 
+    @pytest.mark.parametrize("island_header", [None, "Nur Abholung", "Versand möglich"])
     @pytest.mark.parametrize(
         ("shipping_text", "expected_type", "expected_cost"),
         [
@@ -270,9 +271,9 @@ class TestAdExtractorShipping:
     @pytest.mark.asyncio
     # pylint: disable=protected-access
     async def test_extract_shipping_info(
-        self, test_extractor:extract_module.AdExtractor, shipping_text:str, expected_type:str, expected_cost:float | None
+        self, test_extractor:extract_module.AdExtractor, shipping_text:str, expected_type:str, expected_cost:float | None, island_header:str | None
     ) -> None:
-        """Test shipping info extraction with different text formats."""
+        """DOM shipping text takes precedence over potentially conflicting island props."""
         with (
             patch.object(test_extractor, "page", MagicMock()),
             patch.object(test_extractor, "web_text", new_callable = AsyncMock, return_value = shipping_text),
@@ -284,7 +285,9 @@ class TestAdExtractorShipping:
                 }
                 mock_web_request.return_value = {"content": json.dumps(shipping_response)}
 
-            shipping_type, costs, options = await test_extractor._extract_shipping_info_from_ad_page()
+            shipping_type, costs, options = await test_extractor._extract_shipping_info_from_ad_page(
+                island_props = {"shippingHeader": [0, island_header]} if island_header is not None else None
+            )
 
             assert shipping_type == expected_type
             assert costs == expected_cost
@@ -295,8 +298,9 @@ class TestAdExtractorShipping:
 
     @pytest.mark.asyncio
     # pylint: disable=protected-access
-    async def test_extract_shipping_info_from_island_props_fallback(self, test_extractor:extract_module.AdExtractor) -> None:
-        """Shipping is extracted from the shippingHeader island prop when the legacy DOM element is absent."""
+    @pytest.mark.parametrize("dom_text", [None, ""], ids = ["absent", "empty"])
+    async def test_extract_shipping_info_from_island_props_fallback(self, test_extractor:extract_module.AdExtractor, dom_text:str | None) -> None:
+        """Shipping falls back to island props when the legacy DOM element is absent or empty."""
         island_props:dict[str, Any] = {"shippingHeader": [0, "+ Versand ab 2,99 €"]}
         shipping_response:dict[str, Any] = {
             "content": json.dumps(
@@ -311,7 +315,10 @@ class TestAdExtractorShipping:
         }
         with (
             patch.object(test_extractor, "page", MagicMock()),
-            patch.object(test_extractor, "web_text", new_callable = AsyncMock, side_effect = TimeoutError),
+            patch.object(
+                test_extractor, "web_text", new_callable = AsyncMock,
+                side_effect = TimeoutError if dom_text is None else None, return_value = dom_text,
+            ),
             patch.object(test_extractor, "web_request", new_callable = AsyncMock, return_value = shipping_response),
         ):
             shipping_type, costs, options = await test_extractor._extract_shipping_info_from_ad_page(island_props = island_props)


### PR DESCRIPTION
## ℹ️ Description

Fixes the `download` side of #1256 for accounts served the redesigned (Astro) ad page: the legacy shipping element `.boxedarticle--details--shipping` is absent on owned ads, so shipping extraction fell through to `TimeoutError` and wrote `shipping_type: NOT_APPLICABLE` — which then fails Pydantic validation (`sell_directly requires shipping_type to be SHIPPING`) for ads with `sell_directly: true`, aborting the whole batch ("downloaded 2 of 15 ads (13 failed)").

This PR adds a fallback to the `shippingHeader` Astro island prop when the legacy DOM element is missing. `shippingHeader` carries the same display wording as the legacy element (`+ Versand ab 0,99 €`, `Nur Abholung`, `Versand möglich`), so the existing parser logic applies unchanged. Option-set resolution is untouched (price-match against the shipping-options API), matching the analysis in #1256 by @Naumsede.

## 📋 Changes Summary

- `src/kleinanzeigen_bot/extract.py`
  - New `_extract_shipping_text_from_dom()`: reads the legacy shipping element, returns `None` on absence instead of collapsing the whole extraction.
  - New `_shipping_text_from_island_props()`: unwraps the `shippingHeader` island prop (`[0, "..."]` envelope) via the existing `_unwrap_island_value()`.
  - `_extract_shipping_info_from_ad_page()` now accepts optional `island_props` and falls back to `shippingHeader` when the DOM element is absent; without props it keeps the previous `NOT_APPLICABLE` behaviour.
  - `_extract_ad_page_info()` passes the already-extracted `island_props` through.
- `tests/fixtures/astro_ad_props_shipping.json`, `tests/fixtures/astro_ad_props_pickup.json`: **real saved props fragments** captured from a redesigned owned ad page of an affected account (ad reached via the same search-redirect path the bot uses). **Sanitized:** contact/poster/imprint/description/media fields removed, and the identity-tracing fields (`id`, `title`, `ogTitle`) neutralized to placeholder values so the live ads (and thus the seller profile) cannot be looked up from the fixtures. The structural shape — envelope encoding, field names, `shippingHeader` values `[0, "+ Versand ab 0,99 €"]` and `[0, "Nur Abholung"]` — is preserved as captured.
- `tests/unit/test_extract.py`: unit tests for the fallback (SHIPPING with costs, PICKUP, missing `shippingHeader`) plus tests driving the two real fixtures through `_extract_shipping_info_from_ad_page()`.

### ⚙️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

Verification status: `tests/unit/test_extract.py` → 173 passed; `ruff check --preview` clean; `mypy` clean on `extract.py`; `autopep8` + `post_autopep8` produce no diff. Note: the full local `pdm run test` suite cannot complete in this WSL2 environment — pytest segfaults during whole-directory collection and in `tests/unit/test_publishing_workflow.py`, reproducible on clean `main` (pre-existing, environment-specific; CI runs in Docker and is unaffected).

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [ ] I have tested my changes and ensured that all tests pass (`pdm run test`) — see verification note above; affected test module fully green, CI will run the full suite.
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`) — ruff + mypy locally; pyright/actionlint run in CI.
- [ ] I have updated documentation where necessary. — no docs affected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.