### PR TITLE
fix: skip null auto price reduction when downloading ads

### DIFF
--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -362,7 +362,7 @@ class AdExtractor(WebScrapingMixin):
                     # validated independently so a malformed APR doesn't block other fields.
                     preserved:dict[str, Any] = {}
 
-                    if "auto_price_reduction" in existing_data:
+                    if existing_data.get("auto_price_reduction") is not None:
                         try:
                             preserved["auto_price_reduction"] = AutoPriceReductionConfig.model_validate(
                                 dict(existing_data["auto_price_reduction"])

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -3343,6 +3343,7 @@ class TestAdExtractorDownload:
             ),
         ],
     )
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_download_ad_preserves_local_settings_when_enabled(
         self, extractor:extract_module.AdExtractor, tmp_path:Path, rendered_stem:str,
@@ -3451,6 +3452,7 @@ class TestAdExtractorDownload:
         assert any("Could not preserve local settings" in message for message in caplog.messages)
 
     @pytest.mark.parametrize("apr_value", [{"enabled": True}, False], ids = ["incomplete", "false"])
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_download_ad_preserves_other_fields_when_apr_invalid(
         self, extractor:extract_module.AdExtractor, tmp_path:Path, apr_value:Any, caplog:pytest.LogCaptureFixture

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -3331,9 +3331,22 @@ class TestAdExtractorDownload:
             "ad_12345_newtitle",   # mismatched — triggers glob fallback
         ],
     )
+    @pytest.mark.parametrize(
+        "apr_fields",
+        [
+            pytest.param({}, id = "absent"),
+            pytest.param({"auto_price_reduction": None}, id = "null"),
+            pytest.param({"auto_price_reduction": {}}, id = "empty-disabled"),
+            pytest.param(
+                {"auto_price_reduction": {"enabled": True, "strategy": "PERCENTAGE", "amount": 10, "min_price": 1}},
+                id = "valid",
+            ),
+        ],
+    )
     @pytest.mark.asyncio
     async def test_download_ad_preserves_local_settings_when_enabled(
-        self, extractor:extract_module.AdExtractor, tmp_path:Path, rendered_stem:str
+        self, extractor:extract_module.AdExtractor, tmp_path:Path, rendered_stem:str,
+        apr_fields:dict[str, Any], caplog:pytest.LogCaptureFixture
     ) -> None:
         """Re-downloading an existing ad with preserve_local_settings=True keeps local counters and overrides."""
         download_base = tmp_path / "downloaded-ads"
@@ -3354,7 +3367,7 @@ class TestAdExtractorDownload:
             "price_type": "NEGOTIABLE",
             "repost_count": 5,
             "price_reduction_count": 3,
-            "auto_price_reduction": {"enabled": True, "strategy": "PERCENTAGE", "amount": 10, "min_price": 1},
+            **apr_fields,
             "republication_interval": 14,
         }
         await asyncio.to_thread(dicts.save_dict, str(existing_yaml), existing_data)
@@ -3378,10 +3391,16 @@ class TestAdExtractorDownload:
         assert saved_data["price"] == 100
         assert saved_data["repost_count"] == 5
         assert saved_data["price_reduction_count"] == 3
-        assert saved_data["auto_price_reduction"]["enabled"] is True
+        if apr_fields.get("auto_price_reduction") is None:
+            assert saved_data.get("auto_price_reduction") is None
+        else:
+            assert saved_data["auto_price_reduction"]["enabled"] is apr_fields["auto_price_reduction"].get("enabled", False)
+            for field, value in apr_fields["auto_price_reduction"].items():
+                assert saved_data["auto_price_reduction"][field] == value
         assert saved_data["republication_interval"] == 14
         assert isinstance(saved_data.get("content_hash"), str)
         assert len(saved_data["content_hash"]) == 64
+        assert not any("Could not preserve" in message for message in caplog.messages)
 
     @pytest.mark.asyncio
     async def test_download_ad_logs_warning_when_preservation_fails(
@@ -3431,9 +3450,10 @@ class TestAdExtractorDownload:
         assert not staging_dir.exists()
         assert any("Could not preserve local settings" in message for message in caplog.messages)
 
+    @pytest.mark.parametrize("apr_value", [{"enabled": True}, False], ids = ["incomplete", "false"])
     @pytest.mark.asyncio
     async def test_download_ad_preserves_other_fields_when_apr_invalid(
-        self, extractor:extract_module.AdExtractor, tmp_path:Path
+        self, extractor:extract_module.AdExtractor, tmp_path:Path, apr_value:Any, caplog:pytest.LogCaptureFixture
     ) -> None:
         """Malformed auto_price_reduction skips only that field; counters still preserved."""
         download_base = tmp_path / "downloaded-ads"
@@ -3455,7 +3475,7 @@ class TestAdExtractorDownload:
             "repost_count": 5,
             "price_reduction_count": 3,
             "republication_interval": 14,
-            "auto_price_reduction": {"enabled": True},  # missing required fields → validation fails
+            "auto_price_reduction": apr_value,
         }
         await asyncio.to_thread(dicts.save_dict, str(existing_yaml), existing_data)
 
@@ -3477,6 +3497,7 @@ class TestAdExtractorDownload:
         assert saved_data["republication_interval"] == 14
         # auto_price_reduction was not preserved (malformed), so it stays at the fresh download's value
         assert saved_data.get("auto_price_reduction") is None
+        assert any("Could not preserve auto_price_reduction" in message for message in caplog.messages)
 
 
 class TestRenderDownloadNameWithBudgetWarnings:


### PR DESCRIPTION
## ℹ️ Description

Re-downloading an ad with `auto_price_reduction: null` currently emits a preservation warning because the downloader attempts to convert `None` into a dictionary. Treat this normal unset value like a missing key and silently skip it while preserving other valid local settings.

Closes #1250.

## 📋 Changes Summary

- Skip APR preservation when the existing value is absent or null.
- Extend download tests for missing, null, empty-disabled, and enabled APR settings through direct file lookup and the filename fallback.
- Verify that malformed non-null APR values still warn and other local settings remain preserved.
- No dependency, configuration, schema, documentation, or translation changes are required.

Validation: the two null regression cases failed before the fix. After the fix, `pdm run format`, `pdm run lint`, and `pdm run test` pass (1612 passed, 5 skipped).

### ⚙️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary (not required for this fix).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing advertisements with an explicitly empty `auto_price_reduction` setting are now handled correctly.
  * Local settings preservation no longer attempts to reuse unavailable price-reduction values.
  * Clearer warnings are provided when an invalid price-reduction configuration cannot be preserved.

* **Tests**
  * Expanded coverage for missing, empty, disabled, valid, and incomplete price-reduction settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->