### PR TITLE
perf: traverse the ad overview once for bulk actions

### DIFF
--- a/src/kleinanzeigen_bot/bulk_ad_actions.py
+++ b/src/kleinanzeigen_bot/bulk_ad_actions.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Process selected ads during a single traversal of the management overview."""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .model.ad_model import Ad
+from .utils import loggers
+from .utils.web_scraping_mixin import By, WebScrapingMixin
+
+LOG:loggers.Logger = loggers.get_logger(__name__)
+type AdEntry = tuple[str, Ad, dict[str, Any]]
+
+
+async def process_ads(
+    web:WebScrapingMixin,
+    root_url:str,
+    ad_cfgs:list[AdEntry],
+    *,
+    process_ad:Callable[[AdEntry, int], Awaitable[bool]],
+    report_missing:Callable[[Ad], None],
+) -> int:
+    """Act only on selected rows, retaining IDs rather than stale DOM elements."""
+    if not ad_cfgs:
+        return 0
+
+    pending:dict[str, list[AdEntry]] = {}
+    for entry in ad_cfgs:
+        pending.setdefault(str(entry[1].id), []).append(entry)
+    total = len(ad_cfgs)
+    processed_count = 0
+    success_count = 0
+
+    async def process_page(page_num:int) -> bool:
+        nonlocal success_count, processed_count
+        rows = await web.web_find_all(
+            By.CSS_SELECTOR, "#my-manageitems-adlist li[data-adid]", timeout = web.timeout("quick_dom")
+        )
+        # Snapshot IDs before clicks update the DOM; each action resolves its own button.
+        page_ids = [str(row.attrs.get("data-adid")) for row in rows]
+        for ad_id in page_ids:
+            for entry in pending.pop(ad_id, []):
+                ad_file, ad_cfg, _ = entry
+                processed_count += 1
+                LOG.info("Processing %s/%s: '%s' from [%s]...", processed_count, total, ad_cfg.title, ad_file)
+                if await process_ad(entry, page_num):
+                    success_count += 1
+                await web.web_sleep()
+        return not pending
+
+    await web.navigate_paginated_ad_overview(process_page, page_url = f"{root_url}/m-meine-anzeigen.html")
+    for entries in pending.values():
+        for ad_file, ad_cfg, _ in entries:
+            processed_count += 1
+            LOG.info("Processing %s/%s: '%s' from [%s]...", processed_count, total, ad_cfg.title, ad_file)
+            report_missing(ad_cfg)
+            await web.web_sleep()
+    return success_count

--- a/src/kleinanzeigen_bot/extend_flow.py
+++ b/src/kleinanzeigen_bot/extend_flow.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from . import published_ads
+from . import bulk_ad_actions, published_ads
 from .published_ads import ad_matches_id
 from .utils import dicts as _dicts
 
@@ -80,13 +80,16 @@ async def extend_ads(
         LOG.info("############################################")
         return
 
-    # Process extensions
-    success_count = 0
-    for idx, (ad_file, ad_cfg, ad_cfg_orig) in enumerate(ads_to_extend, start = 1):
-        LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ads_to_extend), ad_cfg.title, ad_file)
-        if await _extend_ad(web, root_url, ad_file, ad_cfg, ad_cfg_orig):
-            success_count += 1
-        await web.web_sleep()
+    async def process_ad(entry:bulk_ad_actions.AdEntry, page_num:int) -> bool:
+        ad_file, ad_cfg, ad_cfg_orig = entry
+        return await _extend_ad(web, ad_file, ad_cfg, ad_cfg_orig, page_num = page_num)
+
+    def report_missing(ad_cfg:Ad) -> None:
+        LOG.error(" -> FAILED: Could not find extend button for ad ID %s", ad_cfg.id)
+
+    success_count = await bulk_ad_actions.process_ads(
+        web, root_url, ads_to_extend, process_ad = process_ad, report_missing = report_missing
+    )
 
     LOG.info("############################################")
     LOG.info("DONE: Extended %s", pluralize("ad", success_count))
@@ -95,34 +98,24 @@ async def extend_ads(
 
 async def _extend_ad(
     web:WebScrapingMixin,
-    root_url:str,
     ad_file:str,
     ad_cfg:Ad,
     ad_cfg_orig:dict[str, Any],
+    *,
+    page_num:int,
 ) -> bool:
     """Extends a single ad listing."""
     LOG.info("Extending ad '%s' (ID: %s)...", ad_cfg.title, ad_cfg.id)
 
     try:
-        # Navigate to ad management page and find extend button across all pages
         extend_button_xpath = f'//li[@data-adid="{ad_cfg.id}"]//button[contains(., "Verlängern")]'
-
-        async def find_and_click_extend_button(page_num:int) -> bool:
-            """Try to find and click extend button on current page."""
-            try:
-                extend_button = await web.web_find(By.XPATH, extend_button_xpath, timeout = web.timeout("quick_dom"))
-                LOG.info("Found extend button on page %s", page_num)
-                await extend_button.click()
-                return True  # Success - stop pagination
-            except TimeoutError:
-                LOG.debug("Extend button not found on page %s", page_num)
-                return False  # Continue to next page
-
-        success = await web.navigate_paginated_ad_overview(find_and_click_extend_button, page_url = f"{root_url}/m-meine-anzeigen.html")
-
-        if not success:
+        try:
+            extend_button = await web.web_find(By.XPATH, extend_button_xpath, timeout = web.timeout("quick_dom"))
+        except TimeoutError:
             LOG.error(" -> FAILED: Could not find extend button for ad ID %s", ad_cfg.id)
             return False
+        LOG.info("Found extend button on page %s", page_num)
+        await extend_button.click()
 
         # Handle confirmation dialog
         # After clicking "Verlängern", a dialog appears with:

--- a/src/kleinanzeigen_bot/reserve_flow.py
+++ b/src/kleinanzeigen_bot/reserve_flow.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from . import published_ads
+from . import bulk_ad_actions, published_ads
 from .published_ads import ad_matches_id
 
 if TYPE_CHECKING:
@@ -87,12 +87,15 @@ async def set_reservation_state(
         LOG.info("############################################")
         return
 
-    success_count = 0
-    for idx, (ad_file, ad_cfg, _ad_cfg_orig) in enumerate(ads_to_change, start = 1):
-        LOG.info("Processing %s/%s: '%s' from [%s]...", idx, len(ads_to_change), ad_cfg.title, ad_file)
-        if await _change_ad_state(web, root_url, ad_cfg, action = action):
-            success_count += 1
-        await web.web_sleep()
+    async def process_ad(entry:bulk_ad_actions.AdEntry, page_num:int) -> bool:
+        return await _change_ad_state(web, root_url, entry[1], action = action, page_num = page_num)
+
+    def report_missing(ad_cfg:Ad) -> None:
+        LOG.error(" -> FAILED: Could not find '%s' button for ad ID %s", _BUTTON_LABELS[action], ad_cfg.id)
+
+    success_count = await bulk_ad_actions.process_ads(
+        web, root_url, ads_to_change, process_ad = process_ad, report_missing = report_missing
+    )
 
     LOG.info("############################################")
     if action == "reserve":
@@ -138,6 +141,7 @@ async def _change_ad_state(
     ad_cfg:Ad,
     *,
     action:ReserveAction,
+    page_num:int,
 ) -> bool:
     """Clicks the reserve/activate button for a single ad in the manage-ads overview."""
     if action == "reserve":
@@ -148,26 +152,17 @@ async def _change_ad_state(
     label = _BUTTON_LABELS[action]
     button_xpath = f'//li[@data-adid="{ad_cfg.id}"]//button[contains(., "{label}")]'
 
-    async def find_and_click_button(page_num:int) -> bool:
-        try:
-            button = await web.web_find(By.XPATH, button_xpath, timeout = web.timeout("quick_dom"))
-            LOG.info("Found '%s' button on page %s", label, page_num)
-            await button.click()
-            return True
-        except TimeoutError:
-            LOG.debug("'%s' button not found on page %s", label, page_num)
-            return False
-
     try:
-        success = await web.navigate_paginated_ad_overview(
-            find_and_click_button, page_url = f"{root_url}/m-meine-anzeigen.html"
-        )
-    except TimeoutError as ex:
-        LOG.error(" -> FAILED: Timeout while switching ad '%s': %s", ad_cfg.title, ex)
+        button = await web.web_find(By.XPATH, button_xpath, timeout = web.timeout("quick_dom"))
+    except TimeoutError:
+        LOG.error(" -> FAILED: Could not find '%s' button for ad ID %s", label, ad_cfg.id)
         return False
 
-    if not success:
-        LOG.error(" -> FAILED: Could not find '%s' button for ad ID %s", label, ad_cfg.id)
+    LOG.info("Found '%s' button on page %s", label, page_num)
+    try:
+        await button.click()
+    except TimeoutError as ex:
+        LOG.error(" -> FAILED: Timeout while switching ad '%s': %s", ad_cfg.title, ex)
         return False
 
     await _dismiss_confirmation_dialog(web)

--- a/src/kleinanzeigen_bot/resources/translations.de.yaml
+++ b/src/kleinanzeigen_bot/resources/translations.de.yaml
@@ -422,6 +422,14 @@ kleinanzeigen_bot/delete_flow.py:
     " -> ad %s not found (status %s), may have been removed already": " -> Anzeige %s nicht gefunden (Status %s), möglicherweise bereits entfernt"
 
 #################################################
+kleinanzeigen_bot/bulk_ad_actions.py:
+#################################################
+  process_ads:
+    "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' aus [%s]..."
+  process_page:
+    "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' aus [%s]..."
+
+#################################################
 kleinanzeigen_bot/extend_flow.py:
 #################################################
   extend_ads:
@@ -437,7 +445,6 @@ kleinanzeigen_bot/extend_flow.py:
     " -> SKIPPED: ad '%s' has invalid endDate format: %s": " -> ÜBERSPRUNGEN: Anzeige '%s' hat ungültiges Ablaufdatum-Format: %s"
     " -> ad '%s' expires in %d days, will extend": " -> Anzeige '%s' läuft in %d Tagen ab, wird verlängert"
     " -> SKIPPED: ad '%s' expires in %d days (can only extend within 8 days)": " -> ÜBERSPRUNGEN: Anzeige '%s' läuft in %d Tagen ab (Verlängern nur innerhalb von 8 Tagen möglich)"
-    "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' aus [%s]..."
 
   _extend_ad:
     "Extending ad '%s' (ID: %s)...": "Verlängere Anzeige '%s' (ID: %s)..."
@@ -446,9 +453,10 @@ kleinanzeigen_bot/extend_flow.py:
     " -> SUCCESS: ad extended with ID %s": " -> ERFOLG: Anzeige mit ID %s verlängert"
     " -> FAILED: Timeout while extending ad '%s': %s": " -> FEHLER: Zeitüberschreitung beim Verlängern der Anzeige '%s': %s"
     " -> FAILED: Could not persist extension for ad '%s': %s": " -> FEHLER: Verlängerung der Anzeige '%s' konnte nicht gespeichert werden: %s"
-
-  find_and_click_extend_button:
     "Found extend button on page %s": "'Verlängern'-Button auf Seite %s gefunden"
+
+  report_missing:
+    " -> FAILED: Could not find extend button for ad ID %s": " -> FEHLER: 'Verlängern'-Button für Anzeigen-ID %s nicht gefunden"
 
 #################################################
 kleinanzeigen_bot/reserve_flow.py:
@@ -460,7 +468,6 @@ kleinanzeigen_bot/reserve_flow.py:
     "DONE: Reserved %s": "FERTIG: %s reserviert"
     "DONE: Activated %s": "FERTIG: %s aktiviert"
     "ad": "Anzeige"
-    "Processing %s/%s: '%s' from [%s]...": "Verarbeite %s/%s: '%s' aus [%s]..."
 
   _is_applicable:
     " -> SKIPPED: ad '%s' is not published yet": " -> ÜBERSPRUNGEN: Anzeige '%s' ist noch nicht veröffentlicht"
@@ -476,9 +483,10 @@ kleinanzeigen_bot/reserve_flow.py:
     " -> FAILED: Could not confirm state change for ad '%s' (ID: %s)": " -> FEHLER: Die Zustandsänderung für die Anzeige '%s' (ID: %s) konnte nicht bestätigt werden."
     " -> SUCCESS: ad '%s' (ID: %s) is now reserved": " -> ERFOLG: Anzeige '%s' (ID: %s) ist jetzt reserviert"
     " -> SUCCESS: ad '%s' (ID: %s) is now active": " -> ERFOLG: Anzeige '%s' (ID: %s) ist jetzt aktiv"
-
-  find_and_click_button:
     "Found '%s' button on page %s": "'%s'-Button auf Seite %s gefunden"
+
+  report_missing:
+    " -> FAILED: Could not find '%s' button for ad ID %s": " -> FEHLER: '%s'-Button für Anzeigen-ID %s nicht gefunden"
 
 #################################################
 kleinanzeigen_bot/download_flow.py:

--- a/tests/unit/test_bulk_ad_actions.py
+++ b/tests/unit/test_bulk_ad_actions.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: © Jens Bergmann and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-ArtifactOfProjectHomePage: https://github.com/Second-Hand-Friends/kleinanzeigen-bot/
+"""Bulk commands traverse simulated overview pages without a browser or network."""
+
+import re
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Literal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kleinanzeigen_bot import extend_flow, reserve_flow
+from kleinanzeigen_bot.app import KleinanzeigenBot
+from kleinanzeigen_bot.model.ad_model import Ad
+from kleinanzeigen_bot.utils import dicts, misc
+from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
+
+
+class Overview:
+    """Only the DOM boundary is simulated; commands use the real pagination loop."""
+
+    def __init__(self, pages:list[list[int]], failed_id:int | None, action:str) -> None:
+        self.pages = pages
+        self.failed_id = failed_id
+        self.action = action
+        self.page = 0
+        self.visited:list[int] = []
+        self.attempted:list[int] = []
+        self.succeeded:list[int] = []
+
+    async def open(self, url:str) -> None:
+        assert url == "https://example.invalid/m-meine-anzeigen.html"
+        self.page = 0
+        self.visited.append(self.page)
+
+    async def next_page(self) -> None:
+        self.page += 1
+        self.visited.append(self.page)
+
+    async def find_all(self, selector_type:By, selector_value:str, **_kwargs:Any) -> list[Element]:
+        assert selector_type == By.CSS_SELECTOR
+        if selector_value == 'button[aria-label="Nächste"]':
+            button = MagicMock()
+            button.attrs = {} if self.page + 1 < len(self.pages) else {"disabled": ""}
+            button.click = self.next_page
+            return [button]
+        assert selector_value == "#my-manageitems-adlist li[data-adid]"
+        return [MagicMock(attrs = {"data-adid": str(ad_id)}) for ad_id in self.pages[self.page]]
+
+    async def find(self, selector_type:By, selector_value:str, **_kwargs:Any) -> Element:
+        if selector_type == By.ID:
+            assert selector_value == "my-manageitems-adlist"
+            return MagicMock()
+        assert selector_type == By.XPATH
+        match = re.search(r'data-adid="(\d+)"', selector_value)
+        assert match is not None
+        ad_id = int(match.group(1))
+        if ad_id not in self.pages[self.page]:
+            raise TimeoutError("Ad is on another page")
+
+        async def click() -> None:
+            self.attempted.append(ad_id)
+            if ad_id == self.failed_id:
+                raise TimeoutError("Simulated click timeout")
+            self.succeeded.append(ad_id)
+
+        return MagicMock(click = click)
+
+    def published(self, ad_ids:list[int]) -> list[dict[str, Any]]:
+        initial_state = "paused" if self.action == "activate" else "active"
+        resulting_state = "paused" if self.action == "reserve" else "active"
+        return [{
+            "id": ad_id,
+            "state": resulting_state if ad_id in self.succeeded else initial_state,
+            "endDate": (misc.now().date() + timedelta(days = 2)).strftime("%d.%m.%Y"),
+        } for ad_id in ad_ids]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["extend", "reserve", "activate"])
+@pytest.mark.parametrize(("requested", "failed_id", "fail_open", "expected_pages", "expected_attempts"), [
+    ([30, 20, 10], None, False, [0, 1], [20, 10, 30]),
+    ([20, 10], None, False, [0], [20, 10]),
+    ([30, 20, 10], 20, False, [0, 1], [20, 10, 30]),
+    ([99, 30, 10], None, False, [0, 1, 2], [10, 30]),
+    ([20, 20, 10], None, False, [0], [20, 20, 10]),
+    ([20, 10], None, True, [], []),
+    ([], None, False, [], []),
+])
+async def test_bulk_command_visits_each_needed_page_once(
+    *,
+    test_bot:KleinanzeigenBot, tmp_path:Path, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture,
+    action:Literal["extend", "reserve", "activate"], requested:list[int], failed_id:int | None,
+    fail_open:bool, expected_pages:list[int], expected_attempts:list[int],
+) -> None:
+    overview = Overview([[20, 10, 777], [30], [40]], failed_id, action)
+    ads:list[tuple[str, Ad, dict[str, Any]]] = []
+    for index, ad_id in enumerate(requested):
+        raw = {**base_ad_config, "id": ad_id, "title": f"Test listing {ad_id}"}
+        path = str(tmp_path / f"{index}-{ad_id}.yaml")
+        dicts.save_dict(path, raw)
+        ads.append((path, Ad.model_validate(raw), raw))
+    before = {path: Path(path).read_bytes() for path, _, _ in ads}  # noqa: ASYNC240 Small temporary test files
+
+    async def fetch(*_args:Any, **_kwargs:Any) -> list[dict[str, Any]]:
+        return overview.published(requested)
+
+    with (
+        patch.object(test_bot, "web_open", side_effect = TimeoutError("Overview unavailable") if fail_open else overview.open) as opened,
+        patch.object(test_bot, "web_find", side_effect = overview.find),
+        patch.object(test_bot, "web_find_all", side_effect = overview.find_all),
+        patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
+        patch.object(test_bot, "web_click", new_callable = AsyncMock),
+        patch.object(test_bot, "web_sleep", new_callable = AsyncMock) as sleep,
+        patch("kleinanzeigen_bot.published_ads.fetch_published_ads", side_effect = fetch),
+    ):
+        if action == "extend":
+            await extend_flow.extend_ads(test_bot, "https://example.invalid", ads)
+        else:
+            await reserve_flow.set_reservation_state(test_bot, "https://example.invalid", ads, action = action)
+
+    assert opened.await_count == bool(requested)
+    assert overview.visited == expected_pages
+    assert overview.attempted == expected_attempts
+    assert overview.succeeded == [ad_id for ad_id in expected_attempts if ad_id != failed_id]
+    assert sum(not call.args and not call.kwargs for call in sleep.await_args_list) == len(requested)
+    for path, ad, raw in ads:
+        if action == "extend" and ad.id in overview.succeeded:
+            assert raw["updated_on"]
+            assert Path(path).read_bytes() != before[path]  # noqa: ASYNC240 Small temporary test file
+        else:
+            assert Path(path).read_bytes() == before[path]  # noqa: ASYNC240 Small temporary test file
+    if 99 in requested:
+        assert "button for ad ID 99" in caplog.text
+    if failed_id is not None:
+        assert "FAILED" in caplog.text

--- a/tests/unit/test_bulk_ad_actions.py
+++ b/tests/unit/test_bulk_ad_actions.py
@@ -91,7 +91,7 @@ class Overview:
 ])
 async def test_bulk_command_visits_each_needed_page_once(
     *,
-    test_bot:KleinanzeigenBot, tmp_path:Path, base_ad_config:dict[str, Any], caplog:pytest.LogCaptureFixture,
+    test_bot:KleinanzeigenBot, tmp_path:Path, base_ad_config:dict[str, Any],
     action:Literal["extend", "reserve", "activate"], requested:list[int], failed_id:int | None,
     fail_open:bool, expected_pages:list[int], expected_attempts:list[int],
 ) -> None:
@@ -132,7 +132,3 @@ async def test_bulk_command_visits_each_needed_page_once(
             assert Path(path).read_bytes() != before[path]  # noqa: ASYNC240 Small temporary test file
         else:
             assert Path(path).read_bytes() == before[path]  # noqa: ASYNC240 Small temporary test file
-    if 99 in requested:
-        assert "button for ad ID 99" in caplog.text
-    if failed_id is not None:
-        assert "FAILED" in caplog.text

--- a/tests/unit/test_extend_flow.py
+++ b/tests/unit/test_extend_flow.py
@@ -4,6 +4,7 @@
 """Tests for the extend command and extend_flow module."""
 
 import json
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -15,7 +16,6 @@ from kleinanzeigen_bot import extend_flow, runtime_config
 from kleinanzeigen_bot.app import KleinanzeigenBot
 from kleinanzeigen_bot.model.ad_model import Ad
 from kleinanzeigen_bot.utils import dicts, misc, xdg_paths
-from kleinanzeigen_bot.utils.web_scraping_mixin import By, Element
 
 
 @pytest.fixture
@@ -90,6 +90,18 @@ class TestExtendCommand:
 
 class TestExtendAdsMethod:
     """Tests for the extend_ads() method."""
+
+    @pytest.fixture(autouse = True)
+    def overview(self, test_bot:KleinanzeigenBot) -> Any:
+        async def navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            return await callback(1)
+
+        rows = [MagicMock(attrs = {"data-adid": str(ad_id)}) for ad_id in (12345, 67890)]
+        with (
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = navigate),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = rows),
+        ):
+            yield
 
     @pytest.mark.asyncio
     async def test_extend_ads_skips_unpublished_ad(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
@@ -293,13 +305,7 @@ class TestExtendAdsMethod:
 
 
 class TestExtendAdMethod:
-    """Tests for the _extend_ad() method.
-
-    Note: These tests mock `navigate_paginated_ad_overview` rather than individual browser methods
-    (web_find, web_click, etc.) because the pagination helper involves complex multi-step browser
-    interactions that would require extensive, brittle mock choreography. Mocking at this level
-    keeps tests focused on _extend_ad's own logic (dialog handling, YAML persistence, error paths).
-    """
+    """Tests for current-page button handling and extension persistence."""
 
     @pytest.mark.asyncio
     async def test_extend_ad_success(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any], tmp_path:Path) -> None:
@@ -311,23 +317,23 @@ class TestExtendAdMethod:
         dicts.save_dict(str(ad_file), base_ad_config_with_id)
 
         with (
-            patch.object(test_bot, "navigate_paginated_ad_overview", new_callable = AsyncMock) as mock_paginate,
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
             patch("kleinanzeigen_bot.utils.misc.now") as mock_now,
         ):
             # Test mock datetime - timezone not relevant for timestamp formatting test
             mock_now.return_value = datetime(2025, 1, 28, 14, 30, 0)  # noqa: DTZ001
 
-            mock_paginate.return_value = True
+            mock_find.return_value = AsyncMock()
 
             result = await extend_flow._extend_ad(
-                web = test_bot, root_url = test_bot.root_url,
+                web = test_bot, page_num = 1,
                 ad_file = str(ad_file), ad_cfg = ad_cfg,
                 ad_cfg_orig = base_ad_config_with_id,
             )
 
             assert result is True
-            assert mock_paginate.call_count == 1
+            assert mock_find.call_count == 1
 
             # Verify updated_on was updated in the YAML file
             updated_config = dicts.load_dict(str(ad_file))
@@ -342,18 +348,18 @@ class TestExtendAdMethod:
         ad_file = tmp_path / "test_ad.yaml"
         dicts.save_dict(str(ad_file), base_ad_config_with_id)
 
-        with patch.object(test_bot, "navigate_paginated_ad_overview", new_callable = AsyncMock) as mock_paginate:
-            # Simulate button not found by having pagination return False (not found on any page)
-            mock_paginate.return_value = False
+        with patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find:
+            # The current row has no extend button.
+            mock_find.side_effect = TimeoutError("Button not found")
 
             result = await extend_flow._extend_ad(
-                web = test_bot, root_url = test_bot.root_url,
+                web = test_bot, page_num = 1,
                 ad_file = str(ad_file), ad_cfg = ad_cfg,
                 ad_cfg_orig = base_ad_config_with_id,
             )
 
             assert result is False
-            assert mock_paginate.call_count == 1
+            assert mock_find.call_count == 1
 
     @pytest.mark.asyncio
     async def test_extend_ad_dialog_timeout(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any], tmp_path:Path) -> None:
@@ -365,20 +371,20 @@ class TestExtendAdMethod:
         dicts.save_dict(str(ad_file), base_ad_config_with_id)
 
         with (
-            patch.object(test_bot, "navigate_paginated_ad_overview", new_callable = AsyncMock) as mock_paginate,
+            patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
             patch.object(test_bot, "web_click", new_callable = AsyncMock) as mock_click,
             patch("kleinanzeigen_bot.utils.misc.now") as mock_now,
         ):
             # Test mock datetime - timezone not relevant for timestamp formatting test
             mock_now.return_value = datetime(2025, 1, 28, 14, 30, 0)  # noqa: DTZ001
 
-            # Pagination succeeds (button found and clicked)
-            mock_paginate.return_value = True
+            # The extend button is available.
+            mock_find.return_value = AsyncMock()
             # Dialog close button times out
             mock_click.side_effect = TimeoutError("Dialog not found")
 
             result = await extend_flow._extend_ad(
-                web = test_bot, root_url = test_bot.root_url,
+                web = test_bot, page_num = 1,
                 ad_file = str(ad_file), ad_cfg = ad_cfg,
                 ad_cfg_orig = base_ad_config_with_id,
             )
@@ -395,79 +401,32 @@ class TestExtendAdMethod:
         ad_file = tmp_path / "test_ad.yaml"
         dicts.save_dict(str(ad_file), base_ad_config_with_id)
 
-        with patch.object(test_bot, "navigate_paginated_ad_overview", new_callable = AsyncMock) as mock_paginate:
-            # Simulate unexpected exception during pagination
-            mock_paginate.side_effect = Exception("Unexpected error")
+        with patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find:
+            # Unexpected browser errors must propagate.
+            mock_find.side_effect = Exception("Unexpected error")
 
             with pytest.raises(Exception, match = "Unexpected error"):
                 await extend_flow._extend_ad(
-                    web = test_bot, root_url = test_bot.root_url,
+                    web = test_bot, page_num = 1,
                     ad_file = str(ad_file), ad_cfg = ad_cfg,
                     ad_cfg_orig = base_ad_config_with_id,
                 )
 
-    @pytest.mark.asyncio
-    async def test_extend_ad_with_web_mocks(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any], tmp_path:Path) -> None:
-        """Test _extend_ad with web-level mocks to exercise the find_and_click_extend_button callback."""
-        ad_cfg = Ad.model_validate(base_ad_config_with_id)
-
-        # Create temporary YAML file
-        ad_file = tmp_path / "test_ad.yaml"
-        dicts.save_dict(str(ad_file), base_ad_config_with_id)
-
-        extend_button_mock = AsyncMock()
-        extend_button_mock.click = AsyncMock()
-
-        pagination_section = MagicMock()
-
-        find_call_count = {"count": 0}
-
-        async def mock_web_find(selector_type:By, selector_value:str, **kwargs:Any) -> Element:
-            find_call_count["count"] += 1
-            # Ad list container (called by pagination helper)
-            if selector_type == By.ID and selector_value == "my-manageitems-adlist":
-                return MagicMock()
-            # Pagination section (called by pagination helper)
-            if selector_type == By.CSS_SELECTOR and selector_value == ".Pagination":
-                # Raise TimeoutError on first call (pagination detection) to indicate single page
-                if find_call_count["count"] == 2:
-                    raise TimeoutError("No pagination")
-                return pagination_section
-            # Extend button (called by find_and_click_extend_button callback)
-            if selector_type == By.XPATH and "Verlängern" in selector_value:
-                return extend_button_mock
-            raise TimeoutError(f"Unexpected find: {selector_type} {selector_value}")
-
-        with (
-            patch.object(test_bot, "web_open", new_callable = AsyncMock),
-            patch.object(test_bot, "web_sleep", new_callable = AsyncMock),
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = mock_web_find),
-            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = []),
-            patch.object(test_bot, "web_scroll_page_down", new_callable = AsyncMock),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "timeout", return_value = 10),
-            patch("kleinanzeigen_bot.utils.misc.now") as mock_now,
-        ):
-            # Test mock datetime - timezone not relevant for timestamp formatting test
-            mock_now.return_value = datetime(2025, 1, 28, 15, 0, 0)  # noqa: DTZ001
-
-            result = await extend_flow._extend_ad(
-                web = test_bot, root_url = test_bot.root_url,
-                ad_file = str(ad_file), ad_cfg = ad_cfg,
-                ad_cfg_orig = base_ad_config_with_id,
-            )
-
-            assert result is True
-            # Verify the extend button was found and clicked
-            extend_button_mock.click.assert_awaited_once()
-
-            # Verify updated_on was updated
-            updated_config = dicts.load_dict(str(ad_file))
-            assert updated_config["updated_on"] == "2025-01-28T15:00:00"
-
 
 class TestExtendEdgeCases:
     """Tests for edge cases and boundary conditions."""
+
+    @pytest.fixture(autouse = True)
+    def overview(self, test_bot:KleinanzeigenBot) -> Any:
+        async def navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            return await callback(1)
+
+        rows = [MagicMock(attrs = {"data-adid": str(ad_id)}) for ad_id in (12345, 67890)]
+        with (
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = navigate),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = rows),
+        ):
+            yield
 
     @pytest.mark.asyncio
     async def test_extend_ads_exactly_8_days(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:

--- a/tests/unit/test_reserve_flow.py
+++ b/tests/unit/test_reserve_flow.py
@@ -112,6 +112,18 @@ class TestReserveCommand:
 class TestSetReservationState:
     """Tests for the set_reservation_state() method."""
 
+    @pytest.fixture(autouse = True)
+    def overview(self, test_bot:KleinanzeigenBot) -> Any:
+        async def navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
+            return await callback(1)
+
+        rows = [MagicMock(attrs = {"data-adid": str(ad_id)}) for ad_id in (12345, 67890)]
+        with (
+            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = navigate),
+            patch.object(test_bot, "web_find_all", new_callable = AsyncMock, return_value = rows),
+        ):
+            yield
+
     @pytest.mark.asyncio
     async def test_skips_unpublished_ad(self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]) -> None:
         """An ad without an ID was never published — there is nothing to reserve."""
@@ -293,13 +305,9 @@ class TestChangeAdState:
         button = MagicMock()
         button.click = AsyncMock()
 
-        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
-            return await callback(1)
-
         with (
             patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_find,
             patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
             patch(
                 "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
                 new_callable = AsyncMock,
@@ -309,7 +317,7 @@ class TestChangeAdState:
             mock_find.return_value = button
 
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
-                test_bot, test_bot.root_url, ad_cfg, action = action,
+                test_bot, test_bot.root_url, ad_cfg, action = action, page_num = 1,
             )
 
             assert result is True
@@ -319,53 +327,17 @@ class TestChangeAdState:
             assert label in xpath
 
     @pytest.mark.asyncio
-    async def test_button_missing_on_page_continues_pagination(
+    async def test_button_lookup_timeout_is_reported_as_failure(
         self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
     ) -> None:
-        """The ad may sit on a later page, so a miss must not abort the search."""
-        ad_cfg = Ad.model_validate(base_ad_config_with_id)
-        button = MagicMock()
-        button.click = AsyncMock()
-        visited_pages:list[int] = []
-
-        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
-            for page_num in (1, 2):
-                visited_pages.append(page_num)
-                if await callback(page_num):
-                    return True
-            return False
-
-        with (
-            # Page 1 has no matching row, page 2 does.
-            patch.object(test_bot, "web_find", new_callable = AsyncMock, side_effect = [TimeoutError, button]),
-            patch.object(test_bot, "web_click", new_callable = AsyncMock),
-            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
-            patch(
-                "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
-                new_callable = AsyncMock,
-                return_value = [{"id": 12345, "state": reserve_flow.STATE_RESERVED}],
-            ),
-        ):
-            result = await reserve_flow._change_ad_state(  # noqa: SLF001
-                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
-            )
-
-            assert result is True
-            assert visited_pages == [1, 2]
-            button.click.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_navigation_timeout_is_reported_as_failure(
-        self, test_bot:KleinanzeigenBot, base_ad_config_with_id:dict[str, Any]
-    ) -> None:
-        """A timeout while loading the overview must be caught, not propagated to the caller."""
+        """A button lookup timeout must be caught, not propagated to the caller."""
         ad_cfg = Ad.model_validate(base_ad_config_with_id)
 
         with patch.object(
-            test_bot, "navigate_paginated_ad_overview", new_callable = AsyncMock, side_effect = TimeoutError("overview did not load")
+            test_bot, "web_find", new_callable = AsyncMock, side_effect = TimeoutError("overview did not load")
         ):
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
-                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve", page_num = 1,
             )
 
             assert result is False
@@ -377,11 +349,11 @@ class TestChangeAdState:
         """A missing button means the state did not change — that must not read as success."""
         ad_cfg = Ad.model_validate(base_ad_config_with_id)
 
-        with patch.object(test_bot, "navigate_paginated_ad_overview", new_callable = AsyncMock) as mock_nav:
-            mock_nav.return_value = False
+        with patch.object(test_bot, "web_find", new_callable = AsyncMock) as mock_nav:
+            mock_nav.side_effect = TimeoutError("Button not found")
 
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
-                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve", page_num = 1,
             )
 
             assert result is False
@@ -395,13 +367,9 @@ class TestChangeAdState:
         button = MagicMock()
         button.click = AsyncMock()
 
-        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
-            return await callback(1)
-
         with (
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
             patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
-            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
             patch(
                 "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
                 new_callable = AsyncMock,
@@ -409,7 +377,7 @@ class TestChangeAdState:
             ),
         ):
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
-                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve", page_num = 1,
             )
 
             assert result is True
@@ -423,13 +391,9 @@ class TestChangeAdState:
         button = MagicMock()
         button.click = AsyncMock()
 
-        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
-            return await callback(1)
-
         with (
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
             patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
-            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
             patch(
                 "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
                 new_callable = AsyncMock,
@@ -437,7 +401,7 @@ class TestChangeAdState:
             ),
         ):
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
-                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve", page_num = 1,
             )
 
         assert result is False
@@ -451,13 +415,9 @@ class TestChangeAdState:
         button = MagicMock()
         button.click = AsyncMock()
 
-        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
-            return await callback(1)
-
         with (
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
             patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
-            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
             patch(
                 "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
                 new_callable = AsyncMock,
@@ -465,7 +425,7 @@ class TestChangeAdState:
             ),
         ):
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
-                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve", page_num = 1,
             )
 
         assert result is False
@@ -479,13 +439,9 @@ class TestChangeAdState:
         button = MagicMock()
         button.click = AsyncMock()
 
-        async def fake_navigate(callback:Callable[[int], Awaitable[bool]], page_url:str) -> bool:  # noqa: ARG001
-            return await callback(1)
-
         with (
             patch.object(test_bot, "web_find", new_callable = AsyncMock, return_value = button),
             patch.object(test_bot, "web_click", new_callable = AsyncMock, side_effect = TimeoutError),
-            patch.object(test_bot, "navigate_paginated_ad_overview", side_effect = fake_navigate),
             patch(
                 "kleinanzeigen_bot.reserve_flow.published_ads.fetch_published_ads",
                 new_callable = AsyncMock,
@@ -493,7 +449,7 @@ class TestChangeAdState:
             ),
         ):
             result = await reserve_flow._change_ad_state(  # noqa: SLF001
-                test_bot, test_bot.root_url, ad_cfg, action = "reserve",
+                test_bot, test_bot.root_url, ad_cfg, action = "reserve", page_num = 1,
             )
 
         assert result is False


### PR DESCRIPTION
## ℹ️ Description

Closes #1265.

Bulk `extend`, `reserve`, and `activate` currently restart the manage-ads overview at page 1 for every eligible ad. They now share one traversal, processing all selected rows on each page and stopping when every requested entry has been handled or pagination ends. This reduces repeated overview loads for accounts with many ads.

## 📋 Changes Summary

- Add a shared bulk-action coordinator that tracks pending IDs and resolves each action button on the current page.
- Preserve per-entry progress/results, action delays, duplicate configuration entries, timeout handling, extension metadata persistence, and strict reservation-state verification.
- Move German translations to the new logging locations and adapt existing flow tests.
- Add 21 browser-independent regression cases covering all three commands, multiple rows/pages, early completion, missing IDs, click/open timeouts, duplicate entries, empty selections, and persisted file behavior.

No dependencies, configuration changes, or additional requirements are introduced. No user documentation changes are needed for this internal performance improvement. Tests use simulated pages and never contact kleinanzeigen.de. Validation: `pdm run format`, `pdm run lint`, and `pdm run test` all pass; the full suite reports **1,605 passed, 5 skipped**.

### ⚙️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)
- [x] ⚡ Performance improvement (reduces repeated overview navigation without changing CLI usage)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary (no documentation changes needed).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unified bulk processing for extension, reservation, and activation actions across paginated ad listings.
  - Improved handling and reporting of ads whose action buttons cannot be found.
  - Added German translations for shared bulk-action messages.

- **Bug Fixes**
  - Reduced repeated page traversal during bulk ad operations.
  - Improved reliability when action buttons time out or are unavailable.

- **Tests**
  - Added and updated coverage for pagination, successful actions, timeouts, missing buttons, and ad updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->