### PR TITLE
refactor: use asyncio.to_thread for blocking operations

### DIFF
--- a/src/kleinanzeigen_bot/app.py
+++ b/src/kleinanzeigen_bot/app.py
@@ -159,8 +159,7 @@ class KleinanzeigenBot(WebScrapingMixin):  # noqa: PLR0904
             await self.close_browser_session()
             if self._timing_collector is not None:
                 try:
-                    loop = asyncio.get_running_loop()
-                    await loop.run_in_executor(None, self._timing_collector.flush)
+                    await asyncio.to_thread(self._timing_collector.flush)
                 except Exception as exc:  # noqa: BLE001
                     LOG.warning("Timing collector flush failed: %s", exc)
 

--- a/src/kleinanzeigen_bot/extract.py
+++ b/src/kleinanzeigen_bot/extract.py
@@ -344,17 +344,16 @@ class AdExtractor(WebScrapingMixin):
         if self.config.download.preserve_local_settings and await files.exists(final_dir):
             existing_yaml_path = final_dir / f"{ad_file_stem}.yaml"
             # Fall back to glob if the rendered stem does not match (e.g. title changed)
-            loop = asyncio.get_running_loop()
             if not await files.exists(existing_yaml_path):
-                yaml_candidates = await loop.run_in_executor(
-                    None, lambda: sorted(final_dir.glob("*.yaml"))
+                yaml_candidates = await asyncio.to_thread(
+                    lambda: sorted(final_dir.glob("*.yaml"))
                 )
                 if len(yaml_candidates) == 1:
                     existing_yaml_path = yaml_candidates[0]
             if await files.exists(existing_yaml_path):
                 try:
-                    existing_data = await loop.run_in_executor(
-                        None, lambda: dicts.load_dict(str(existing_yaml_path), content_label = f"existing ad {ad_id}")
+                    existing_data = await asyncio.to_thread(
+                        dicts.load_dict, str(existing_yaml_path), content_label = f"existing ad {ad_id}"
                     )
                     # Collect candidate local-only values without mutating ad_cfg yet
                     # to avoid saving partially corrupted state if validation fails.
@@ -408,27 +407,26 @@ class AdExtractor(WebScrapingMixin):
         On any failure, restores the backup (if created by us) and removes staging,
         then re-raises.
         """
-        loop = asyncio.get_running_loop()
         ad_file_path = staging_dir / f"{ad_file_stem}.yaml"
         backup_dir = final_dir.with_name(f"{_BACKUP_DIR_PREFIX}{ad_file_stem}")
         final_yaml_path = final_dir / f"{ad_file_stem}.yaml"
         backup_created_by_us = False
         try:
-            await loop.run_in_executor(None, lambda: dicts.save_dict(str(ad_file_path), ad_cfg.model_dump(mode = "json"), header = header_string))
+            await asyncio.to_thread(lambda: dicts.save_dict(str(ad_file_path), ad_cfg.model_dump(mode = "json"), header = header_string))
 
             if await files.exists(backup_dir):
                 raise FileExistsError(_("Backup directory %s already exists. Aborting download for ad %s to avoid data loss.") % (backup_dir, ad_id))
 
             if await files.exists(final_dir):
-                await loop.run_in_executor(None, final_dir.rename, backup_dir)
+                await asyncio.to_thread(final_dir.rename, backup_dir)
                 backup_created_by_us = True
 
-            await loop.run_in_executor(None, staging_dir.rename, final_dir)
+            await asyncio.to_thread(staging_dir.rename, final_dir)
             LOG.info("Saved ad config to: %s", final_yaml_path)
 
             if await files.exists(backup_dir):
                 try:
-                    await loop.run_in_executor(None, _remove_tree_with_retries, backup_dir)
+                    await asyncio.to_thread(_remove_tree_with_retries, backup_dir)
                 except OSError as ex:
                     LOG.warning("Could not remove backup directory %s: %s", backup_dir, ex)
         except Exception:  # noqa: BLE001
@@ -436,12 +434,12 @@ class AdExtractor(WebScrapingMixin):
             # asyncio.CancelledError is a BaseException and is therefore not caught here.
             if backup_created_by_us and await files.exists(backup_dir) and not await files.exists(final_dir):
                 try:
-                    await loop.run_in_executor(None, backup_dir.rename, final_dir)
+                    await asyncio.to_thread(backup_dir.rename, final_dir)
                 except OSError as restore_ex:
                     LOG.error("Failed to restore backup directory %s to %s after download failure: %s", backup_dir, final_dir, restore_ex)
             if await files.exists(staging_dir):
                 try:
-                    await loop.run_in_executor(None, _remove_tree_with_retries, staging_dir)
+                    await asyncio.to_thread(_remove_tree_with_retries, staging_dir)
                 except OSError as cleanup_ex:
                     LOG.warning("Could not remove staging directory %s: %s", staging_dir, cleanup_ex)
             raise
@@ -495,10 +493,8 @@ class AdExtractor(WebScrapingMixin):
 
             image_paths:list[str] = []
             image_filename_prefix = f"{ad_file_stem}__img"
-            loop = asyncio.get_running_loop()
             for image_number, image_url in enumerate(image_urls, start = 1):
-                image_path = await loop.run_in_executor(
-                    None,
+                image_path = await asyncio.to_thread(
                     self._download_and_save_image_sync,
                     image_url,
                     directory,
@@ -552,14 +548,12 @@ class AdExtractor(WebScrapingMixin):
             img_nr = 1
             dl_counter = 0
 
-            loop = asyncio.get_running_loop()
-
             for img_element in images:
                 current_img_url = img_element.attrs["src"]  # URL of the image
                 if current_img_url is None:
                     continue
 
-                img_path = await loop.run_in_executor(None, self._download_and_save_image_sync, str(current_img_url), directory, img_fn_prefix, img_nr)
+                img_path = await asyncio.to_thread(self._download_and_save_image_sync, str(current_img_url), directory, img_fn_prefix, img_nr)
 
                 if img_path:
                     dl_counter += 1
@@ -939,15 +933,13 @@ class AdExtractor(WebScrapingMixin):
         legacy_dir = relative_directory / f"ad_{ad_id}"
         staging_dir = relative_directory / f"{_STAGING_DIR_PREFIX}{ad_file_stem}"
 
-        loop = asyncio.get_running_loop()
-
         if await files.exists(legacy_dir):
             if self.config.download.rename_existing_folders:
                 # Rename the old folder to the new name with title
                 if not await files.exists(final_dir):
                     LOG.info("Renaming folder from %s to %s for ad %s...", legacy_dir.name, final_dir.name, ad_id)
                     LOG.debug("Renaming: %s -> %s", legacy_dir, final_dir)
-                    await loop.run_in_executor(None, legacy_dir.rename, final_dir)
+                    await asyncio.to_thread(legacy_dir.rename, final_dir)
             else:
                 # Use the existing folder without renaming
                 final_dir = legacy_dir
@@ -956,7 +948,7 @@ class AdExtractor(WebScrapingMixin):
         if await files.exists(staging_dir):
             LOG.info("Removing stale staging directory: %s", staging_dir)
             try:
-                await loop.run_in_executor(None, _remove_tree_with_retries, staging_dir)
+                await asyncio.to_thread(_remove_tree_with_retries, staging_dir)
             except OSError as cleanup_ex:
                 LOG.warning("Could not remove stale staging directory %s: %s", staging_dir, cleanup_ex)
                 if await files.exists(staging_dir):
@@ -964,7 +956,7 @@ class AdExtractor(WebScrapingMixin):
                         _("Could not remove stale staging directory %s. Aborting extraction to avoid using a dirty staging directory.") % staging_dir
                     ) from cleanup_ex
 
-        await loop.run_in_executor(None, lambda: staging_dir.mkdir(exist_ok = True))
+        await asyncio.to_thread(staging_dir.mkdir, exist_ok = True)
         LOG.debug("Staging directory for ad: %s", staging_dir)
         LOG.info("Downloading ad to: %s", final_dir)
 
@@ -973,7 +965,7 @@ class AdExtractor(WebScrapingMixin):
         except Exception:  # noqa: BLE001 — intentional broad catch for staging directory cleanup on failure
             if await files.exists(staging_dir):
                 try:
-                    await loop.run_in_executor(None, _remove_tree_with_retries, staging_dir)
+                    await asyncio.to_thread(_remove_tree_with_retries, staging_dir)
                 except OSError as cleanup_ex:
                     LOG.warning("Could not remove staging directory %s: %s", staging_dir, cleanup_ex)
             raise

--- a/src/kleinanzeigen_bot/utils/files.py
+++ b/src/kleinanzeigen_bot/utils/files.py
@@ -34,7 +34,7 @@ async def exists(path:str | Path) -> bool:
     :param path: Path to check
     :return: True if path exists, False otherwise
     """
-    return await asyncio.get_running_loop().run_in_executor(None, Path(path).exists)
+    return await asyncio.to_thread(Path(path).exists)
 
 
 async def is_dir(path:str | Path) -> bool:
@@ -44,4 +44,4 @@ async def is_dir(path:str | Path) -> bool:
     :param path: Path to check
     :return: True if path is a directory, False otherwise
     """
-    return await asyncio.get_running_loop().run_in_executor(None, Path(path).is_dir)
+    return await asyncio.to_thread(Path(path).is_dir)

--- a/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
+++ b/src/kleinanzeigen_bot/utils/web_scraping_mixin.py
@@ -833,8 +833,7 @@ class WebScrapingMixin:  # noqa: PLR0904
         """Resolve the effective user data directory, handling args vs config conflicts."""
         effective = user_data_dir_from_args or self.browser_config.user_data_dir
         if user_data_dir_from_args and self.browser_config.user_data_dir:
-            arg_path, cfg_path = await asyncio.get_running_loop().run_in_executor(
-                None,
+            arg_path, cfg_path = await asyncio.to_thread(
                 _resolve_user_data_dir_paths,
                 user_data_dir_from_args,
                 self.browser_config.user_data_dir,
@@ -855,7 +854,7 @@ class WebScrapingMixin:  # noqa: PLR0904
         prefs_file = profile_dir / "Preferences"
         if not await files.exists(prefs_file):
             LOG.info(" -> Setting chrome prefs [%s]...", prefs_file)
-            await asyncio.get_running_loop().run_in_executor(None, _write_initial_prefs, str(prefs_file))
+            await asyncio.to_thread(_write_initial_prefs, str(prefs_file))
 
     async def _add_browser_extensions(self, cfg:NodriverConfig) -> None:
         """Add configured browser extensions to the nodriver config."""

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -2501,8 +2501,11 @@ class TestAdExtractorDownload:
             call(staging_dir, final_dir),
         ]
 
+    @pytest.mark.parametrize("error_type", [OSError, TimeoutError])
     @pytest.mark.asyncio
-    async def test_download_ad_preserves_final_dir_when_yaml_write_fails(self, extractor:extract_module.AdExtractor, tmp_path:Path) -> None:
+    async def test_download_ad_preserves_final_dir_when_yaml_write_fails(
+        self, extractor:extract_module.AdExtractor, tmp_path:Path, error_type:type[OSError],
+    ) -> None:
         download_base = tmp_path / "downloaded-ads"
         final_dir = download_base / "ad_12345_Test Advertisement Title"
         staging_dir = download_base / ".tmp-ad_12345"
@@ -2516,7 +2519,7 @@ class TestAdExtractorDownload:
 
         with (
             patch.object(extractor, "_extract_ad_page_info_with_directory_handling", new_callable = AsyncMock) as mock_extract_with_dir,
-            patch("kleinanzeigen_bot.extract.dicts.save_dict", autospec = True, side_effect = OSError("write failed")),
+            patch("kleinanzeigen_bot.extract.dicts.save_dict", autospec = True, side_effect = error_type("write failed")),
             patch.object(Path, "rename", autospec = True) as mock_rename,
         ):
             mock_extract_with_dir.return_value = (
@@ -2526,11 +2529,11 @@ class TestAdExtractorDownload:
                 "ad_12345",
             )
 
-            with pytest.raises(OSError, match = "write failed"):
+            with pytest.raises(error_type, match = "write failed"):
                 await extractor.download_ad(12345)
 
         assert final_dir.exists()
-        assert old_file.exists()
+        assert old_file.read_text() == "old content"
         assert not backup_dir.exists()
         assert not staging_dir.exists()
         mock_rename.assert_not_called()

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -4,12 +4,33 @@
 """Tests for the files utility module."""
 import os
 import tempfile
+from contextvars import ContextVar
+from pathlib import Path
 
-from kleinanzeigen_bot.utils.files import abspath
+import pytest
+
+from kleinanzeigen_bot.utils.files import abspath, exists
 
 
 class TestFiles:
     """Test suite for files utility functions."""
+
+    @pytest.mark.asyncio
+    async def test_exists_preserves_task_context(self, monkeypatch:pytest.MonkeyPatch) -> None:
+        context:ContextVar[str] = ContextVar("file_operation_context", default = "unset")
+        token = context.set("download")
+
+        def exists_with_context(_path:Path) -> bool:
+            assert context.get() == "download"
+            context.set("worker")
+            return True
+
+        monkeypatch.setattr(Path, "exists", exists_with_context)
+        try:
+            assert await exists("ad.yaml")
+            assert context.get() == "download"
+        finally:
+            context.reset(token)
 
     def test_abspath_without_relative_to(self) -> None:
         """Test abspath function without relative_to parameter."""


### PR DESCRIPTION
## ℹ️ Description

Replace default-executor dispatch with `asyncio.to_thread()` for ordinary blocking work, simplifying calls and propagating the caller's context variables.

Closes #1238.

## 📋 Changes Summary

- Convert all 19 production `run_in_executor()` calls: 14 in extraction, one timing flush, two browser-profile operations, and two filesystem helpers. None require a custom executor or explicit Future handling.
- Pass keyword arguments directly where possible. Keep compound glob and model-serialization operations inside worker threads.
- Preserve sequential downloads, ordering, exception propagation, cancellation handling, rollback, cleanup, and log messages.
- Extend save-failure coverage to timeouts and verify original contents survive; test worker context propagation and isolation.
- No dependencies, configuration, translations, or generated artifacts need updating.

### ⚙️ Type of Change

Internal behavior-preserving refactor; none of the feature/fix/breaking-change categories apply.

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (adds new functionality without breaking existing usage)
- [ ] 💥 Breaking change (changes that might break existing user setups, scripts, or configurations)

## ✅ Checklist

- [x] I have reviewed my changes to ensure they meet the project's standards.
- [x] I have tested my changes and ensured that all tests pass (`pdm run test`).
- [x] I have formatted the code (`pdm run format`).
- [x] I have verified that linting passes (`pdm run lint`).
- [x] I have updated documentation where necessary (no documentation changes needed).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved asynchronous handling for file operations, downloads, cleanup, browser profile preparation, and timing collection.
  * Preserved existing behavior and error handling while maintaining task context across asynchronous file checks.

* **Tests**
  * Expanded coverage for YAML-write failures involving operating system and timeout errors.
  * Added validation that asynchronous file existence checks preserve task context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->